### PR TITLE
Added acceptence for the update function of many resources

### DIFF
--- a/gridscale/resource_network_test.go
+++ b/gridscale/resource_network_test.go
@@ -27,6 +27,16 @@ func TestAccDataSourceGridscaleNetwork_Basic(t *testing.T) {
 						"gridscale_network.foo", "name", name),
 				),
 			},
+			{
+				Config: testAccCheckDataSourceGridscaleNetworkConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceGridscaleNetworkExists("gridscale_network.foo", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "name", "newname"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "l2security", "true"),
+				),
+			},
 		},
 	})
 }
@@ -93,4 +103,13 @@ resource "gridscale_network" "foo" {
   name   = "%s"
 }
 `, name)
+}
+
+func testAccCheckDataSourceGridscaleNetworkConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_network" "foo" {
+  name   = "newname"
+  l2security = true
+}
+`)
 }

--- a/gridscale/resource_server_test.go
+++ b/gridscale/resource_server_test.go
@@ -31,6 +31,18 @@ func TestAccDataSourceGridscaleServer_Basic(t *testing.T) {
 						"gridscale_server.foo", "memory", "1"),
 				),
 			},
+			{
+				Config: testAccCheckDataSourceGridscaleServerConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceGridscaleServerExists("gridscale_server.foo", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_server.foo", "name", "newname"),
+					resource.TestCheckResourceAttr(
+						"gridscale_server.foo", "cores", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_server.foo", "memory", "2"),
+				),
+			},
 		},
 	})
 }
@@ -99,4 +111,14 @@ resource "gridscale_server" "foo" {
   memory = 1
 }
 `, name)
+}
+
+func testAccCheckDataSourceGridscaleServerConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_server" "foo" {
+  name   = "newname"
+  cores = 2
+  memory = 2
+}
+`)
 }

--- a/gridscale/resource_sshkey_test.go
+++ b/gridscale/resource_sshkey_test.go
@@ -29,6 +29,16 @@ func TestAccDataSourceGridscaleSshkey_Basic(t *testing.T) {
 						"gridscale_sshkey.foo", "sshkey", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKea3u6cuJ/2ZoMA4fpnXRK8ZIZWQz8ddXJv+iul9gTAc4fbm30IjZNnBBxiFOETc5ev1mcxvi6XvW99gLmxJAGwUrHylxYODXl1fLhc2G5czwQS9Qk57ED+IYb7AGOWPxGYeDaDka6gxJal/aaUx0C42fQErpUiJj2mJlF8yUOqyygtQOZhT2XUBU5UBZd50r8die8oRgdKJrbcn48q1Eu60vpx4S4JgH+krrHoXuCRydQ31KfOXmD8Y3/oGlZQ40luhfnj6g1jpm6PIQEBehGyZl6Dyh0MeeJsePWAGmXMEA33FcDkUiQPLoaalr4QQZdAUS74/irf+mgRcSRPvL root@475d4232363a"),
 				),
 			},
+			{
+				Config: testAccCheckDataSourceGridscaleSshkeyConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_sshkey.foo", "name", "newname"),
+					resource.TestCheckResourceAttr(
+						"gridscale_sshkey.foo", "sshkey", "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvOYJ3xXtPXaPOacFQ97+nGq5QDkl17/JeTaY36RLPKgYBt2Z5YSPSROdzh/5GgZ0p6E3W84gKNaedUo3v+zvgmdGZeDFk+cxlC0HtXwQN87GQRtYTMsucbI6OJT7p4qntl70MIBzvIrmheGZqXnpeRxA7PjVcjkA3nxps3XJsuMDd0Ft0Ue3j0lmOno779mfgg34VeTgE2GZlH31gFqxWz3fXUgaZoLdO7HbLKu4ybfFWdCzqBt4B8RG9xMq0220gJR6ZwAaiMc1CGIknK7C6EKeCx9LOWDjCaHg6pA2iPAb/PoxDuiqbUIzfRmkgMf0lYmrf0kqx529ALm92ulSx root@33c294c5235e"),
+				),
+			},
 		},
 	})
 }
@@ -96,4 +106,13 @@ resource "gridscale_sshkey" "foo" {
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKea3u6cuJ/2ZoMA4fpnXRK8ZIZWQz8ddXJv+iul9gTAc4fbm30IjZNnBBxiFOETc5ev1mcxvi6XvW99gLmxJAGwUrHylxYODXl1fLhc2G5czwQS9Qk57ED+IYb7AGOWPxGYeDaDka6gxJal/aaUx0C42fQErpUiJj2mJlF8yUOqyygtQOZhT2XUBU5UBZd50r8die8oRgdKJrbcn48q1Eu60vpx4S4JgH+krrHoXuCRydQ31KfOXmD8Y3/oGlZQ40luhfnj6g1jpm6PIQEBehGyZl6Dyh0MeeJsePWAGmXMEA33FcDkUiQPLoaalr4QQZdAUS74/irf+mgRcSRPvL root@475d4232363a"
 }
 `, name)
+}
+
+func testAccCheckDataSourceGridscaleSshkeyConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_sshkey" "foo" {
+  name   = "newname"
+  sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvOYJ3xXtPXaPOacFQ97+nGq5QDkl17/JeTaY36RLPKgYBt2Z5YSPSROdzh/5GgZ0p6E3W84gKNaedUo3v+zvgmdGZeDFk+cxlC0HtXwQN87GQRtYTMsucbI6OJT7p4qntl70MIBzvIrmheGZqXnpeRxA7PjVcjkA3nxps3XJsuMDd0Ft0Ue3j0lmOno779mfgg34VeTgE2GZlH31gFqxWz3fXUgaZoLdO7HbLKu4ybfFWdCzqBt4B8RG9xMq0220gJR6ZwAaiMc1CGIknK7C6EKeCx9LOWDjCaHg6pA2iPAb/PoxDuiqbUIzfRmkgMf0lYmrf0kqx529ALm92ulSx root@33c294c5235e"
+}
+`)
 }

--- a/gridscale/resource_storage_test.go
+++ b/gridscale/resource_storage_test.go
@@ -30,6 +30,14 @@ func TestAccDataSourceGridscaleStorage_Basic(t *testing.T) {
 						"gridscale_storage.foo", "capacity", "1"),
 				),
 			},
+			{
+				Config: testAccCheckDataSourceGridscaleStorageConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataSourceGridscaleStorageExists("gridscale_storage.foo", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_storage.foo", "name", "newname"),
+				),
+			},
 		},
 	})
 }
@@ -125,6 +133,15 @@ resource "gridscale_storage" "foo" {
   capacity = 1
 }
 `, name)
+}
+
+func testAccCheckDataSourceGridscaleStorageConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_storage" "foo" {
+  name   = "newname"
+  capacity = 1
+}
+`)
 }
 
 func testAccCheckDataSourceGridscaleStorageConfig_advanced(name string) string {


### PR DESCRIPTION
This pull requests adds acceptance tests for the update function in the sshkey, network, storage and server resources. It does so only in a very simple fashion right now.

Still missing are these same tests for ip addresses.