### PR TITLE
Fixed a typo in name argument description

### DIFF
--- a/website/docs/r/ipv6.html.md
+++ b/website/docs/r/ipv6.html.md
@@ -24,7 +24,7 @@ resource "gridscale_ipv6" "terra-ipv6-test" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 66 characters.
+* `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
 * `location_uuid` - (Optional) Helps to identify which datacenter an object belongs to. Frankfurt is the default.
 


### PR DESCRIPTION
According to the gridscale API documentation the maximum amount of supported characters is 64: https://gridscale.io/en/api-documentation/index.html#operation/createIp