### PR TITLE
Update docs and coding convention

### DIFF
--- a/gridscale/datasource_gridscale_ipv4_test.go
+++ b/gridscale/datasource_gridscale_ipv4_test.go
@@ -14,7 +14,7 @@ func TestAccdataSourceGridscaleIPv4_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleIpv4DestroyCheck,
+		CheckDestroy: testAccCheckGridscaleIpv4DestroyCheck,
 		Steps: []resource.TestStep{
 			{
 

--- a/gridscale/datasource_gridscale_ipv6_test.go
+++ b/gridscale/datasource_gridscale_ipv6_test.go
@@ -13,7 +13,7 @@ func TestAccdataSourceGridscaleIPv6_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleIpv6DestroyCheck,
+		CheckDestroy: testAccCheckGridscaleIpv6DestroyCheck,
 		Steps: []resource.TestStep{
 			{
 

--- a/gridscale/datasource_gridscale_loadbalancer_test.go
+++ b/gridscale/datasource_gridscale_loadbalancer_test.go
@@ -13,7 +13,7 @@ func TestAccdataSourceGridscaleLoadBalancer_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckResourceGridscaleLoadBalancerDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleLoadBalancerDestroyCheck,
 		Steps: []resource.TestStep{
 			{
 

--- a/gridscale/datasource_gridscale_network_test.go
+++ b/gridscale/datasource_gridscale_network_test.go
@@ -13,7 +13,7 @@ func TestAccdataSourceGridscaleNetwork_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleNetworkDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleNetworkDestroyCheck,
 		Steps: []resource.TestStep{
 			{
 

--- a/gridscale/datasource_gridscale_sshkey_test.go
+++ b/gridscale/datasource_gridscale_sshkey_test.go
@@ -13,7 +13,7 @@ func TestAccdataSourceGridscaleSSHKey_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleSshkeyDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleSshkeyDestroyCheck,
 		Steps: []resource.TestStep{
 			{
 

--- a/gridscale/datasource_gridscale_storage_test.go
+++ b/gridscale/datasource_gridscale_storage_test.go
@@ -13,7 +13,7 @@ func TestAccdataSourceGridscaleStorage_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleStorageDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
 

--- a/gridscale/resource_gridscale_ipv4_test.go
+++ b/gridscale/resource_gridscale_ipv4_test.go
@@ -11,27 +11,27 @@ import (
 	"github.com/gridscale/gsclient-go"
 )
 
-func TestAccDataSourceGridscaleIpv4_Basic(t *testing.T) {
+func TestAccResourceGridscaleIpv4_Basic(t *testing.T) {
 	var object gsclient.IP
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleIpv4DestroyCheck,
+		CheckDestroy: testAccCheckGridscaleIpv4DestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleIpv4Config_basic(name),
+				Config: testAccCheckResourceGridscaleIpv4Config_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleIpv4Exists("gridscale_ipv4.foo", &object),
+					testAccCheckResourceGridscaleIpv4Exists("gridscale_ipv4.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_ipv4.foo", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleIpv4Config_basic_update(),
+				Config: testAccCheckResourceGridscaleIpv4Config_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleIpv4Exists("gridscale_ipv4.foo", &object),
+					testAccCheckResourceGridscaleIpv4Exists("gridscale_ipv4.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_ipv4.foo", "name", "newname"),
 					resource.TestCheckResourceAttr(
@@ -44,7 +44,7 @@ func TestAccDataSourceGridscaleIpv4_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceGridscaleIpv4Exists(n string, object *gsclient.IP) resource.TestCheckFunc {
+func testAccCheckResourceGridscaleIpv4Exists(n string, object *gsclient.IP) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -76,7 +76,7 @@ func testAccCheckDataSourceGridscaleIpv4Exists(n string, object *gsclient.IP) re
 	}
 }
 
-func testAccCheckDataSourceGridscaleIpv4DestroyCheck(s *terraform.State) error {
+func testAccCheckGridscaleIpv4DestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_ipv4" {
@@ -100,7 +100,7 @@ func testAccCheckDataSourceGridscaleIpv4DestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleIpv4Config_basic(name string) string {
+func testAccCheckResourceGridscaleIpv4Config_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
   name   = "%s"
@@ -108,7 +108,7 @@ resource "gridscale_ipv4" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleIpv4Config_basic_update() string {
+func testAccCheckResourceGridscaleIpv4Config_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_ipv6_test.go
+++ b/gridscale/resource_gridscale_ipv6_test.go
@@ -11,27 +11,27 @@ import (
 	"github.com/gridscale/gsclient-go"
 )
 
-func TestAccDataSourceGridscaleIpv6_Basic(t *testing.T) {
+func TestAccResourceGridscaleIpv6_Basic(t *testing.T) {
 	var object gsclient.IP
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleIpv6DestroyCheck,
+		CheckDestroy: testAccCheckGridscaleIpv6DestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleIpv6Config_basic(name),
+				Config: testAccCheckResourceGridscaleIpv6Config_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleIpv6Exists("gridscale_ipv6.foo", &object),
+					testAccCheckResourceGridscaleIpv6Exists("gridscale_ipv6.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_ipv6.foo", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleIpv6Config_basic_update(),
+				Config: testAccCheckResourceGridscaleIpv6Config_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleIpv6Exists("gridscale_ipv6.foo", &object),
+					testAccCheckResourceGridscaleIpv6Exists("gridscale_ipv6.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_ipv6.foo", "name", "newname"),
 					resource.TestCheckResourceAttr(
@@ -44,7 +44,7 @@ func TestAccDataSourceGridscaleIpv6_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceGridscaleIpv6Exists(n string, object *gsclient.IP) resource.TestCheckFunc {
+func testAccCheckResourceGridscaleIpv6Exists(n string, object *gsclient.IP) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -76,7 +76,7 @@ func testAccCheckDataSourceGridscaleIpv6Exists(n string, object *gsclient.IP) re
 	}
 }
 
-func testAccCheckDataSourceGridscaleIpv6DestroyCheck(s *terraform.State) error {
+func testAccCheckGridscaleIpv6DestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_ipv6" {
@@ -100,7 +100,7 @@ func testAccCheckDataSourceGridscaleIpv6DestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleIpv6Config_basic(name string) string {
+func testAccCheckResourceGridscaleIpv6Config_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv6" "foo" {
   name   = "%s"
@@ -108,7 +108,7 @@ resource "gridscale_ipv6" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleIpv6Config_basic_update() string {
+func testAccCheckResourceGridscaleIpv6Config_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv6" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_loadbalancer_test.go
+++ b/gridscale/resource_gridscale_loadbalancer_test.go
@@ -18,7 +18,7 @@ func TestAccResourceGridscaleLoadBalancerBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckResourceGridscaleLoadBalancerDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleLoadBalancerDestroyCheck,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckResourceGridscaleLoadBalancerConfig_basic(name, "leastconn"),
@@ -136,7 +136,7 @@ resource "gridscale_loadbalancer" "foo" {
 }`, name, name, name, name, algorithm)
 }
 
-func testAccCheckResourceGridscaleLoadBalancerDestroyCheck(s *terraform.State) error {
+func testAccCheckGridscaleLoadBalancerDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_loadbalancer" {

--- a/gridscale/resource_gridscale_network_test.go
+++ b/gridscale/resource_gridscale_network_test.go
@@ -11,27 +11,27 @@ import (
 	"github.com/gridscale/gsclient-go"
 )
 
-func TestAccDataSourceGridscaleNetwork_Basic(t *testing.T) {
+func TestAccResourceGridscaleNetwork_Basic(t *testing.T) {
 	var object gsclient.Network
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleNetworkDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleNetworkDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleNetworkConfig_basic(name),
+				Config: testAccCheckResourceGridscaleNetworkConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleNetworkExists("gridscale_network.foo", &object),
+					testAccCheckResourceGridscaleNetworkExists("gridscale_network.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_network.foo", "name", name),
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleNetworkConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleNetworkConfig_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleNetworkExists("gridscale_network.foo", &object),
+					testAccCheckResourceGridscaleNetworkExists("gridscale_network.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_network.foo", "name", "newname"),
 					resource.TestCheckResourceAttr(
@@ -42,7 +42,7 @@ func TestAccDataSourceGridscaleNetwork_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceGridscaleNetworkExists(n string, object *gsclient.Network) resource.TestCheckFunc {
+func testAccCheckResourceGridscaleNetworkExists(n string, object *gsclient.Network) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -74,7 +74,7 @@ func testAccCheckDataSourceGridscaleNetworkExists(n string, object *gsclient.Net
 	}
 }
 
-func testAccCheckDataSourceGridscaleNetworkDestroyCheck(s *terraform.State) error {
+func testAccCheckGridscaleNetworkDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_network" {
@@ -98,7 +98,7 @@ func testAccCheckDataSourceGridscaleNetworkDestroyCheck(s *terraform.State) erro
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleNetworkConfig_basic(name string) string {
+func testAccCheckResourceGridscaleNetworkConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_network" "foo" {
   name   = "%s"
@@ -106,7 +106,7 @@ resource "gridscale_network" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleNetworkConfig_basic_update() string {
+func testAccCheckResourceGridscaleNetworkConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_network" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -11,19 +11,19 @@ import (
 	"github.com/gridscale/gsclient-go"
 )
 
-func TestAccDataSourceGridscaleServer_Basic(t *testing.T) {
+func TestAccResourceGridscaleServer_Basic(t *testing.T) {
 	var object gsclient.Server
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleServerDestroyCheck,
+		CheckDestroy: testAccCheckResourceGridscaleServerDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleServerConfig_basic(name),
+				Config: testAccCheckResourceGridscaleServerConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleServerExists("gridscale_server.foo", &object),
+					testAccCheckResourceGridscaleServerExists("gridscale_server.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_server.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -35,9 +35,9 @@ func TestAccDataSourceGridscaleServer_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleServerConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleServerConfig_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleServerExists("gridscale_server.foo", &object),
+					testAccCheckResourceGridscaleServerExists("gridscale_server.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_server.foo", "name", "newname"),
 					resource.TestCheckResourceAttr(
@@ -52,7 +52,7 @@ func TestAccDataSourceGridscaleServer_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceGridscaleServerExists(n string, object *gsclient.Server) resource.TestCheckFunc {
+func testAccCheckResourceGridscaleServerExists(n string, object *gsclient.Server) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -84,7 +84,7 @@ func testAccCheckDataSourceGridscaleServerExists(n string, object *gsclient.Serv
 	}
 }
 
-func testAccCheckDataSourceGridscaleServerDestroyCheck(s *terraform.State) error {
+func testAccCheckResourceGridscaleServerDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_server" {
@@ -108,7 +108,7 @@ func testAccCheckDataSourceGridscaleServerDestroyCheck(s *terraform.State) error
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleServerConfig_basic(name string) string {
+func testAccCheckResourceGridscaleServerConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_server" "foo" {
   name   = "%s"
@@ -119,7 +119,7 @@ resource "gridscale_server" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleServerConfig_basic_update() string {
+func testAccCheckResourceGridscaleServerConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_server" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_sshkey_test.go
+++ b/gridscale/resource_gridscale_sshkey_test.go
@@ -11,19 +11,19 @@ import (
 	"github.com/gridscale/gsclient-go"
 )
 
-func TestAccDataSourceGridscaleSshkey_Basic(t *testing.T) {
+func TestAccResourceGridscaleSshkey_Basic(t *testing.T) {
 	var object gsclient.Sshkey
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleSshkeyDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleSshkeyDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleSshkeyConfig_basic(name),
+				Config: testAccCheckResourceGridscaleSshkeyConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
+					testAccCheckResourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_sshkey.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -31,9 +31,9 @@ func TestAccDataSourceGridscaleSshkey_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleSshkeyConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleSshkeyConfig_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
+					testAccCheckResourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_sshkey.foo", "name", "newname"),
 					resource.TestCheckResourceAttr(
@@ -44,7 +44,7 @@ func TestAccDataSourceGridscaleSshkey_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceGridscaleSshkeyExists(n string, object *gsclient.Sshkey) resource.TestCheckFunc {
+func testAccCheckResourceGridscaleSshkeyExists(n string, object *gsclient.Sshkey) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -76,7 +76,7 @@ func testAccCheckDataSourceGridscaleSshkeyExists(n string, object *gsclient.Sshk
 	}
 }
 
-func testAccCheckDataSourceGridscaleSshkeyDestroyCheck(s *terraform.State) error {
+func testAccCheckGridscaleSshkeyDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_sshkey" {
@@ -100,7 +100,7 @@ func testAccCheckDataSourceGridscaleSshkeyDestroyCheck(s *terraform.State) error
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleSshkeyConfig_basic(name string) string {
+func testAccCheckResourceGridscaleSshkeyConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "foo" {
   name   = "%s"
@@ -109,7 +109,7 @@ resource "gridscale_sshkey" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleSshkeyConfig_basic_update() string {
+func testAccCheckResourceGridscaleSshkeyConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_storage_test.go
+++ b/gridscale/resource_gridscale_storage_test.go
@@ -12,19 +12,19 @@ import (
 	"github.com/gridscale/gsclient-go"
 )
 
-func TestAccDataSourceGridscaleStorage_Basic(t *testing.T) {
+func TestAccResourceGridscaleStorage_Basic(t *testing.T) {
 	var object gsclient.Storage
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleStorageDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleStorageConfig_basic(name),
+				Config: testAccCheckResourceGridscaleStorageConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleStorageExists("gridscale_storage.foo", &object),
+					testAccCheckResourceGridscaleStorageExists("gridscale_storage.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_storage.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -32,9 +32,9 @@ func TestAccDataSourceGridscaleStorage_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleStorageConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleStorageConfig_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleStorageExists("gridscale_storage.foo", &object),
+					testAccCheckResourceGridscaleStorageExists("gridscale_storage.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_storage.foo", "name", "newname"),
 				),
@@ -43,19 +43,19 @@ func TestAccDataSourceGridscaleStorage_Basic(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceGridscaleStorage_Advanced(t *testing.T) {
+func TestAccResourceGridscaleStorage_Advanced(t *testing.T) {
 	var object gsclient.Storage
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDataSourceGridscaleStorageDestroyCheck,
+		CheckDestroy: testAccCheckGridscaleStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleStorageConfig_advanced(name),
+				Config: testAccCheckResourceGridscaleStorageConfig_advanced(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDataSourceGridscaleStorageExists("gridscale_storage.foo", &object),
+					testAccCheckResourceGridscaleStorageExists("gridscale_storage.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_storage.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -68,7 +68,7 @@ func TestAccDataSourceGridscaleStorage_Advanced(t *testing.T) {
 	})
 }
 
-func testAccCheckDataSourceGridscaleStorageExists(n string, object *gsclient.Storage) resource.TestCheckFunc {
+func testAccCheckResourceGridscaleStorageExists(n string, object *gsclient.Storage) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -100,7 +100,7 @@ func testAccCheckDataSourceGridscaleStorageExists(n string, object *gsclient.Sto
 	}
 }
 
-func testAccCheckDataSourceGridscaleStorageDestroyCheck(s *terraform.State) error {
+func testAccCheckGridscaleStorageDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_storage" {
@@ -127,7 +127,7 @@ func testAccCheckDataSourceGridscaleStorageDestroyCheck(s *terraform.State) erro
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleStorageConfig_basic(name string) string {
+func testAccCheckResourceGridscaleStorageConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "%s"
@@ -136,7 +136,7 @@ resource "gridscale_storage" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleStorageConfig_basic_update() string {
+func testAccCheckResourceGridscaleStorageConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "newname"
@@ -145,7 +145,7 @@ resource "gridscale_storage" "foo" {
 `)
 }
 
-func testAccCheckDataSourceGridscaleStorageConfig_advanced(name string) string {
+func testAccCheckResourceGridscaleStorageConfig_advanced(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "sshkey" {
   name = "%s"

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -43,6 +43,7 @@ The following attributes are exported:
 * `failover` - failover mode of this ip. If true, then this IP is no longer available for DHCP and can no longer be related to any server..
 * `status` - The status of the ip.
 * `reverse_dns` - The reverse DNS of the ip.
+* `location_iata` - The IATA airport code, which works as a location identifier.
 * `location_country` - The human-readable name of the country of the ip.
 * `location_name` - The human-readable name of the location of the ip.
 * `create_time` - The date and time the ip was initially created.

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -37,3 +37,16 @@ resource "gridscale_server" "servername"{
 The following attributes are exported:
 
 * `id` - The UUID of the ip.
+* `ip` - Defines the IP Address (v4 or v6) the ip.
+* `prefix` - The IP prefix of the ip.
+* `location_uuid` - The UUID of the location, that helps to identify which datacenter an object belongs to.
+* `failover` - failover mode of this ip. If true, then this IP is no longer available for DHCP and can no longer be related to any server..
+* `status` - The status of the ip.
+* `reverse_dns` - The reverse DNS of the ip.
+* `location_country` - The human-readable name of the country of the ip.
+* `location_name` - The human-readable name of the location of the ip.
+* `create_time` - The date and time the ip was initially created.
+* `change_time` - The date and time of the last ip change.
+* `delete_block` - Defines if the ip is administratively blocked.
+* `usage_in_minutes` - Total minutes the ip has been running.
+* `current_price` - The price for the current period since the last bill.

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -15,20 +15,20 @@ Get the id of an ip resource. This can be used to link ip addresses to a server.
 Using the ip datasource for the creation of a server:
 
 ```terraform
-resource "gridscale_ipv4" "ipv4name"{
-	name = "terraform-ipv4"
+data "gridscale_ipv4" "ipv4name"{
+	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
-resource "gridscale_ipv6" "ipv6name"{
-	name = "terraform-ipv6"
+data "gridscale_ipv6" "ipv6name"{
+	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
 	name = "terra-server"
 	cores = 2
 	memory = 4
-	ipv4 = "${gridscale_ipv4.ipv4name.id}"
-	ipv6 = "${gridscale_ipv6.ipv6name.id}"
+	ipv4 = "${data.gridscale_ipv4.ipv4name.id}"
+	ipv6 = "${data.gridscale_ipv6.ipv6name.id}"
 }
 ```
 

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -51,3 +51,4 @@ The following attributes are exported:
 * `delete_block` - Defines if the ip is administratively blocked.
 * `usage_in_minutes` - Total minutes the ip has been running.
 * `current_price` - The price for the current period since the last bill.
+* `labels` - The list of labels.

--- a/website/docs/d/loadbalancer.html.md
+++ b/website/docs/d/loadbalancer.html.md
@@ -23,3 +23,12 @@ data "gridscale_loadbalancer" "foo" {
 The following attributes are exported:
 
 * `id` - The UUID of the loadbalancer.
+* `name` - The human-readable name of the loadbalancer.
+* `algorithm` - The algorithm used to process requests.
+* `status` - The status of the loadbalancer.
+* `redirect_http_to_https` - Whether the Load balancer is forced to redirect requests from HTTP to HTTPS.
+* `listen_ipv4_uuid` - The UUID of the IPv4 address the loadbalancer will listen to for incoming requests.
+* `listen_ipv6_uuid` - The UUID of the IPv6 address the loadbalancer will listen to for incoming requests.
+* `forwarding_rule` - The forwarding rules of the loadbalancer.
+* `backend_server` - The servers that the loadbalancer can communicate with.
+* `labels` - The list of labels.

--- a/website/docs/d/loadbalancer.html.md
+++ b/website/docs/d/loadbalancer.html.md
@@ -1,0 +1,25 @@
+---
+layout: "gridscale"
+page_title: "gridscale: loadbalancer"
+sidebar_current: "docs-gridscale-datasource-loadbalancer"
+description: |-
+  Gets the id of a loadbalancer.
+---
+
+# gridscale_loadbalancer
+
+Get the id of an loabalancer resource.
+
+## Example Usage
+
+```terraform
+data "gridscale_loadbalancer" "foo" {
+	resource_id   = "xxxx-xxxx-xxxx-xxxx"
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The UUID of the loadbalancer.

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -35,3 +35,15 @@ resource "gridscale_server" "servername"{
 The following attributes are exported:
 
 * `id` - The UUID of the network.
+* `name` - The UUID of the network.
+* `location_uuid` - The UUID of the location, that helps to identify which datacenter the network belongs to.
+* `l2security` - Defines information about MAC spoofing protection.
+* `status` - The status of the network.
+* `network_type` - The type of the network.
+* `location_country` - The human-readable name of the country where the network locates.
+* `location_iata` - The IATA airport code, which works as a location identifier.
+* `location_name` - The uman-readable name of the location where the network locates.
+* `delete_block` - Defines if the network is administratively blocked.
+* `create_time` - Defines the date and time the network was initially created.
+* `change_time` - Defines the date and time of the last network change.
+* `labels` - The list of labels.

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -15,8 +15,8 @@ Get the id of a network resource. This can be used to link networks to a server.
 Using the network datasource for the creation of a server:
 
 ```terraform
-resource "gridscale_network" "networkname"{
-	name = "terraform-network"
+data "gridscale_network" "networkname"{
+	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
@@ -24,7 +24,7 @@ resource "gridscale_server" "servername"{
 	cores = 2
 	memory = 4
 	network {
-		object_uuid = "${gridscale_network.networkname.id}"
+		object_uuid = "${data.gridscale_network.networkname.id}"
 		bootdevice = true
 	}
 }

--- a/website/docs/d/sshkey.html.md
+++ b/website/docs/d/sshkey.html.md
@@ -15,14 +15,12 @@ Get the id of an sshkey resource. This can be used to link SSH keys to a storage
 Using the sshkey datasource for the creation of a storage:
 
 ```terraform
-resource "gridscale_sshkey" "sshkey-john"{
-	name = "john's computer"
-	sshkey = "an ssh public key"
+data "gridscale_sshkey" "sshkey-john"{
+	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
-resource "gridscale_sshkey" "sshkey-jane"{
-	name = "jane's computer"
-	sshkey = "an ssh public key"
+data "gridscale_sshkey" "sshkey-jane"{
+	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_storage" "storagename"{
@@ -30,8 +28,8 @@ resource "gridscale_storage" "storagename"{
 	capacity = 10
 	template {
 		sshkeys = [
-		    "${gridscale_sshkey.sshkey-john.id}",
-		    "${gridscale_sshkey.sshkey-jane.id}"
+		    "${data.gridscale_sshkey.sshkey-john.id}",
+		    "${data.gridscale_sshkey.sshkey-jane.id}"
 		]
 		template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
 	}

--- a/website/docs/d/sshkey.html.md
+++ b/website/docs/d/sshkey.html.md
@@ -41,3 +41,9 @@ resource "gridscale_storage" "storagename"{
 The following attributes are exported:
 
 * `id` - The UUID of the sshkey.
+* `name` - The human-readable name of the sshkey.
+* `sshkey` - The OpenSSH public key string of the sshkey.
+* `status` - The status of the sshkey.
+* `create_time` - The date and time of the sshkey was initially created.
+* `change_time` - The date and time of the last sshkey change.
+* `labels` - The list of labels.

--- a/website/docs/d/storage.html.md
+++ b/website/docs/d/storage.html.md
@@ -15,9 +15,8 @@ Get the id of a storage resource. This can be used to link storages to a server.
 Using the storage datasource for the creation of a server:
 
 ```terraform
-resource "gridscale_storage" "storagename"{
-	name = "terraform-storage"
-	capacity = 10
+data "gridscale_storage" "storagename"{
+	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
@@ -25,7 +24,7 @@ resource "gridscale_server" "servername"{
 	cores = 2
 	memory = 4
 	storage {
-		object_uuid = "${gridscale_storage.storagename.id}"
+		object_uuid = "${data.gridscale_storage.storagename.id}"
 		bootdevice = true
 	}
 }

--- a/website/docs/d/storage.html.md
+++ b/website/docs/d/storage.html.md
@@ -35,3 +35,19 @@ resource "gridscale_server" "servername"{
 The following attributes are exported:
 
 * `id` - The UUID of the storage.
+* `change_time` - Defines the date and time of the last storage change.
+* `location_iata` - The IATA airport code of the location where storage locates.
+* `status` - The status of the storage.
+* `license_product_no` - The license key (e.g. Windows Servers), if the template used by the storage requires.
+* `location_country` - The human-readable name of the country where the storage locates.
+* `usage_in_minutes` - Total minutes the the storage has been running.
+* `last_used_template` - The UUID of the last used template on the storage.
+* `current_price` - The price for the current period since the last bill.
+* `capacity` - The capacity (GB) of the storage.
+* `location_uuid` - The UUID of the location where the storage locates.
+* `storage_type` - The type of the storage.
+* `parent_uuid` - The UUID of the parent of the storage.
+* `name` - The human-readable name of the storage.
+* `location_name` - The human-readable name of the location where the storage locates.
+* `create_time` - Defines the date and time the storage was initially created.
+* `labels` - The list of labels.

--- a/website/docs/d/template.html.md
+++ b/website/docs/d/template.html.md
@@ -45,4 +45,4 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The UUID of the template.
+* `name` - The name of the template.

--- a/website/docs/r/loadbalancer.html.md
+++ b/website/docs/r/loadbalancer.html.md
@@ -32,8 +32,35 @@ resource "gridscale_loadbalancer" "foo" {
 }
 ```
 
-## Attributes Reference
+## Argument Reference
 
-The following attributes are exported:
+The following arguments are supported:
+
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+
+* `location_uuid` - (Optional) Helps to identify which datacenter an object belongs to. Frankfurt is the default.
+
+* `redirect_http_to_https` - (Required) Whether the loadbalancer is forced to redirect requests from HTTP to HTTPS.
+
+* `listen_ipv4_uuid` - (Required) The UUID of the IPv4 address the loadbalancer will listen to for incoming requests.
+
+* `listen_ipv6_uuid` - (Required) The UUID of the IPv6 address the loadbalancer will listen to for incoming requests.
+
+* `algorithm` - (Required) The algorithm used to process requests. Accepted values: roundrobin/leastconn.
+
+* `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+## Attributes
+
+This resource exports the following attributes:
 
 * `id` - The UUID of the loadbalancer.
+* `name` - The human-readable name of the loadbalancer.
+* `algorithm` - The algorithm used to process requests.
+* `status` - The status of the loadbalancer.
+* `redirect_http_to_https` - Whether the Load balancer is forced to redirect requests from HTTP to HTTPS.
+* `listen_ipv4_uuid` - The UUID of the IPv4 address the loadbalancer will listen to for incoming requests.
+* `listen_ipv6_uuid` - The UUID of the IPv6 address the loadbalancer will listen to for incoming requests.
+* `forwarding_rule` - The forwarding rules of the loadbalancer.
+* `backend_server` - The servers that the loadbalancer can communicate with.
+* `labels` - The list of labels.

--- a/website/docs/r/loadbalancer.html.md
+++ b/website/docs/r/loadbalancer.html.md
@@ -1,0 +1,39 @@
+---
+layout: "gridscale"
+page_title: "gridscale: loadbalancer"
+sidebar_current: "docs-gridscale-resource-loadbalancer"
+description: |-
+  Manage a loadbalancer in gridscale.
+---
+
+# gridscale_loadbalancer
+
+Provides a loadbalancer resource. This can be used to create, modify and delete loadbalancers.
+
+## Example Usage
+
+```terraform
+resource "gridscale_loadbalancer" "foo" {
+	name   = "%s"
+	algorithm = "%s"
+	redirect_http_to_https = false
+	listen_ipv4_uuid = "${gridscale_ipv4.lb.id}"
+	listen_ipv6_uuid = "${gridscale_ipv6.lb.id}"
+	labels = []
+	backend_server {
+		weight = 100
+		host   = "${gridscale_ipv4.server.ip}"
+	}
+	forwarding_rule {
+		listen_port =  80
+		mode        =  "http"
+		target_port =  80
+	}
+}
+```
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The UUID of the loadbalancer.


### PR DESCRIPTION
- Change `resource` to `data` when querying data.
- `ip`, `network`, `sshkey`, and `storage` are currently query-able through their UUIDs.
- Add `loadbalancer` docs.
- Update coding convention: naming.