### PR TITLE
Add GitLab CI pipeline with acceptance tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,20 @@
+image: golang:1.13
+
+stages:
+  - test
+  - build
+
+unit_tests:
+  stage: test
+  script:
+    - make test
+
+vet:
+  stage: test
+  script:
+    - make vet
+
+build:
+  stage: build
+  script:
+    - make

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,13 @@ vet:
   script:
     - make vet
 
+acceptance_tests:
+  stage: test
+  script:
+    # Note: this uses GRIDSCALE_URL, GRIDSCALE_UUID, GRIDSCALE_TOKEN variables
+    # defined under Settings → CI/CD → Variables
+    - make testacc
+
 build:
   stage: build
   script:


### PR DESCRIPTION
This PR adds a GitLab CI pipeline along with acceptance tests.

Add `.gitlab-ci.yml` file to enable our GitLab CI pipeline. The pipeline will be running on our internal pull mirror at https://gitlab.com/gridscale/wolf/terraform-provider-gridscale.

Additionally to the tests we run on GitHub, we run a bunch of acceptance tests against our public API and, later, downstream projects consuming this Terraform provider.