### PR TITLE
GitLab CI: run acceptance tests with TF_LOG=DEBUG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ vet:
 
 acceptance_tests:
   stage: test
+  variables:
+    TF_LOG: DEBUG
   script:
     # Note: this uses GRIDSCALE_URL, GRIDSCALE_UUID, GRIDSCALE_TOKEN variables
     # defined under Settings → CI/CD → Variables


### PR DESCRIPTION
This PR just adds TF_LOG=DEBUG environment variable when running acceptance tests.