### PR TITLE
Remove interpolation expressions

### DIFF
--- a/gridscale/datasource_gridscale_ipv4_test.go
+++ b/gridscale/datasource_gridscale_ipv4_test.go
@@ -38,7 +38,7 @@ resource "gridscale_ipv4" "foo" {
 
 
 data "gridscale_ipv4" "foo" {
-	resource_id   = "${gridscale_ipv4.foo.id}"
+	resource_id   = gridscale_ipv4.foo.id
 }
 
 `, name)

--- a/gridscale/datasource_gridscale_ipv6_test.go
+++ b/gridscale/datasource_gridscale_ipv6_test.go
@@ -36,7 +36,7 @@ resource "gridscale_ipv6" "foo" {
 }
 
 data "gridscale_ipv6" "foo" {
-	resource_id   = "${gridscale_ipv6.foo.id}"
+	resource_id   = gridscale_ipv6.foo.id
 }
 `, name)
 }

--- a/gridscale/datasource_gridscale_loadbalancer_test.go
+++ b/gridscale/datasource_gridscale_loadbalancer_test.go
@@ -50,12 +50,12 @@ resource "gridscale_loadbalancer" "foo" {
 	name   = "%s"
 	algorithm = "leastconn"
 	redirect_http_to_https = false
-	listen_ipv4_uuid = "${gridscale_ipv4.lb.id}"
-	listen_ipv6_uuid = "${gridscale_ipv6.lb.id}"
+	listen_ipv4_uuid = gridscale_ipv4.lb.id
+	listen_ipv6_uuid = gridscale_ipv6.lb.id
 	labels = []
 	backend_server {
 		weight = 100
-		host   = "${gridscale_ipv4.server.ip}"
+		host   = gridscale_ipv4.server.ip
 	}
 	forwarding_rule {
 		listen_port =  80
@@ -65,6 +65,6 @@ resource "gridscale_loadbalancer" "foo" {
 }
 
 data "gridscale_loadbalancer" "foo" {
-	resource_id   = "${gridscale_loadbalancer.foo.id}"
+	resource_id   = gridscale_loadbalancer.foo.id
 }`, name, name, name, name)
 }

--- a/gridscale/datasource_gridscale_network_test.go
+++ b/gridscale/datasource_gridscale_network_test.go
@@ -36,6 +36,6 @@ resource "gridscale_network" "foo" {
 }
 
 data "gridscale_network" "foo" {
-	resource_id   = "${gridscale_network.foo.id}"
+	resource_id   = gridscale_network.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_paas_test.go
+++ b/gridscale/datasource_gridscale_paas_test.go
@@ -40,6 +40,6 @@ resource "gridscale_paas" "foo" {
 }
 
 data "gridscale_paas" "foo" {
-	resource_id   = "${gridscale_paas.foo.id}"
+	resource_id   = gridscale_paas.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_securityzone_test.go
+++ b/gridscale/datasource_gridscale_securityzone_test.go
@@ -35,6 +35,6 @@ resource "gridscale_paas_securityzone" "foo" {
 }
 
 data "gridscale_paas_securityzone" "foo" {
-	resource_id   = "${gridscale_paas_securityzone.foo.id}"
+	resource_id   = gridscale_paas_securityzone.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_snapshot_test.go
+++ b/gridscale/datasource_gridscale_snapshot_test.go
@@ -36,11 +36,11 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshot" "foo" {
   name = "%s"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
 }
 
 data "gridscale_snapshot" "foo" {
-	resource_id   = "${gridscale_snapshot.foo.id}"
-  	storage_uuid = "${gridscale_storage.foo.id}"
+	resource_id   = gridscale_snapshot.foo.id
+  	storage_uuid = gridscale_storage.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_snapshotschedule_test.go
+++ b/gridscale/datasource_gridscale_snapshotschedule_test.go
@@ -38,14 +38,14 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshotschedule" "foo" {
   name = "%s"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
   run_interval = 60
   next_runtime = "2025-12-30 15:04:05"
 }
 data "gridscale_snapshotschedule" "foo" {
-	resource_id   = "${gridscale_snapshotschedule.foo.id}"
-	storage_uuid   = "${gridscale_storage.foo.id}"
+	resource_id   = gridscale_snapshotschedule.foo.id
+	storage_uuid   = gridscale_storage.foo.id
 }
 `, name)
 }

--- a/gridscale/datasource_gridscale_sshkey_test.go
+++ b/gridscale/datasource_gridscale_sshkey_test.go
@@ -37,6 +37,6 @@ resource "gridscale_sshkey" "foo" {
 }
 
 data "gridscale_sshkey" "foo" {
-	resource_id   = "${gridscale_sshkey.foo.id}"
+	resource_id   = gridscale_sshkey.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_storage_test.go
+++ b/gridscale/datasource_gridscale_storage_test.go
@@ -38,6 +38,6 @@ resource "gridscale_storage" "foo" {
 }
 
 data "gridscale_storage" "foo" {
-	resource_id   = "${gridscale_storage.foo.id}"
+	resource_id   = gridscale_storage.foo.id
 }`, name)
 }

--- a/gridscale/resource_gridscale_loadbalancer_test.go
+++ b/gridscale/resource_gridscale_loadbalancer_test.go
@@ -91,12 +91,12 @@ resource "gridscale_loadbalancer" "foo" {
 	name   = "%s"
 	algorithm = "%s"
 	redirect_http_to_https = false
-	listen_ipv4_uuid = "${gridscale_ipv4.lb.id}"
-	listen_ipv6_uuid = "${gridscale_ipv6.lb.id}"
+	listen_ipv4_uuid = gridscale_ipv4.lb.id
+	listen_ipv6_uuid = gridscale_ipv6.lb.id
 	labels = []
 	backend_server {
 		weight = 100
-		host   = "${gridscale_ipv4.server.ip}"
+		host   = gridscale_ipv4.server.ip
 	}
 	forwarding_rule {
 		listen_port =  80
@@ -121,12 +121,12 @@ resource "gridscale_loadbalancer" "foo" {
 	name   = "%s"
 	algorithm = "%s"
 	redirect_http_to_https = false
-	listen_ipv4_uuid = "${gridscale_ipv4.lb.id}"
-	listen_ipv6_uuid = "${gridscale_ipv6.lb.id}"
+	listen_ipv4_uuid = gridscale_ipv4.lb.id
+	listen_ipv6_uuid = gridscale_ipv6.lb.id
 	labels = []
 	backend_server {
 		weight = 100
-		host   = "${gridscale_ipv4.server.ip}"
+		host   = gridscale_ipv4.server.ip
 	}
 	forwarding_rule {
 		listen_port =  80

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -125,9 +125,9 @@ resource "gridscale_server" "foo" {
   cores = 2
   memory = 2
   power = true
-  ipv4 = "${gridscale_ipv4.foo.id}"
+  ipv4 = gridscale_ipv4.foo.id
   network {
-		object_uuid = "${gridscale_network.foo.id}"
+		object_uuid = gridscale_network.foo.id
 		rules_v4_in {
 				order = 0
 				protocol = "tcp"
@@ -174,9 +174,9 @@ resource "gridscale_server" "foo" {
   cores = 1
   memory = 1
   power = true
-  ipv4 = "${gridscale_ipv4.foo1.id}"
+  ipv4 = gridscale_ipv4.foo1.id
   network {
-		object_uuid = "${gridscale_network.foo.id}"
+		object_uuid = gridscale_network.foo.id
 		rules_v4_in {
 				order = 0
 				protocol = "tcp"

--- a/gridscale/resource_gridscale_snapshot_test.go
+++ b/gridscale/resource_gridscale_snapshot_test.go
@@ -103,7 +103,7 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshot" "foo" {
   name = "%s"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   rollback = true
 }
 `, name)
@@ -117,7 +117,7 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshot" "foo" {
   name = "newname"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   labels = ["test"]
 }
 `)
@@ -131,7 +131,7 @@ resource "gridscale_storage" "new" {
 }
 resource "gridscale_snapshot" "foo" {
   name = "newname"
-  storage_uuid = "${gridscale_storage.new.id}"
+  storage_uuid = gridscale_storage.new.id
 }
 `)
 }

--- a/gridscale/resource_gridscale_snapshotschedule_test.go
+++ b/gridscale/resource_gridscale_snapshotschedule_test.go
@@ -103,7 +103,7 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshotschedule" "foo" {
   name = "%s"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
   run_interval = 60
   next_runtime = "2025-12-30 15:04:05"
@@ -119,7 +119,7 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshotschedule" "foo" {
   name = "newname"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   labels = ["test"]
   keep_snapshots = 1
   run_interval = 60
@@ -135,7 +135,7 @@ resource "gridscale_storage" "new" {
 }
 resource "gridscale_snapshotschedule" "foo" {
   name = "newname"
-  storage_uuid = "${gridscale_storage.new.id}"
+  storage_uuid = gridscale_storage.new.id
   keep_snapshots = 1
   run_interval = 60
 }

--- a/gridscale/resource_gridscale_storage_test.go
+++ b/gridscale/resource_gridscale_storage_test.go
@@ -159,7 +159,7 @@ resource "gridscale_storage" "foo" {
   template {
     template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
     hostname = "ubuntu"
-    sshkeys = [ "${gridscale_sshkey.sshkey.id}"]
+    sshkeys = [ gridscale_sshkey.sshkey.id ]
   }
 }
 `, name, name)

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -27,8 +27,8 @@ resource "gridscale_server" "servername"{
 	name = "terra-server"
 	cores = 2
 	memory = 4
-	ipv4 = "${data.gridscale_ipv4.ipv4name.id}"
-	ipv6 = "${data.gridscale_ipv6.ipv6name.id}"
+	ipv4 = data.gridscale_ipv4.ipv4name.id
+	ipv6 = data.gridscale_ipv6.ipv6name.id
 }
 ```
 

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -24,7 +24,7 @@ resource "gridscale_server" "servername"{
 	cores = 2
 	memory = 4
 	network {
-		object_uuid = "${data.gridscale_network.networkname.id}"
+		object_uuid = data.gridscale_network.networkname.id
 		bootdevice = true
 	}
 }

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -21,7 +21,7 @@ resource "gridscale_paas" "foo" {
 }
 
 data "gridscale_paas" "foo" {
-	resource_id   = "${gridscale_paas.foo.id}"
+	resource_id   = gridscale_paas.foo.id
 }
 ```
 

--- a/website/docs/d/publicnetwork.html.md
+++ b/website/docs/d/publicnetwork.html.md
@@ -23,7 +23,7 @@ resource "gridscale_server" "servername"{
 	cores = 2
 	memory = 4
 	network {
-		object_uuid = "${data.gridscale_public_network.pubnet.id}"
+		object_uuid = data.gridscale_public_network.pubnet.id
 		bootdevice = true
 	}
 }

--- a/website/docs/d/securityzone.html.md
+++ b/website/docs/d/securityzone.html.md
@@ -23,7 +23,7 @@ data "gridscale_paas_securityzone" "foo"{
 resource "gridscale_paas" "foo"{
 	name = "terra-paas-test"
     service_template_uuid = "f9625726-5ca8-4d5c-b9bd-3257e1e2211a"
-    security_zone_uuid = "${data.gridscale_paas_securityzone.foo.id}"
+    security_zone_uuid = data.gridscale_paas_securityzone.foo.id
 }
 ```
 

--- a/website/docs/d/snapshot.html.md
+++ b/website/docs/d/snapshot.html.md
@@ -19,12 +19,12 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshot" "foo" {
   name = "snapshot"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
 }
 
 data "gridscale_snapshot" "foo" {
-	resource_id   = "${gridscale_snapshot.foo.id}"
-  	storage_uuid = "${gridscale_storage.foo.id}"
+	resource_id   = gridscale_snapshot.foo.id
+  	storage_uuid = gridscale_storage.foo.id
 }
 ```
 

--- a/website/docs/d/snapshotschedule.html.md
+++ b/website/docs/d/snapshotschedule.html.md
@@ -19,14 +19,14 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshotschedule" "foo" {
   name = "snapshotschedule"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
   run_interval = 60
   next_runtime = "2025-12-30 15:04:05"
 }
 data "gridscale_snapshotschedule" "foo" {
-	resource_id   = "${gridscale_snapshotschedule.foo.id}"
-	storage_uuid   = "${gridscale_storage.foo.id}"
+	resource_id   = gridscale_snapshotschedule.foo.id
+	storage_uuid   = gridscale_storage.foo.id
 }
 ```
 

--- a/website/docs/d/sshkey.html.md
+++ b/website/docs/d/sshkey.html.md
@@ -28,8 +28,8 @@ resource "gridscale_storage" "storagename"{
 	capacity = 10
 	template {
 		sshkeys = [
-		    "${data.gridscale_sshkey.sshkey-john.id}",
-		    "${data.gridscale_sshkey.sshkey-jane.id}"
+		    data.gridscale_sshkey.sshkey-john.id,
+		    data.gridscale_sshkey.sshkey-jane.id
 		]
 		template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
 	}

--- a/website/docs/d/storage.html.md
+++ b/website/docs/d/storage.html.md
@@ -24,7 +24,7 @@ resource "gridscale_server" "servername"{
 	cores = 2
 	memory = 4
 	storage {
-		object_uuid = "${data.gridscale_storage.storagename.id}"
+		object_uuid = data.gridscale_storage.storagename.id
 		bootdevice = true
 	}
 }

--- a/website/docs/d/template.html.md
+++ b/website/docs/d/template.html.md
@@ -30,7 +30,7 @@ resource "gridscale_storage" "storage-test"{
 	capacity = 10
 	template {
 		sshkeys = [ "e17e8fd2-0797-4a00-a85d-eb9a612a6e4e" ]
-		template_uuid = "${data.gridscale_template.ubuntu.id}"
+		template_uuid = data.gridscale_template.ubuntu.id
 	}
 }
 ```

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,8 +17,8 @@ Use the navigation to the left to read about the available data sources and reso
 ```terraform
 # Configure the gridscale provider
 provider "gridscale" {
-	uuid = "${var.gridscale_uuid}"
-	token = "${var.gridscale_token}"
+	uuid = var.gridscale_uuid
+	token = var.gridscale_token
 }
 
 # Create a server

--- a/website/docs/r/loadbalancer.html.md
+++ b/website/docs/r/loadbalancer.html.md
@@ -17,12 +17,12 @@ resource "gridscale_loadbalancer" "foo" {
 	name   = "%s"
 	algorithm = "%s"
 	redirect_http_to_https = false
-	listen_ipv4_uuid = "${gridscale_ipv4.lb.id}"
-	listen_ipv6_uuid = "${gridscale_ipv6.lb.id}"
+	listen_ipv4_uuid = gridscale_ipv4.lb.id
+	listen_ipv6_uuid = gridscale_ipv6.lb.id
 	labels = []
 	backend_server {
 		weight = 100
-		host   = "${gridscale_ipv4.server.ip}"
+		host   = gridscale_ipv4.server.ip
 	}
 	forwarding_rule {
 		listen_port =  80

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -20,20 +20,20 @@ resource "gridscale_server" "terra-server-test"{
 	cores = 2
 	memory = 1
 	storage {
-		object_uuid = "${gridscale_storage.terra-storage-test.id}"
+		object_uuid = gridscale_storage.terra-storage-test.id
 		bootdevice = true
 	}
 	storage {
     		object_uuid = "UUID of storage 2",
     	}
 	network {
-		object_uuid = "${gridscale_network.terra-network-test.id}"
+		object_uuid = gridscale_network.terra-network-test.id
 		bootdevice = true
 	}
 	network {
     		object_uuid = "UUID of network 2"
     }
-	ipv4 = "${gridscale_ipv4.terra-ipv4-test.id}"
+	ipv4 = gridscale_ipv4.terra-ipv4-test.id}
 	ipv6 = "UUID of ipv6 address"
 	isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
 }

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -19,7 +19,7 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshot" "foo" {
   name = "snapshot"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
 }
 ```
 

--- a/website/docs/r/snapshotschedule.html.md
+++ b/website/docs/r/snapshotschedule.html.md
@@ -19,7 +19,7 @@ resource "gridscale_storage" "foo" {
 }
 resource "gridscale_snapshotschedule" "foo" {
   name = "snapshotschedule"
-  storage_uuid = "${gridscale_storage.foo.id}"
+  storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
   run_interval = 60
   next_runtime = "2025-12-30 15:04:05"

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -21,7 +21,7 @@ resource "gridscale_storage" "storage-john"{
 	storage_type = "storage_high"
 	template {
 	    template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
-	    password = "${var.gridscale_password-john}"
+	    password = var.gridscale_password-john
 	    password_type = "plain"
 	    hostname = "Ubuntu"
 	}


### PR DESCRIPTION
Remove interpolation expressions from code and docs. Interpolation expressions, such as `"${gridscale_storage.caching-storage.id}"` are deprecated. These should be replaced by expressions like `gridscale_storage.caching-storage.id`.

See also issue in examples over here: https://github.com/gridscale/terraform_examples/issues/3.