### PR TITLE
Fix switched documentation links

### DIFF
--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -23,10 +23,10 @@
               <a href="/docs/providers/gridscale/d/loadbalancer.html">gridscale_loadbalancer</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-datasource-paas") %>>
-              <a href="/docs/providers/gridscale/d/securityzone.html">gridscale_paas</a>
+              <a href="/docs/providers/gridscale/d/paas.html">gridscale_paas</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-datasource-securityzone") %>>
-              <a href="/docs/providers/gridscale/d/paas.html">gridscale_paas_securityzone</a>
+              <a href="/docs/providers/gridscale/d/securityzone.html">gridscale_paas_securityzone</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-datasource-server") %>>
               <a href="/docs/providers/gridscale/d/server.html">gridscale_server</a>
@@ -77,10 +77,12 @@
               <a href="/docs/providers/gridscale/r/network.html">gridscale_network</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-paas") %>>
-              <a href="/docs/providers/gridscale/r/securityzone.html">gridscale_paas</a>
+              <a href="/docs/providers/gridscale/r/paas.html">gridscale_
+              
+              </a>
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-securityzone") %>>
-              <a href="/docs/providers/gridscale/r/paas.html">gridscale_paas_securityzone</a>
+              <a href="/docs/providers/gridscale/r/securityzone.html">gridscale_paas_securityzone</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-server") %>>
               <a href="/docs/providers/gridscale/r/server.html">gridscale_server</a>

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -77,9 +77,7 @@
               <a href="/docs/providers/gridscale/r/network.html">gridscale_network</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-paas") %>>
-              <a href="/docs/providers/gridscale/r/paas.html">gridscale_
-              
-              </a>
+              <a href="/docs/providers/gridscale/r/paas.html">gridscale_paas</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-securityzone") %>>
               <a href="/docs/providers/gridscale/r/securityzone.html">gridscale_paas_securityzone</a>


### PR DESCRIPTION
Solves #57 

I noticed that the links for the paas and securityzone were switched.