### PR TITLE
Multiple project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Available Features
 | Snapshot to S3 | :x: |  
 | Snapshot schedule (CRUD) | :heavy_check_mark: |  
 | Template (CRUD) | :heavy_check_mark: |  
-| Multiple project support | :x: |
+| Multiple project support | :heavy_check_mark: |
 
 Developing the Provider
 ---------------------------

--- a/gridscale/common.go
+++ b/gridscale/common.go
@@ -128,7 +128,7 @@ func getProjectClientFromMeta(projectName string, meta interface{}) (*gsclient.C
 	}
 	client, ok := projectsClients[projectName]
 	if !ok {
-		return nil, fmt.Errorf("project %s's client has not configured", projectName)
+		return nil, fmt.Errorf("project %s's client has not been configured", projectName)
 	}
 	return client, nil
 }

--- a/gridscale/common.go
+++ b/gridscale/common.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 const (
@@ -88,4 +89,31 @@ func convInterfaceToString(interfaceType string, val interface{}) (string, error
 	default:
 		return "", errors.New("type is invalid")
 	}
+}
+
+//covStringToMapStringString converts a string to map[string]string
+//String format: "key1:val1,key2:val2,key3:val3"
+func covStringToMapStringString(str string) (map[string]string, error) {
+	formatError := errors.New(`invalid string. valid format: "key1:val1,key2:val2,key3:val3"`)
+	result := make(map[string]string)
+	//Split string by commas
+	commaSplitSlice := strings.Split(str, ",")
+	//loop through all "key:value" element in commaSplitSlice
+	for _, v := range commaSplitSlice {
+		if strings.TrimSpace(v) != "" {
+			//Split the element by a colon
+			colonSplitSlice := strings.Split(v, ":")
+			//the length of colonSplitSlice has to be 2 as
+			//there are 2 elements: key and value
+			if len(colonSplitSlice) == 2 {
+				result[colonSplitSlice[0]] = colonSplitSlice[1]
+			} else {
+				return nil, formatError
+			}
+		} else {
+			//if there is a empty element, return error
+			return nil, formatError
+		}
+	}
+	return result, nil
 }

--- a/gridscale/common.go
+++ b/gridscale/common.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+
+	"github.com/gridscale/gsclient-go/v2"
 )
 
 const (
@@ -116,4 +118,17 @@ func covStringToMapStringString(str string) (map[string]string, error) {
 		}
 	}
 	return result, nil
+}
+
+//getProjectClientFromMeta get gs client from meta by project's name
+func getProjectClientFromMeta(projectName string, meta interface{}) (*gsclient.Client, error) {
+	projectsClients, ok := meta.(map[string]*gsclient.Client)
+	if !ok {
+		return nil, fmt.Errorf("project %s: cannot convert meta to map[string]*gsclient.Client", projectName)
+	}
+	client, ok := projectsClients[projectName]
+	if !ok {
+		return nil, fmt.Errorf("project %s's client has not configured", projectName)
+	}
+	return client, nil
 }

--- a/gridscale/datasource_gridscale_firewall.go
+++ b/gridscale/datasource_gridscale_firewall.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleFirewall() *schema.Resource {
 		Read: dataSourceGridscaleFirewallRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -121,7 +125,11 @@ func dataSourceGridscaleFirewall() *schema.Resource {
 }
 
 func dataSourceGridscaleFirewallRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read firewall (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_firewall_test.go
+++ b/gridscale/datasource_gridscale_firewall_test.go
@@ -32,6 +32,7 @@ func TestAccdataSourceGridscaleFirewall_basic(t *testing.T) {
 func testAccCheckDataSourceFirewallConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_firewall" "foo" {
+  project = "default"
   name   = "%s"
   rules_v4_in {
 	order = 0
@@ -50,6 +51,7 @@ resource "gridscale_firewall" "foo" {
 }
 
 data "gridscale_firewall" "foo" {
+	project   = gridscale_firewall.foo.project
 	resource_id   = gridscale_firewall.foo.id
 }
 

--- a/gridscale/datasource_gridscale_ipv4.go
+++ b/gridscale/datasource_gridscale_ipv4.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 		Read: dataSourceGridscaleIpv4Read,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -102,7 +106,11 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 }
 
 func dataSourceGridscaleIpv4Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read IPv4 (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_ipv4_test.go
+++ b/gridscale/datasource_gridscale_ipv4_test.go
@@ -33,11 +33,13 @@ func testAccCheckDataSourceIPv4Config_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ipv4" "foo" {
+	project = "default"
 	name   = "%s"
 }
 
 
 data "gridscale_ipv4" "foo" {
+	project = gridscale_ipv4.foo.project
 	resource_id   = gridscale_ipv4.foo.id
 }
 

--- a/gridscale/datasource_gridscale_ipv6.go
+++ b/gridscale/datasource_gridscale_ipv6.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 		Read: dataSourceGridscaleIpv6Read,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -102,7 +106,11 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 }
 
 func dataSourceGridscaleIpv6Read(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read IPv6 (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_ipv6_test.go
+++ b/gridscale/datasource_gridscale_ipv6_test.go
@@ -32,10 +32,12 @@ func testAccCheckDataSourceIPv6Config_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ipv6" "foo" {
+	project = "default"
 	name   = "%s"
 }
 
 data "gridscale_ipv6" "foo" {
+	project = gridscale_ipv6.foo.project
 	resource_id   = gridscale_ipv6.foo.id
 }
 `, name)

--- a/gridscale/datasource_gridscale_isoimage.go
+++ b/gridscale/datasource_gridscale_isoimage.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
-	"github.com/gridscale/gsclient-go/v2"
 )
 
 func dataSourceGridscaleISOImage() *schema.Resource {
@@ -15,6 +13,11 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 		Read: dataSourceGridscaleISOImageRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -132,7 +135,11 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 }
 
 func dataSourceGridscaleISOImageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read ISO-Image (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_isoimage_test.go
+++ b/gridscale/datasource_gridscale_isoimage_test.go
@@ -2,8 +2,9 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
@@ -31,11 +32,13 @@ func TestAccDataSourceISOImage_basic(t *testing.T) {
 func testAccCheckDataSourceGridscaleISOImageConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_isoimage" "foo" {
+  project = "default"
   name   = "%s"
   source_url = "http://tinycorelinux.net/10.x/x86/release/TinyCore-current.iso"
 }
 
 resource "gridscale_server" "foo" {
+  project = gridscale_isoimage.foo.project
   name   = "%s"
   cores = 1
   memory = 1
@@ -43,6 +46,7 @@ resource "gridscale_server" "foo" {
 }
 
 data "gridscale_isoimage" "foo" {
+	project = gridscale_isoimage.foo.project
 	resource_id   = gridscale_isoimage.foo.id
 }
 `, name, name)

--- a/gridscale/datasource_gridscale_loadbalancer.go
+++ b/gridscale/datasource_gridscale_loadbalancer.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleLoadBalancer() *schema.Resource {
 		Read: dataSourceGridscaleLoadBalancerRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -107,7 +111,11 @@ func dataSourceGridscaleLoadBalancer() *schema.Resource {
 }
 
 func dataSourceGridscaleLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read loadbalancer (%s) datasource-", id)
 	loadbalancer, err := client.GetLoadBalancer(emptyCtx, id)

--- a/gridscale/datasource_gridscale_loadbalancer_test.go
+++ b/gridscale/datasource_gridscale_loadbalancer_test.go
@@ -38,15 +38,19 @@ func testAccCheckDataSourceLoadBalancerConfig_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ipv4" "lb" {
+	project = "default"
 	name   = "ipv4-%s"
 }
 resource "gridscale_ipv6" "lb" {
+	project = "default"
 	name   = "ipv6-%s"
 }
 resource "gridscale_ipv4" "server" {
+	project = "default"
 	name   = "server-%s"
 }
 resource "gridscale_loadbalancer" "foo" {
+	project = "default"
 	name   = "%s"
 	algorithm = "leastconn"
 	redirect_http_to_https = false
@@ -65,6 +69,7 @@ resource "gridscale_loadbalancer" "foo" {
 }
 
 data "gridscale_loadbalancer" "foo" {
+	project = gridscale_loadbalancer.foo.project
 	resource_id   = gridscale_loadbalancer.foo.id
 }`, name, name, name, name)
 }

--- a/gridscale/datasource_gridscale_network.go
+++ b/gridscale/datasource_gridscale_network.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 		Read: dataSourceGridscaleNetworkRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -85,7 +89,11 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 }
 
 func dataSourceGridscaleNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read network (%s) datasource-", id)

--- a/gridscale/datasource_gridscale_network_test.go
+++ b/gridscale/datasource_gridscale_network_test.go
@@ -32,10 +32,12 @@ func testAccCheckDataSourceNetworkConfig_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_network" "foo" {
+  project = "default"
   name   = "%s"
 }
 
 data "gridscale_network" "foo" {
+	project = gridscale_network.foo.project
 	resource_id   = gridscale_network.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_objectstorage.go
+++ b/gridscale/datasource_gridscale_objectstorage.go
@@ -2,7 +2,7 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/gridscale/gsclient-go/v2"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -11,6 +11,11 @@ func dataSourceGridscaleObjectStorage() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGridscaleObjectStorageRead,
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -32,7 +37,11 @@ func dataSourceGridscaleObjectStorage() *schema.Resource {
 }
 
 func dataSourceGridscaleObjectStorageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read object storage (%s) datasource-", id)

--- a/gridscale/datasource_gridscale_objectstorage_test.go
+++ b/gridscale/datasource_gridscale_objectstorage_test.go
@@ -31,10 +31,12 @@ func TestAccdataSourceGridscaleObjectStorage_basic(t *testing.T) {
 func testAccCheckDataSourceObjectStorageConfig_basic() string {
 	return fmt.Sprint(`
 resource "gridscale_object_storage_accesskey" "foo" {
+	project = "default"
 }
 
 data "gridscale_object_storage_accesskey" "foo" {
-	resource_id   = "${gridscale_object_storage_accesskey.foo.id}"
+	project = gridscale_object_storage_accesskey.foo.project
+	resource_id   = gridscale_object_storage_accesskey.foo.id
 }
 `)
 }

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -2,7 +2,7 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/gridscale/gsclient-go/v2"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -12,6 +12,11 @@ func dataSourceGridscalePaaS() *schema.Resource {
 		Read: dataSourceGridscalePaaSRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -139,7 +144,11 @@ func dataSourceGridscalePaaS() *schema.Resource {
 }
 
 func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read paas (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_paas_test.go
+++ b/gridscale/datasource_gridscale_paas_test.go
@@ -30,6 +30,7 @@ func TestAccdataSourceGridscalePaaS_basic(t *testing.T) {
 func testAccCheckDataSourcePaaSConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas" "foo" {
+  project = "default"
   name = "%s"
   service_template_uuid = "8bcb216c-65ec-4c93-925d-1b8feaa5c2c5"
   parameter {
@@ -40,6 +41,7 @@ resource "gridscale_paas" "foo" {
 }
 
 data "gridscale_paas" "foo" {
+	project = gridscale_paas.foo.project
 	resource_id   = gridscale_paas.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_publicnetwork.go
+++ b/gridscale/datasource_gridscale_publicnetwork.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
@@ -12,6 +11,11 @@ func dataSourceGridscalePublicNetwork() *schema.Resource {
 		Read: dataSourceGridscalePublicNetworkRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
@@ -78,7 +82,11 @@ func dataSourceGridscalePublicNetwork() *schema.Resource {
 }
 
 func dataSourceGridscalePublicNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := "read public network datasource -"
 	network, err := client.GetNetworkPublic(emptyCtx)
 	if err != nil {

--- a/gridscale/datasource_gridscale_publicnetwork_test.go
+++ b/gridscale/datasource_gridscale_publicnetwork_test.go
@@ -28,5 +28,6 @@ func TestAccdataSourceGridscalePublicNetwork_basic(t *testing.T) {
 func testAccCheckDataSourcePublicNetworkConfig_basic() string {
 	return fmt.Sprint(`
 data "gridscale_public_network" "foo" {
+	project = "default"
 }`)
 }

--- a/gridscale/datasource_gridscale_securityzone.go
+++ b/gridscale/datasource_gridscale_securityzone.go
@@ -12,6 +12,11 @@ func dataSourceGridscalePaaSSecurityZone() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGridscalePaaSSecurityZoneRead,
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -75,7 +80,11 @@ func dataSourceGridscalePaaSSecurityZone() *schema.Resource {
 }
 
 func dataSourceGridscalePaaSSecurityZoneRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read paas security zone (%s) datasource -", id)
 	secZone, err := client.GetPaaSSecurityZone(emptyCtx, id)

--- a/gridscale/datasource_gridscale_securityzone_test.go
+++ b/gridscale/datasource_gridscale_securityzone_test.go
@@ -31,10 +31,12 @@ func TestAccdataSourceGridscaleSecurityZone_basic(t *testing.T) {
 func testAccCheckDataSourceSecurityZoneConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas_securityzone" "foo" {
+  project = "default"
   name = "%s"
 }
 
 data "gridscale_paas_securityzone" "foo" {
+	project = gridscale_paas_securityzone.foo.project
 	resource_id   = gridscale_paas_securityzone.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_server.go
+++ b/gridscale/datasource_gridscale_server.go
@@ -2,7 +2,7 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/gridscale/gsclient-go/v2"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -12,6 +12,11 @@ func dataSourceGridscaleServer() *schema.Resource {
 		Read: dataSourceGridscaleServerRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -242,7 +247,11 @@ func dataSourceGridscaleServer() *schema.Resource {
 }
 
 func dataSourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read server (%s) datasource-", id)

--- a/gridscale/datasource_gridscale_server_test.go
+++ b/gridscale/datasource_gridscale_server_test.go
@@ -32,12 +32,14 @@ func TestAccdataSourceGridscaleServer_basic(t *testing.T) {
 func testAccCheckDataSourceServerConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_server" "foo" {
+  project = "default"
   name   = "%s"
   cores = 1
   memory = 1
 }
 
 data "gridscale_server" "foo" {
+	project = gridscale_server.foo.project
 	resource_id   = gridscale_server.foo.id
 }
 

--- a/gridscale/datasource_gridscale_snapshot.go
+++ b/gridscale/datasource_gridscale_snapshot.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleStorageSnapshot() *schema.Resource {
 		Read: dataSourceGridscaleSnapshotRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
@@ -96,7 +100,11 @@ the product_no of the license (see the /prices endpoint for more details)`,
 }
 
 func dataSourceGridscaleSnapshotRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	storageUuid := d.Get("storage_uuid").(string)
 	id := d.Get("resource_id").(string)

--- a/gridscale/datasource_gridscale_snapshot_test.go
+++ b/gridscale/datasource_gridscale_snapshot_test.go
@@ -31,15 +31,18 @@ func TestAccdataSourceGridscaleSnapshot_basic(t *testing.T) {
 func testAccCheckDataSourceSnapshotConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshot" "foo" {
+  project = gridscale_storage.foo.project
   name = "%s"
   storage_uuid = gridscale_storage.foo.id
 }
 
 data "gridscale_snapshot" "foo" {
+	project = gridscale_storage.foo.project
 	resource_id   = gridscale_snapshot.foo.id
   	storage_uuid = gridscale_storage.foo.id
 }`, name)

--- a/gridscale/datasource_gridscale_snapshotschedule.go
+++ b/gridscale/datasource_gridscale_snapshotschedule.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleStorageSnapshotSchedule() *schema.Resource {
 		Read: dataSourceGridscaleSnapshotScheduleRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -91,7 +95,11 @@ func dataSourceGridscaleStorageSnapshotSchedule() *schema.Resource {
 }
 
 func dataSourceGridscaleSnapshotScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	storageUUID := d.Get("storage_uuid").(string)

--- a/gridscale/datasource_gridscale_snapshotschedule_test.go
+++ b/gridscale/datasource_gridscale_snapshotschedule_test.go
@@ -33,10 +33,12 @@ func testAccCheckDataSourceSnapshotScheduleConfig_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshotschedule" "foo" {
+  project = gridscale_storage.foo.project
   name = "%s"
   storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
@@ -44,6 +46,7 @@ resource "gridscale_snapshotschedule" "foo" {
   next_runtime = "2025-12-30 15:04:05"
 }
 data "gridscale_snapshotschedule" "foo" {
+	project   = gridscale_snapshotschedule.foo.project
 	resource_id   = gridscale_snapshotschedule.foo.id
 	storage_uuid   = gridscale_storage.foo.id
 }

--- a/gridscale/datasource_gridscale_sshkey.go
+++ b/gridscale/datasource_gridscale_sshkey.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -13,6 +12,11 @@ func dataSourceGridscaleSshkey() *schema.Resource {
 		Read: dataSourceGridscaleSshkeyRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -52,7 +56,11 @@ func dataSourceGridscaleSshkey() *schema.Resource {
 }
 
 func dataSourceGridscaleSshkeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read SSH key (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_sshkey_test.go
+++ b/gridscale/datasource_gridscale_sshkey_test.go
@@ -32,11 +32,13 @@ func testAccCheckDataSourceSSHKeyConfig_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_sshkey" "foo" {
+  project = "default"
   name   = "%s"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKea3u6cuJ/2ZoMA4fpnXRK8ZIZWQz8ddXJv+iul9gTAc4fbm30IjZNnBBxiFOETc5ev1mcxvi6XvW99gLmxJAGwUrHylxYODXl1fLhc2G5czwQS9Qk57ED+IYb7AGOWPxGYeDaDka6gxJal/aaUx0C42fQErpUiJj2mJlF8yUOqyygtQOZhT2XUBU5UBZd50r8die8oRgdKJrbcn48q1Eu60vpx4S4JgH+krrHoXuCRydQ31KfOXmD8Y3/oGlZQ40luhfnj6g1jpm6PIQEBehGyZl6Dyh0MeeJsePWAGmXMEA33FcDkUiQPLoaalr4QQZdAUS74/irf+mgRcSRPvL root@475d4232363a"
 }
 
 data "gridscale_sshkey" "foo" {
+	project = gridscale_sshkey.foo.project
 	resource_id   = gridscale_sshkey.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_storage.go
+++ b/gridscale/datasource_gridscale_storage.go
@@ -3,7 +3,6 @@ package gridscale
 import (
 	"fmt"
 
-	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
@@ -12,6 +11,11 @@ func dataSourceGridscaleStorage() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGridscaleStorageRead,
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"resource_id": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -100,7 +104,11 @@ func dataSourceGridscaleStorage() *schema.Resource {
 }
 
 func dataSourceGridscaleStorageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	id := d.Get("resource_id").(string)
 	errorPrefix := fmt.Sprintf("read storage (%s) datasource -", id)

--- a/gridscale/datasource_gridscale_storage_test.go
+++ b/gridscale/datasource_gridscale_storage_test.go
@@ -33,11 +33,13 @@ func testAccCheckDataSourceStorageConfig_basic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "%s"
   capacity = 1
 }
 
 data "gridscale_storage" "foo" {
+	project   = gridscale_storage.foo.project
 	resource_id   = gridscale_storage.foo.id
 }`, name)
 }

--- a/gridscale/datasource_gridscale_template.go
+++ b/gridscale/datasource_gridscale_template.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-
-	"github.com/gridscale/gsclient-go/v2"
 )
 
 func dataSourceGridscaleTemplate() *schema.Resource {
@@ -15,6 +13,11 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 		Read: dataSourceGridscaleTemplateRead,
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+			},
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
 				Required:     true,
@@ -111,7 +114,11 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 }
 
 func dataSourceGridscaleTemplateRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	name := d.Get("name").(string)
 	errorPrefix := fmt.Sprintf("read template (%s) datasource -", name)

--- a/gridscale/datasource_gridscale_template_test.go
+++ b/gridscale/datasource_gridscale_template_test.go
@@ -30,6 +30,7 @@ func TestAccDataSourceTemplate_basic(t *testing.T) {
 func testAccCheckDataSourceGridscaleTemplateConfig_basic(name string) string {
 	return fmt.Sprintf(`
 data "gridscale_template" "foo" {
+	project = "default"
 	name   = "%s"
 }
 `, name)

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -14,11 +14,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_UUID", nil),
 				Description: "User-UUID for the gridscale API.",
 			},
-			"token": {
+			"projects_tokens": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_TOKEN", nil),
-				Description: "API-token for the gridscale API.",
+				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_PROJECTS_TOKENS", nil),
+				Description: "Projects' API-tokens for the gridscale API.",
 			},
 			"api_url": {
 				Type:        schema.TypeString,
@@ -68,11 +68,15 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	projectsTokensMap, err := covStringToMapStringString(d.Get("projects_tokens").(string))
+	if err != nil {
+		return nil, err
+	}
 	config := Config{
-		UserUUID: d.Get("uuid").(string),
-		APIToken: d.Get("token").(string),
-		APIUrl:   d.Get("api_url").(string),
+		UserUUID:        d.Get("uuid").(string),
+		APIUrl:          d.Get("api_url").(string),
+		ProjectAPIToken: projectsTokensMap,
 	}
 
-	return config.Client()
+	return config.Clients()
 }

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -18,7 +18,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_PROJECTS_TOKENS", nil),
-				Description: "Projects' API-tokens for the gridscale API.",
+				Description: `Projects' API-tokens for the gridscale API. Format: ""project1:token1,project2:token1,project3:token1""`,
 			},
 			"api_url": {
 				Type:        schema.TypeString,

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -18,7 +18,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_PROJECTS_TOKENS", nil),
-				Description: `Projects' API-tokens for the gridscale API. Format: ""project1:token1,project2:token1,project3:token1""`,
+				Description: `Projects' API-tokens for the gridscale API. Format: "project1:token1,project2:token1,project3:token1`,
 			},
 			"api_url": {
 				Type:        schema.TypeString,

--- a/gridscale/provider_test.go
+++ b/gridscale/provider_test.go
@@ -33,7 +33,7 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("GRIDSCALE_UUID must be set for acceptance tests")
 	}
 
-	if v := os.Getenv("GRIDSCALE_TOKEN"); v == "" {
-		t.Fatal("GRIDSCALE_TOKEN must be set for acceptance tests")
+	if v := os.Getenv("GRIDSCALE_PROJECTS_TOKENS"); v == "" {
+		t.Fatal("GRIDSCALE_PROJECTS_TOKENS must be set for acceptance tests")
 	}
 }

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -3,10 +3,11 @@ package gridscale
 import (
 	"errors"
 	"fmt"
+	"log"
+
 	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
 )
 
 func resourceGridscaleFirewall() *schema.Resource {
@@ -20,6 +21,12 @@ func resourceGridscaleFirewall() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -130,7 +130,11 @@ func resourceGridscaleFirewall() *schema.Resource {
 }
 
 func resourceGridscaleFirewallRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read firewall (%s) resource -", d.Id())
 	template, err := client.GetFirewall(emptyCtx, d.Id())
 	if err != nil {
@@ -213,7 +217,11 @@ func resourceGridscaleFirewallRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleFirewallCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	var rulesV4In, rulesV4Out, rulesV6In, rulesV6Out []gsclient.FirewallRuleProperties
 	//Get firewall rules from schema
 	if attr, ok := d.GetOk("rules_v4_in"); ok {
@@ -256,7 +264,11 @@ func resourceGridscaleFirewallCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleFirewallUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update firewall (%s) resource -", d.Id())
 
 	var rulesV4In, rulesV4Out, rulesV6In, rulesV6Out []gsclient.FirewallRuleProperties
@@ -296,7 +308,11 @@ func resourceGridscaleFirewallUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleFirewallDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete firewall (%s) resource -", d.Id())
 	err := client.DeleteFirewall(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -299,7 +299,7 @@ func resourceGridscaleFirewallUpdate(d *schema.ResourceData, meta interface{}) e
 		RulesV4In:  rulesV4In,
 		RulesV4Out: rulesV4Out,
 	}
-	err := client.UpdateFirewall(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateFirewall(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -314,7 +314,7 @@ func resourceGridscaleFirewallDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete firewall (%s) resource -", d.Id())
-	err := client.DeleteFirewall(emptyCtx, d.Id())
+	err = client.DeleteFirewall(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_firewall_test.go
+++ b/gridscale/resource_gridscale_firewall_test.go
@@ -52,7 +52,11 @@ func testAccCheckResourceGridscaleFirewallExists(n string, object *gsclient.Fire
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -73,13 +77,16 @@ func testAccCheckResourceGridscaleFirewallExists(n string, object *gsclient.Fire
 }
 
 func testAccCheckGridscaleFirewallDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_firewall" {
 			continue
 		}
-
-		_, err := client.GetIP(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetIP(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_firewall_test.go
+++ b/gridscale/resource_gridscale_firewall_test.go
@@ -99,6 +99,7 @@ func testAccCheckGridscaleFirewallDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleFirewallConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_firewall" "foo" {
+  project = "default"
   name   = "%s"
   rules_v4_in {
 	order = 0
@@ -122,6 +123,7 @@ resource "gridscale_firewall" "foo" {
 func testAccCheckResourceGridscaleFirewallConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_firewall" "foo" {
+  project = "default"
   name   = "newname"
   rules_v4_out {
 	order = 0

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -199,7 +199,7 @@ func resourceGridscaleIpUpdate(d *schema.ResourceData, meta interface{}) error {
 		Labels:     &labels,
 	}
 
-	err := client.UpdateIP(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateIP(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -255,7 +255,7 @@ func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 		//DeleteIP requires the server to be off
-		err = globalServerStatusList.runActionRequireServerOff(emptyCtx, client, server.ServerUUID, false, unlinkIPAction)
+		err = globalServerStatusList[projectName].runActionRequireServerOff(emptyCtx, client, server.ServerUUID, false, unlinkIPAction)
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -116,7 +116,11 @@ func resourceGridscaleIpv4() *schema.Resource {
 }
 
 func resourceGridscaleIpRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read IP (%s) resource -", d.Id())
 	ip, err := client.GetIP(emptyCtx, d.Id())
 	if err != nil {
@@ -180,7 +184,11 @@ func resourceGridscaleIpRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGridscaleIpUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update IP (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -200,7 +208,11 @@ func resourceGridscaleIpUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGridscaleIpv4Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.IPCreateRequest{
 		Family:     gsclient.IPv4Type,
@@ -223,7 +235,11 @@ func resourceGridscaleIpv4Create(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete IP (%s) resource -", d.Id())
 
 	ip, err := client.GetIP(emptyCtx, d.Id())

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -22,6 +22,12 @@ func resourceGridscaleIpv4() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"ip": {
 				Type:        schema.TypeString,
 				Description: "Defines the IP Address.",

--- a/gridscale/resource_gridscale_ipv4_test.go
+++ b/gridscale/resource_gridscale_ipv4_test.go
@@ -56,7 +56,11 @@ func testAccCheckResourceGridscaleIpv4Exists(n string, object *gsclient.IP) reso
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -77,13 +81,16 @@ func testAccCheckResourceGridscaleIpv4Exists(n string, object *gsclient.IP) reso
 }
 
 func testAccCheckGridscaleIpv4DestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_ipv4" {
 			continue
 		}
-
-		_, err := client.GetIP(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetIP(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_ipv4_test.go
+++ b/gridscale/resource_gridscale_ipv4_test.go
@@ -103,6 +103,7 @@ func testAccCheckGridscaleIpv4DestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleIpv4Config_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
+  project = "default"
   name   = "%s"
 }
 `, name)
@@ -111,6 +112,7 @@ resource "gridscale_ipv4" "foo" {
 func testAccCheckResourceGridscaleIpv4Config_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
+  project = "default"
   name   = "newname"
   failover = true
   reverse_dns = "test.test"

--- a/gridscale/resource_gridscale_ipv6.go
+++ b/gridscale/resource_gridscale_ipv6.go
@@ -19,6 +19,12 @@ func resourceGridscaleIpv6() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"ip": {
 				Type:        schema.TypeString,
 				Description: "Defines the IP Address.",

--- a/gridscale/resource_gridscale_ipv6.go
+++ b/gridscale/resource_gridscale_ipv6.go
@@ -113,7 +113,11 @@ func resourceGridscaleIpv6() *schema.Resource {
 }
 
 func resourceGridscaleIpv6Create(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.IPCreateRequest{
 		Family:     gsclient.IPv6Type,

--- a/gridscale/resource_gridscale_ipv6_test.go
+++ b/gridscale/resource_gridscale_ipv6_test.go
@@ -56,7 +56,11 @@ func testAccCheckResourceGridscaleIpv6Exists(n string, object *gsclient.IP) reso
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -77,13 +81,16 @@ func testAccCheckResourceGridscaleIpv6Exists(n string, object *gsclient.IP) reso
 }
 
 func testAccCheckGridscaleIpv6DestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_ipv6" {
 			continue
 		}
-
-		_, err := client.GetIP(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetIP(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_ipv6_test.go
+++ b/gridscale/resource_gridscale_ipv6_test.go
@@ -103,6 +103,7 @@ func testAccCheckGridscaleIpv6DestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleIpv6Config_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv6" "foo" {
+  project = "default"
   name   = "%s"
 }
 `, name)
@@ -111,6 +112,7 @@ resource "gridscale_ipv6" "foo" {
 func testAccCheckResourceGridscaleIpv6Config_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv6" "foo" {
+  project = "default"
   name   = "newname"
   failover = true
   reverse_dns = "test.test"

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -138,7 +138,11 @@ func resourceGridscaleISOImage() *schema.Resource {
 }
 
 func resourceGridscaleISOImageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read ISO-Image (%s) resource -", d.Id())
 	iso, err := client.GetISOImage(emptyCtx, d.Id())
 	if err != nil {
@@ -219,7 +223,11 @@ func resourceGridscaleISOImageRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleISOImageCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.ISOImageCreateRequest{
 		Name:      d.Get("name").(string),
@@ -240,7 +248,11 @@ func resourceGridscaleISOImageCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleISOImageUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update ISO-Image (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -258,7 +270,11 @@ func resourceGridscaleISOImageUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleISOImageDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete ISO-Image (%s) resource -", d.Id())
 
 	isoimage, err := client.GetISOImage(emptyCtx, d.Id())

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -261,7 +261,7 @@ func resourceGridscaleISOImageUpdate(d *schema.ResourceData, meta interface{}) e
 		Labels: &labels,
 	}
 
-	err := client.UpdateISOImage(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateISOImage(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -2,10 +2,11 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/gridscale/gsclient-go/v2"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"net/http"
+
+	"github.com/gridscale/gsclient-go/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceGridscaleISOImage() *schema.Resource {
@@ -19,6 +20,12 @@ func resourceGridscaleISOImage() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",

--- a/gridscale/resource_gridscale_isoimage_test.go
+++ b/gridscale/resource_gridscale_isoimage_test.go
@@ -99,11 +99,13 @@ func testAccCheckGridscaleISOImageDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleISOImageConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_isoimage" "foo" {
+  project = "default"
   name   = "%s"
   source_url = "http://tinycorelinux.net/10.x/x86/release/TinyCore-current.iso"
 }
 
 resource "gridscale_server" "foo" {
+  project = gridscale_isoimage.foo.project
   name   = "%s"
   cores = 1
   memory = 1
@@ -115,6 +117,7 @@ resource "gridscale_server" "foo" {
 func testAccCheckResourceGridscaleISOImageConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_isoimage" "foo" {
+  project = "default"
   name   = "newname"
   source_url = "http://tinycorelinux.net/10.x/x86/release/TinyCore-current.iso"
 }

--- a/gridscale/resource_gridscale_isoimage_test.go
+++ b/gridscale/resource_gridscale_isoimage_test.go
@@ -52,7 +52,11 @@ func testAccCheckResourceGridscaleISOImageExists(n string, object *gsclient.ISOI
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -73,13 +77,16 @@ func testAccCheckResourceGridscaleISOImageExists(n string, object *gsclient.ISOI
 }
 
 func testAccCheckGridscaleISOImageDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_isoimage" {
 			continue
 		}
-
-		_, err := client.GetISOImage(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetISOImage(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -249,7 +249,7 @@ func resourceGridscaleLoadBalancerUpdate(d *schema.ResourceData, meta interface{
 	if forwardingRules, ok := d.GetOk("forwarding_rule"); ok {
 		requestBody.ForwardingRules = expandLoadbalancerForwardingRules(forwardingRules)
 	}
-	err := client.UpdateLoadBalancer(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateLoadBalancer(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 
@@ -264,7 +264,7 @@ func resourceGridscaleLoadBalancerDelete(d *schema.ResourceData, meta interface{
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete loadbalancer (%s) resource-", d.Id())
-	err := client.DeleteLoadBalancer(emptyCtx, d.Id())
+	err = client.DeleteLoadBalancer(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -20,6 +20,12 @@ func resourceGridscaleLoadBalancer() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -131,7 +131,11 @@ func resourceGridscaleLoadBalancer() *schema.Resource {
 }
 
 func resourceGridscaleLoadBalancerCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.LoadBalancerCreateRequest{
 		Name:                d.Get("name").(string),
@@ -164,7 +168,11 @@ func resourceGridscaleLoadBalancerCreate(d *schema.ResourceData, meta interface{
 }
 
 func resourceGridscaleLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read loadbalancer (%s) resource -", d.Id())
 	loadbalancer, err := client.GetLoadBalancer(emptyCtx, d.Id())
 	if err != nil {
@@ -215,7 +223,11 @@ func resourceGridscaleLoadBalancerRead(d *schema.ResourceData, meta interface{})
 }
 
 func resourceGridscaleLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update loadbalancer (%s) resource -", d.Id())
 	requestBody := gsclient.LoadBalancerUpdateRequest{
 		Name:                d.Get("name").(string),
@@ -246,7 +258,11 @@ func resourceGridscaleLoadBalancerUpdate(d *schema.ResourceData, meta interface{
 }
 
 func resourceGridscaleLoadBalancerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete loadbalancer (%s) resource-", d.Id())
 	err := client.DeleteLoadBalancer(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_loadbalancer_test.go
+++ b/gridscale/resource_gridscale_loadbalancer_test.go
@@ -79,16 +79,20 @@ func testAccCheckResourceGridscaleLoadBalancerExists(n string, object *gsclient.
 func testAccCheckResourceGridscaleLoadBalancerConfig_basic(name string, algorithm string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "lb" {
-	name   = "ipv4-%s"
+  project = "default"
+  name   = "ipv4-%s"
 }
 resource "gridscale_ipv6" "lb" {
-	name   = "ipv6-%s"
+  project = "default"
+  name   = "ipv6-%s"
 }
 resource "gridscale_ipv4" "server" {
-	name   = "server-%s"
+  project = "default"
+  name   = "server-%s"
 }
 resource "gridscale_loadbalancer" "foo" {
-	name   = "%s"
+  project = "default"
+  name   = "%s"
 	algorithm = "%s"
 	redirect_http_to_https = false
 	listen_ipv4_uuid = gridscale_ipv4.lb.id
@@ -109,16 +113,20 @@ resource "gridscale_loadbalancer" "foo" {
 func testAccCheckResourceGridscaleLoadBalancerConfig_update(name string, algorithm string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "lb" {
-	name   = "ipv4-%s"
+  project = "default"
+  name   = "ipv4-%s"
 }
 resource "gridscale_ipv6" "lb" {
-	name   = "ipv6-%s"
+  project = "default"
+  name   = "ipv6-%s"
 }
 resource "gridscale_ipv4" "server" {
-	name   = "server-%s"
+  project = "default"
+  name   = "server-%s"
 }
 resource "gridscale_loadbalancer" "foo" {
-	name   = "%s"
+  project = "default"
+  name   = "%s"
 	algorithm = "%s"
 	redirect_http_to_https = false
 	listen_ipv4_uuid = gridscale_ipv4.lb.id

--- a/gridscale/resource_gridscale_loadbalancer_test.go
+++ b/gridscale/resource_gridscale_loadbalancer_test.go
@@ -56,7 +56,11 @@ func testAccCheckResourceGridscaleLoadBalancerExists(n string, object *gsclient.
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -145,13 +149,16 @@ resource "gridscale_loadbalancer" "foo" {
 }
 
 func testAccCheckGridscaleLoadBalancerDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_loadbalancer" {
 			continue
 		}
-
-		_, err := client.GetLoadBalancer(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetLoadBalancer(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -22,6 +22,12 @@ func resourceGridscaleNetwork() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -171,7 +171,7 @@ func resourceGridscaleNetworkUpdate(d *schema.ResourceData, meta interface{}) er
 		Labels:     &labels,
 	}
 
-	err := client.UpdateNetwork(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateNetwork(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -98,7 +98,11 @@ func resourceGridscaleNetwork() *schema.Resource {
 }
 
 func resourceGridscaleNetworkRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read network (%s) resource -", d.Id())
 	network, err := client.GetNetwork(emptyCtx, d.Id())
 	if err != nil {
@@ -153,7 +157,11 @@ func resourceGridscaleNetworkRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGridscaleNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update network (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -172,7 +180,11 @@ func resourceGridscaleNetworkUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGridscaleNetworkCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.NetworkCreateRequest{
 		Name:       d.Get("name").(string),
@@ -193,7 +205,11 @@ func resourceGridscaleNetworkCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete network (%s) resource -", d.Id())
 	net, err := client.GetNetwork(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -223,7 +223,7 @@ func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 		//UnlinkNetwork requires the server to be off
-		err = globalServerStatusList.runActionRequireServerOff(emptyCtx, client, server.ObjectUUID, false, unlinkNetAction)
+		err = globalServerStatusList[projectName].runActionRequireServerOff(emptyCtx, client, server.ObjectUUID, false, unlinkNetAction)
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}

--- a/gridscale/resource_gridscale_network_test.go
+++ b/gridscale/resource_gridscale_network_test.go
@@ -54,7 +54,11 @@ func testAccCheckResourceGridscaleNetworkExists(n string, object *gsclient.Netwo
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -75,13 +79,16 @@ func testAccCheckResourceGridscaleNetworkExists(n string, object *gsclient.Netwo
 }
 
 func testAccCheckGridscaleNetworkDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_network" {
 			continue
 		}
-
-		_, err := client.GetNetwork(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetNetwork(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_network_test.go
+++ b/gridscale/resource_gridscale_network_test.go
@@ -101,6 +101,7 @@ func testAccCheckGridscaleNetworkDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleNetworkConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_network" "foo" {
+  project = "default"
   name   = "%s"
 }
 `, name)
@@ -109,6 +110,7 @@ resource "gridscale_network" "foo" {
 func testAccCheckResourceGridscaleNetworkConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_network" "foo" {
+  project = "default"
   name   = "newname"
   l2security = true
 }

--- a/gridscale/resource_gridscale_objectstorage.go
+++ b/gridscale/resource_gridscale_objectstorage.go
@@ -38,7 +38,11 @@ func resourceGridscaleObjectStorage() *schema.Resource {
 }
 
 func resourceGridscaleObjectStorageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read object storage (%s) resource -", d.Id())
 	objectStorage, err := client.GetObjectStorageAccessKey(emptyCtx, d.Id())
 	if err != nil {
@@ -61,7 +65,11 @@ func resourceGridscaleObjectStorageRead(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGridscaleObjectStorageCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	response, err := client.CreateObjectStorageAccessKey(emptyCtx)
 	if err != nil {
@@ -75,7 +83,11 @@ func resourceGridscaleObjectStorageCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceGridscaleObjectStorageDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete object storage (%s) resource -", d.Id())
 	err := client.DeleteObjectStorageAccessKey(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_objectstorage.go
+++ b/gridscale/resource_gridscale_objectstorage.go
@@ -89,7 +89,7 @@ func resourceGridscaleObjectStorageDelete(d *schema.ResourceData, meta interface
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete object storage (%s) resource -", d.Id())
-	err := client.DeleteObjectStorageAccessKey(emptyCtx, d.Id())
+	err = client.DeleteObjectStorageAccessKey(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_objectstorage.go
+++ b/gridscale/resource_gridscale_objectstorage.go
@@ -2,9 +2,10 @@ package gridscale
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"log"
 )
 
 func resourceGridscaleObjectStorage() *schema.Resource {
@@ -16,6 +17,12 @@ func resourceGridscaleObjectStorage() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"access_key": {
 				Type:        schema.TypeString,
 				Description: "The object storage secret_key.",

--- a/gridscale/resource_gridscale_objectstorage_test.go
+++ b/gridscale/resource_gridscale_objectstorage_test.go
@@ -90,6 +90,7 @@ func testAccCheckGridscaleObjectStorageDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleObjectStorageConfig_basic() string {
 	return fmt.Sprint(`
 resource "gridscale_object_storage_accesskey" "foo" {
+	project = "default"
 }
 `)
 }

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -2,10 +2,11 @@ package gridscale
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"strings"
 
 	"log"
 )
@@ -20,6 +21,12 @@ func resourceGridscalePaaS() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -166,7 +166,11 @@ func resourceGridscalePaaS() *schema.Resource {
 }
 
 func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(emptyCtx, d.Id())
 	if err != nil {
@@ -286,7 +290,11 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceGridscalePaaSServiceCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	requestBody := gsclient.PaaSServiceCreateRequest{
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: d.Get("service_template_uuid").(string),
@@ -330,7 +338,11 @@ func resourceGridscalePaaSServiceCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGridscalePaaSServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update paas (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -373,7 +385,11 @@ func resourceGridscalePaaSServiceUpdate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceGridscalePaaSServiceDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
 	err := client.DeletePaaSService(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -377,7 +377,7 @@ func resourceGridscalePaaSServiceUpdate(d *schema.ResourceData, meta interface{}
 	}
 	requestBody.ResourceLimits = limits
 
-	err := client.UpdatePaaSService(emptyCtx, d.Id(), requestBody)
+	err = client.UpdatePaaSService(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -391,7 +391,7 @@ func resourceGridscalePaaSServiceDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
-	err := client.DeletePaaSService(emptyCtx, d.Id())
+	err = client.DeletePaaSService(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_paas_test.go
+++ b/gridscale/resource_gridscale_paas_test.go
@@ -2,6 +2,7 @@ package gridscale
 
 import (
 	"fmt"
+
 	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -96,6 +97,7 @@ func testAccCheckResourceGridscalePaaSDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscalePaaSConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas" "foopaas" {
+  project = "default"
   name = "%s"
   service_template_uuid = "8bcb216c-65ec-4c93-925d-1b8feaa5c2c5"
 }
@@ -105,6 +107,7 @@ resource "gridscale_paas" "foopaas" {
 func testAccCheckResourceGridscalePaaSConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_paas" "foopaas" {
+  project = "default"
   name = "newname"
   service_template_uuid = "8bcb216c-65ec-4c93-925d-1b8feaa5c2c5"
   resource_limit {
@@ -133,6 +136,7 @@ resource "gridscale_paas" "foopaas" {
 func testAccCheckResourceGridscalePaaSConfig_forcenew_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_paas" "foopaas" {
+  project = "default"
   name = "newname"
   service_template_uuid = "136c1446-13e0-4734-bdb6-ab0a15c1d680"
   resource_limit {

--- a/gridscale/resource_gridscale_securityzone.go
+++ b/gridscale/resource_gridscale_securityzone.go
@@ -84,7 +84,11 @@ func resourceGridscalePaaSSecurityZone() *schema.Resource {
 }
 
 func resourceGridscalePaaSSecurityZoneRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read paas security zone (%s) resource -", d.Id())
 	secZone, err := client.GetPaaSSecurityZone(emptyCtx, d.Id())
 	if err != nil {
@@ -139,7 +143,11 @@ func resourceGridscalePaaSSecurityZoneRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceGridscalePaaSSecurityZoneCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	requestBody := gsclient.PaaSSecurityZoneCreateRequest{
 		Name: d.Get("name").(string),
 	}
@@ -153,7 +161,11 @@ func resourceGridscalePaaSSecurityZoneCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGridscalePaaSSecurityZoneUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update paas security zone (%s) resource -", d.Id())
 	requestBody := gsclient.PaaSSecurityZoneUpdateRequest{
 		Name: d.Get("name").(string),
@@ -166,7 +178,11 @@ func resourceGridscalePaaSSecurityZoneUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceGridscalePaaSSecurityZoneDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete paas security zone (%s) resource -", d.Id())
 	err := client.DeletePaaSSecurityZone(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_securityzone.go
+++ b/gridscale/resource_gridscale_securityzone.go
@@ -170,7 +170,7 @@ func resourceGridscalePaaSSecurityZoneUpdate(d *schema.ResourceData, meta interf
 	requestBody := gsclient.PaaSSecurityZoneUpdateRequest{
 		Name: d.Get("name").(string),
 	}
-	err := client.UpdatePaaSSecurityZone(emptyCtx, d.Id(), requestBody)
+	err = client.UpdatePaaSSecurityZone(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -184,7 +184,7 @@ func resourceGridscalePaaSSecurityZoneDelete(d *schema.ResourceData, meta interf
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete paas security zone (%s) resource -", d.Id())
-	err := client.DeletePaaSSecurityZone(emptyCtx, d.Id())
+	err = client.DeletePaaSSecurityZone(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_securityzone.go
+++ b/gridscale/resource_gridscale_securityzone.go
@@ -2,10 +2,11 @@ package gridscale
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"log"
 )
 
 func resourceGridscalePaaSSecurityZone() *schema.Resource {
@@ -18,6 +19,12 @@ func resourceGridscalePaaSSecurityZone() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Required:     true,

--- a/gridscale/resource_gridscale_securityzone_test.go
+++ b/gridscale/resource_gridscale_securityzone_test.go
@@ -49,7 +49,11 @@ func testAccCheckDataSourceGridscaleSecurityZoneExists(n string, object *gsclien
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No object UUID is set")
 		}
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 		id := rs.Primary.ID
 		foundObject, err := client.GetPaaSSecurityZone(emptyCtx, id)
 		if err != nil {
@@ -64,13 +68,16 @@ func testAccCheckDataSourceGridscaleSecurityZoneExists(n string, object *gsclien
 }
 
 func testAccCheckDataSourceGridscaleSecurityZoneDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_securityzone" {
 			continue
 		}
-
-		_, err := client.GetPaaSSecurityZone(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetPaaSSecurityZone(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_securityzone_test.go
+++ b/gridscale/resource_gridscale_securityzone_test.go
@@ -89,6 +89,7 @@ func testAccCheckDataSourceGridscaleSecurityZoneDestroyCheck(s *terraform.State)
 func testAccCheckDataSourceGridscaleSecurityZoneConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas_securityzone" "foo" {
+  project = "default"
   name = "%s"
 }
 `, name)
@@ -97,6 +98,7 @@ resource "gridscale_paas_securityzone" "foo" {
 func testAccCheckDataSourceGridscaleSecurityZoneConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_paas_securityzone" "foo" {
+  project = "default"
   name = "newname"
 }
 `)

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -678,7 +678,7 @@ func resourceGridscaleServerDelete(d *schema.ResourceData, meta interface{}) err
 	}
 	errorPrefix := fmt.Sprintf("delete server (%s) resource -", d.Id())
 	//remove the server
-	err := globalServerStatusList.removeServerSynchronously(emptyCtx, client, d.Id())
+	err = globalServerStatusList.removeServerSynchronously(emptyCtx, client, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -378,7 +378,11 @@ then it will proceed onto rule 2. Packets that do not match any rules are blocke
 }
 
 func resourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read server (%s) resource -", d.Id())
 	server, err := client.GetServer(emptyCtx, d.Id())
 	if err != nil {
@@ -667,7 +671,11 @@ func resourceGridscaleServerCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleServerDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete server (%s) resource -", d.Id())
 	//remove the server
 	err := globalServerStatusList.removeServerSynchronously(emptyCtx, client, d.Id())

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -3,9 +3,10 @@ package gridscale
 import (
 	"context"
 	"fmt"
-	relation_manager "github.com/terraform-providers/terraform-provider-gridscale/gridscale/relation-manager"
 	"log"
 	"strings"
+
+	relation_manager "github.com/terraform-providers/terraform-provider-gridscale/gridscale/relation-manager"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -24,6 +25,12 @@ func resourceGridscaleServer() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:         schema.TypeString,
 				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -578,7 +578,11 @@ func flattenFirewallRuleProperties(props gsclient.FirewallRuleProperties) map[st
 }
 
 func resourceGridscaleServerCreate(d *schema.ResourceData, meta interface{}) error {
-	gsc := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	gsc, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	serverRelMan := relation_manager.NewServerRelationManger(gsc, d)
 	requestBody := gsclient.ServerCreateRequest{
 		Name:            d.Get("name").(string),
@@ -623,7 +627,7 @@ func resourceGridscaleServerCreate(d *schema.ResourceData, meta interface{}) err
 	log.Printf("[DEBUG] The id for %s has been set to: %v", requestBody.Name, response.ServerUUID)
 
 	//Add server power status to globalServerStatusList
-	err = globalServerStatusList.addServer(d.Id())
+	err = globalServerStatusList[projectName].addServer(d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -661,7 +665,7 @@ func resourceGridscaleServerCreate(d *schema.ResourceData, meta interface{}) err
 	//Set the power state if needed
 	power := d.Get("power").(bool)
 	if power {
-		err = globalServerStatusList.startServerSynchronously(emptyCtx, gsc, d.Id())
+		err = globalServerStatusList[projectName].startServerSynchronously(emptyCtx, gsc, d.Id())
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
@@ -678,7 +682,7 @@ func resourceGridscaleServerDelete(d *schema.ResourceData, meta interface{}) err
 	}
 	errorPrefix := fmt.Sprintf("delete server (%s) resource -", d.Id())
 	//remove the server
-	err = globalServerStatusList.removeServerSynchronously(emptyCtx, client, d.Id())
+	err = globalServerStatusList[projectName].removeServerSynchronously(emptyCtx, client, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -686,10 +690,13 @@ func resourceGridscaleServerDelete(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleServerUpdate(d *schema.ResourceData, meta interface{}) error {
-	gsc := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	gsc, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	serverDepClient := relation_manager.NewServerRelationManger(gsc, d)
 	shutdownRequired := serverDepClient.IsShutdownRequired(emptyCtx)
-	var err error
 	errorPrefix := fmt.Sprintf("update server (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -729,7 +736,7 @@ func resourceGridscaleServerUpdate(d *schema.ResourceData, meta interface{}) err
 			err = serverDepClient.UpdateStoragesRel(ctx)
 			return err
 		}
-		err = globalServerStatusList.runActionRequireServerOff(emptyCtx, gsc, d.Id(), true, updateSequence)
+		err = globalServerStatusList[projectName].runActionRequireServerOff(emptyCtx, gsc, d.Id(), true, updateSequence)
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 
@@ -752,12 +759,12 @@ func resourceGridscaleServerUpdate(d *schema.ResourceData, meta interface{}) err
 	// Make sure the server in is the expected power state.
 	// The StartServer and ShutdownServer functions do a check to see if the server isn't already running, so we don't need to do that here.
 	if d.Get("power").(bool) {
-		err = globalServerStatusList.startServerSynchronously(emptyCtx, gsc, d.Id())
+		err = globalServerStatusList[projectName].startServerSynchronously(emptyCtx, gsc, d.Id())
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 	} else {
-		err = globalServerStatusList.shutdownServerSynchronously(emptyCtx, gsc, d.Id())
+		err = globalServerStatusList[projectName].shutdownServerSynchronously(emptyCtx, gsc, d.Id())
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -64,7 +64,11 @@ func testAccCheckResourceGridscaleServerExists(n string, object *gsclient.Server
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -85,13 +89,16 @@ func testAccCheckResourceGridscaleServerExists(n string, object *gsclient.Server
 }
 
 func testAccCheckResourceGridscaleServerDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_server" {
 			continue
 		}
-
-		_, err := client.GetServer(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetServer(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -111,16 +111,20 @@ func testAccCheckResourceGridscaleServerDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleServerConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
+  project = "default"
   name   = "ip-%s"
 }
 resource "gridscale_network" "foo" {
+  project = "default"
   name   = "net-%s"
 }
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage- %s"
   capacity = 1
 }
 resource "gridscale_server" "foo" {
+  project = "default"
   name   = "%s"
   cores = 2
   memory = 2
@@ -160,16 +164,20 @@ resource "gridscale_server" "foo" {
 func testAccCheckResourceGridscaleServerConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo1" {
+  project = "default"
   name   = "newname"
 }
 resource "gridscale_network" "foo" {
+  project = "default"
   name   = "newname"
 }
 resource "gridscale_storage" "foo1" {
+  project = "default"
   name   = "newname"
   capacity = 1
 }
 resource "gridscale_server" "foo" {
+  project = "default"
   name   = "newname"
   cores = 1
   memory = 1

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -255,7 +255,7 @@ func resourceGridscaleSnapshotUpdate(d *schema.ResourceData, meta interface{}) e
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-	err := client.UpdateStorageSnapshot(emptyCtx, storageUUID, d.Id(), requestBody)
+	err = client.UpdateStorageSnapshot(emptyCtx, storageUUID, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -304,7 +304,7 @@ func resourceGridscaleSnapshotDelete(d *schema.ResourceData, meta interface{}) e
 	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("delete snapshot (%s) resource of storage (%s) -", d.Id(), storageUUID)
-	err := client.DeleteStorageSnapshot(emptyCtx, storageUUID, d.Id())
+	err = client.DeleteStorageSnapshot(emptyCtx, storageUUID, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -129,7 +129,11 @@ the product_no of the license (see the /prices endpoint for more details)`,
 func resourceGridscaleSnapshotRead(d *schema.ResourceData, meta interface{}) error {
 	storageUuid := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("read snapshot (%s) resource of storage (%s)-", d.Id(), storageUuid)
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	snapshot, err := client.GetStorageSnapshot(emptyCtx, storageUuid, d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -185,7 +189,11 @@ func resourceGridscaleSnapshotRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	storageUUID := d.Get("storage_uuid").(string)
 	requestBody := gsclient.StorageSnapshotCreateRequest{
 		Name:   d.Get("name").(string),
@@ -234,7 +242,11 @@ func resourceGridscaleSnapshotCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleSnapshotUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("update snapshot (%s) resource of storage (%s) -", d.Id(), storageUUID)
 
@@ -285,7 +297,11 @@ func resourceGridscaleSnapshotUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("delete snapshot (%s) resource of storage (%s) -", d.Id(), storageUUID)
 	err := client.DeleteStorageSnapshot(emptyCtx, storageUUID, d.Id())

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -2,9 +2,10 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/gridscale/gsclient-go/v2"
 )
@@ -20,6 +21,12 @@ func resourceGridscaleStorageSnapshot() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/gridscale/resource_gridscale_snapshot_test.go
+++ b/gridscale/resource_gridscale_snapshot_test.go
@@ -57,7 +57,11 @@ func testAccCheckDataSourceGridscaleSnapshotExists(n string, object *gsclient.St
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No object UUID is set")
 		}
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 		id := rs.Primary.ID
 		storageID := rs.Primary.Attributes["storage_uuid"]
 		foundObject, err := client.GetStorageSnapshot(emptyCtx, storageID, id)
@@ -73,13 +77,16 @@ func testAccCheckDataSourceGridscaleSnapshotExists(n string, object *gsclient.St
 }
 
 func testAccCheckDataSourceGridscaleSnapshotDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_snapshot" {
 			continue
 		}
-
-		_, err := client.GetStorageSnapshot(emptyCtx, rs.Primary.Attributes["storage_uuid"], rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetStorageSnapshot(emptyCtx, rs.Primary.Attributes["storage_uuid"], rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_snapshot_test.go
+++ b/gridscale/resource_gridscale_snapshot_test.go
@@ -98,10 +98,12 @@ func testAccCheckDataSourceGridscaleSnapshotDestroyCheck(s *terraform.State) err
 func testAccCheckDataSourceGridscaleSnapshotConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshot" "foo" {
+  project = "default"
   name = "%s"
   storage_uuid = gridscale_storage.foo.id
   rollback {
@@ -114,10 +116,12 @@ resource "gridscale_snapshot" "foo" {
 func testAccCheckDataSourceGridscaleSnapshotConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshot" "foo" {
+  project = "default"
   name = "newname"
   storage_uuid = gridscale_storage.foo.id
   labels = ["test"]
@@ -134,10 +138,12 @@ resource "gridscale_snapshot" "foo" {
 func testAccCheckDataSourceGridscaleSnapshotConfig_forcenew_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "new" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshot" "foo" {
+  project = "default"
   name = "newname"
   storage_uuid = gridscale_storage.new.id
 }

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -218,7 +218,7 @@ func resourceGridscaleSnapshotScheduleUpdate(d *schema.ResourceData, meta interf
 		}
 		requestBody.NextRuntime = &gsclient.GSTime{Time: nextRuntime}
 	}
-	err := client.UpdateStorageSnapshotSchedule(emptyCtx, storageUUID, d.Id(), requestBody)
+	err = client.UpdateStorageSnapshotSchedule(emptyCtx, storageUUID, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -233,7 +233,7 @@ func resourceGridscaleSnapshotScheduleDelete(d *schema.ResourceData, meta interf
 	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("delete snapshot schedule (%s) resource of storage (%s)-", d.Id(), storageUUID)
-	err := client.DeleteStorageSnapshotSchedule(emptyCtx, storageUUID, d.Id())
+	err = client.DeleteStorageSnapshotSchedule(emptyCtx, storageUUID, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -104,7 +104,11 @@ func resourceGridscaleStorageSnapshotSchedule() *schema.Resource {
 }
 
 func resourceGridscaleSnapshotScheduleRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("read snapshot schedule (%s) resource of storage (%s)-", d.Id(), storageUUID)
 	scheduler, err := client.GetStorageSnapshotSchedule(emptyCtx, storageUUID, d.Id())
@@ -164,7 +168,11 @@ func resourceGridscaleSnapshotScheduleRead(d *schema.ResourceData, meta interfac
 }
 
 func resourceGridscaleSnapshotScheduleCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	requestBody := gsclient.StorageSnapshotScheduleCreateRequest{
 		Name:          d.Get("name").(string),
 		Labels:        convSOStrings(d.Get("labels").(*schema.Set).List()),
@@ -188,7 +196,11 @@ func resourceGridscaleSnapshotScheduleCreate(d *schema.ResourceData, meta interf
 }
 
 func resourceGridscaleSnapshotScheduleUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("update snapshot schedule (%s) resource of storage (%s)-", d.Id(), storageUUID)
 
@@ -214,7 +226,11 @@ func resourceGridscaleSnapshotScheduleUpdate(d *schema.ResourceData, meta interf
 }
 
 func resourceGridscaleSnapshotScheduleDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	storageUUID := d.Get("storage_uuid").(string)
 	errorPrefix := fmt.Sprintf("delete snapshot schedule (%s) resource of storage (%s)-", d.Id(), storageUUID)
 	err := client.DeleteStorageSnapshotSchedule(emptyCtx, storageUUID, d.Id())

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -22,6 +22,12 @@ func resourceGridscaleStorageSnapshotSchedule() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,

--- a/gridscale/resource_gridscale_snapshotschedule_test.go
+++ b/gridscale/resource_gridscale_snapshotschedule_test.go
@@ -98,10 +98,12 @@ func testAccCheckDataSourceGridscaleSnapshotScheduleDestroyCheck(s *terraform.St
 func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshotschedule" "foo" {
+  project = "default"
   name = "%s"
   storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
@@ -114,10 +116,12 @@ resource "gridscale_snapshotschedule" "foo" {
 func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshotschedule" "foo" {
+  project = "default"
   name = "newname"
   storage_uuid = gridscale_storage.foo.id
   labels = ["test"]
@@ -130,10 +134,12 @@ resource "gridscale_snapshotschedule" "foo" {
 func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_forcenew_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "new" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshotschedule" "foo" {
+  project = "default"
   name = "newname"
   storage_uuid = gridscale_storage.new.id
   keep_snapshots = 1

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -116,7 +116,7 @@ func resourceGridscaleSshkeyUpdate(d *schema.ResourceData, meta interface{}) err
 		Labels: &labels,
 	}
 
-	err := client.UpdateSshkey(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateSshkey(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -156,7 +156,7 @@ func resourceGridscaleSshkeyDelete(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete SSH key (%s) resource -", d.Id())
-	err := client.DeleteSshkey(emptyCtx, d.Id())
+	err = client.DeleteSshkey(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -20,6 +20,12 @@ func resourceGridscaleSshkey() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -61,7 +61,11 @@ func resourceGridscaleSshkey() *schema.Resource {
 }
 
 func resourceGridscaleSshkeyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read SSH key (%s) resource -", d.Id())
 	sshkey, err := client.GetSshkey(emptyCtx, d.Id())
 	if err != nil {
@@ -98,7 +102,11 @@ func resourceGridscaleSshkeyRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceGridscaleSshkeyUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update SSH key (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -117,7 +125,11 @@ func resourceGridscaleSshkeyUpdate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleSshkeyCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.SshkeyCreateRequest{
 		Name:   d.Get("name").(string),
@@ -138,7 +150,11 @@ func resourceGridscaleSshkeyCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleSshkeyDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete SSH key (%s) resource -", d.Id())
 	err := client.DeleteSshkey(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_sshkey_test.go
+++ b/gridscale/resource_gridscale_sshkey_test.go
@@ -56,8 +56,11 @@ func testAccCheckResourceGridscaleSshkeyExists(n string, object *gsclient.Sshkey
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
-
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 		id := rs.Primary.ID
 
 		foundObject, err := client.GetSshkey(emptyCtx, id)
@@ -77,13 +80,16 @@ func testAccCheckResourceGridscaleSshkeyExists(n string, object *gsclient.Sshkey
 }
 
 func testAccCheckGridscaleSshkeyDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_sshkey" {
 			continue
 		}
-
-		_, err := client.GetSshkey(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetSshkey(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_sshkey_test.go
+++ b/gridscale/resource_gridscale_sshkey_test.go
@@ -103,6 +103,7 @@ func testAccCheckGridscaleSshkeyDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleSshkeyConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "foo" {
+  project = "default"
   name   = "%s"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKea3u6cuJ/2ZoMA4fpnXRK8ZIZWQz8ddXJv+iul9gTAc4fbm30IjZNnBBxiFOETc5ev1mcxvi6XvW99gLmxJAGwUrHylxYODXl1fLhc2G5czwQS9Qk57ED+IYb7AGOWPxGYeDaDka6gxJal/aaUx0C42fQErpUiJj2mJlF8yUOqyygtQOZhT2XUBU5UBZd50r8die8oRgdKJrbcn48q1Eu60vpx4S4JgH+krrHoXuCRydQ31KfOXmD8Y3/oGlZQ40luhfnj6g1jpm6PIQEBehGyZl6Dyh0MeeJsePWAGmXMEA33FcDkUiQPLoaalr4QQZdAUS74/irf+mgRcSRPvL root@475d4232363a"
 }
@@ -112,6 +113,7 @@ resource "gridscale_sshkey" "foo" {
 func testAccCheckResourceGridscaleSshkeyConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "foo" {
+  project = "default"
   name   = "newname"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvOYJ3xXtPXaPOacFQ97+nGq5QDkl17/JeTaY36RLPKgYBt2Z5YSPSROdzh/5GgZ0p6E3W84gKNaedUo3v+zvgmdGZeDFk+cxlC0HtXwQN87GQRtYTMsucbI6OJT7p4qntl70MIBzvIrmheGZqXnpeRxA7PjVcjkA3nxps3XJsuMDd0Ft0Ue3j0lmOno779mfgg34VeTgE2GZlH31gFqxWz3fXUgaZoLdO7HbLKu4ybfFWdCzqBt4B8RG9xMq0220gJR6ZwAaiMc1CGIknK7C6EKeCx9LOWDjCaHg6pA2iPAb/PoxDuiqbUIzfRmkgMf0lYmrf0kqx529ALm92ulSx root@33c294c5235e"
 }

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -260,7 +260,7 @@ func resourceGridscaleStorageUpdate(d *schema.ResourceData, meta interface{}) er
 		Labels: &labels,
 	}
 
-	err := client.UpdateStorage(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateStorage(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -3,10 +3,11 @@ package gridscale
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
 	"github.com/gridscale/gsclient-go/v2"
 )
@@ -22,6 +23,12 @@ func resourceGridscaleStorage() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -177,7 +177,11 @@ func resourceGridscaleStorage() *schema.Resource {
 }
 
 func resourceGridscaleStorageRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read storage (%s) resource -", d.Id())
 	storage, err := client.GetStorage(emptyCtx, d.Id())
 	if err != nil {
@@ -243,7 +247,11 @@ func resourceGridscaleStorageRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func resourceGridscaleStorageUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update storage (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -261,7 +269,11 @@ func resourceGridscaleStorageUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGridscaleStorageCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.StorageCreateRequest{
 		Name:     d.Get("name").(string),
@@ -313,7 +325,11 @@ func resourceGridscaleStorageCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete storage (%s) resource -", d.Id())
 	storage, err := client.GetStorage(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -343,7 +343,7 @@ func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) er
 			return err
 		}
 		//UnlinkStorage requires the server to be off
-		err = globalServerStatusList.runActionRequireServerOff(emptyCtx, client, server.ObjectUUID, false, unlinkStorageAction)
+		err = globalServerStatusList[projectName].runActionRequireServerOff(emptyCtx, client, server.ObjectUUID, false, unlinkStorageAction)
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}

--- a/gridscale/resource_gridscale_storage_test.go
+++ b/gridscale/resource_gridscale_storage_test.go
@@ -130,6 +130,7 @@ func testAccCheckGridscaleStorageDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleStorageConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "%s"
   capacity = 1
 }
@@ -139,6 +140,7 @@ resource "gridscale_storage" "foo" {
 func testAccCheckResourceGridscaleStorageConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "newname"
   capacity = 1
 }
@@ -148,10 +150,12 @@ resource "gridscale_storage" "foo" {
 func testAccCheckResourceGridscaleStorageConfig_advanced(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "sshkey" {
+  project = "default"
   name = "%s"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQClJCCOAFyBNIWUpzU4/mFqns5G4+nXzf5iFblNZqtAJmPzKnl0m0Gxj9GV27EkaWpqivVSUblmw3KRWMgCAiJUrMoQt4VAUKUzwdlNZ+6cIDSncEg671SLmCGZmWmVdOR5KaHWlkIRnowfB7UIDyubu/B7r+9L5IPdVgqw3KQW4jZRSsaOOG+I6z0J46c0j+/uJBxuqsr0QD0RQYc2n2Q8O9oNvp3U/L0B5ZYkecAZCCTuGpfNnJdpjj4ww+Qgq/qt4WEIWgVIPEU3B5PlqKZDTO+0JjCsAaQIkN6HOSVHP7h9b+grBnTxSc55CPqBGEBP8zlcne29olJttseJgnBT"
 }
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "%s"
   capacity = 10
   storage_type= "storage"

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -241,7 +241,7 @@ func resourceGridscaleTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 		Labels: &labels,
 	}
 
-	err := client.UpdateTemplate(emptyCtx, d.Id(), requestBody)
+	err = client.UpdateTemplate(emptyCtx, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
@@ -256,7 +256,7 @@ func resourceGridscaleTemplateDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	errorPrefix := fmt.Sprintf("delete template (%s) resource -", d.Id())
-	err := client.DeleteTemplate(emptyCtx, d.Id())
+	err = client.DeleteTemplate(emptyCtx, d.Id())
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -2,9 +2,10 @@ package gridscale
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/gridscale/gsclient-go/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"log"
 )
 
 func resourceGridscaleTemplate() *schema.Resource {
@@ -18,6 +19,12 @@ func resourceGridscaleTemplate() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:        schema.TypeString,
+				Description: "The project name that set in `GRIDSCALE_PROJECTS_TOKENS` env or `projects_tokens` tf variable",
+				Required:    true,
+				ForceNew:    true,
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -126,7 +126,11 @@ func resourceGridscaleTemplate() *schema.Resource {
 }
 
 func resourceGridscaleTemplateRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("read template (%s) resource -", d.Id())
 	template, err := client.GetTemplate(emptyCtx, d.Id())
 	if err != nil {
@@ -199,7 +203,11 @@ func resourceGridscaleTemplateRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceGridscaleTemplateCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 
 	requestBody := gsclient.TemplateCreateRequest{
 		Name:         d.Get("name").(string),
@@ -220,7 +228,11 @@ func resourceGridscaleTemplateCreate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("update template (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
@@ -238,7 +250,11 @@ func resourceGridscaleTemplateUpdate(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGridscaleTemplateDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gsclient.Client)
+	projectName := d.Get("project").(string)
+	client, err := getProjectClientFromMeta(projectName, meta)
+	if err != nil {
+		return err
+	}
 	errorPrefix := fmt.Sprintf("delete template (%s) resource -", d.Id())
 	err := client.DeleteTemplate(emptyCtx, d.Id())
 	if err != nil {

--- a/gridscale/resource_gridscale_template_test.go
+++ b/gridscale/resource_gridscale_template_test.go
@@ -52,7 +52,11 @@ func testAccCheckResourceGridscaleTemplateExists(n string, object *gsclient.Temp
 			return fmt.Errorf("No object UUID is set")
 		}
 
-		client := testAccProvider.Meta().(*gsclient.Client)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
 
 		id := rs.Primary.ID
 
@@ -73,13 +77,16 @@ func testAccCheckResourceGridscaleTemplateExists(n string, object *gsclient.Temp
 }
 
 func testAccCheckGridscaleTemplateDestroyCheck(s *terraform.State) error {
-	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_template" {
 			continue
 		}
-
-		_, err := client.GetTemplate(emptyCtx, rs.Primary.ID)
+		projectName := rs.Primary.Attributes["project"]
+		client, err := getProjectClientFromMeta(projectName, testAccProvider.Meta())
+		if err != nil {
+			return err
+		}
+		_, err = client.GetTemplate(emptyCtx, rs.Primary.ID)
 		if err != nil {
 			if requestError, ok := err.(gsclient.RequestError); ok {
 				if requestError.StatusCode != 404 {

--- a/gridscale/resource_gridscale_template_test.go
+++ b/gridscale/resource_gridscale_template_test.go
@@ -99,16 +99,19 @@ func testAccCheckGridscaleTemplateDestroyCheck(s *terraform.State) error {
 func testAccCheckResourceGridscaleTemplateConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "%s"
   capacity = 1
 }
 
 resource "gridscale_snapshot" "foo" {
+  project = "default"
   name = "%s"
   storage_uuid = gridscale_storage.foo.id
 }
 
 resource "gridscale_template" "foo" {
+  project = "default"
   name   = "%s"
   snapshot_uuid = gridscale_snapshot.foo.id
 }
@@ -118,16 +121,19 @@ resource "gridscale_template" "foo" {
 func testAccCheckResourceGridscaleTemplateConfig_basic_update() string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "newname"
   capacity = 1
 }
 
 resource "gridscale_snapshot" "foo" {
+  project = "default"
   name = "newname"
   storage_uuid = gridscale_storage.foo.id
 }
 
 resource "gridscale_template" "foo" {
+  project = "default"
   name   = "newname"
   labels = ["test"]
   snapshot_uuid = gridscale_snapshot.foo.id

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -14,6 +14,7 @@ Get data of a firewall by its UUID.
 
 ```terraform
 resource "gridscale_firewall" "foo" {
+  project = "default"
   name   = "example-firewall"
   rules_v4_in {
 	order = 0
@@ -32,6 +33,7 @@ resource "gridscale_firewall" "foo" {
 }
 
 data "gridscale_firewall" "foo" {
+  project = gridscale_firewall.foo.project
 	resource_id   = gridscale_firewall.foo.id
 }
 ```
@@ -41,12 +43,15 @@ data "gridscale_firewall" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the firewall.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the firewall.
 * `name` - The name of the firewall.
 * `rules_v4_in` - Firewall template rules for inbound traffic - covers ipv4 addresses.

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -16,14 +16,17 @@ Using ip datasource for the creation of a server:
 
 ```terraform
 data "gridscale_ipv4" "ipv4name"{
+  	project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 data "gridscale_ipv6" "ipv6name"{
+	project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
+	project = "default"
 	name = "terra-server"
 	cores = 2
 	memory = 4
@@ -35,12 +38,15 @@ resource "gridscale_server" "servername"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the IP address.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the ip.
 * `ip` - Defines the IP Address (v4 or v6) the ip.
 * `prefix` - The IP prefix of the ip.

--- a/website/docs/d/isoimage.html.md
+++ b/website/docs/d/isoimage.html.md
@@ -28,12 +28,15 @@ data "gridscale_isoimage" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the ISO Image.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - The name of the ISO Image.
 * `source_url` - Contains the source URL of the ISO Image that it was originally fetched from.
 * `server` - The information about servers which are related to this ISO Image.

--- a/website/docs/d/loadbalancer.html.md
+++ b/website/docs/d/loadbalancer.html.md
@@ -14,6 +14,7 @@ Get the data of a Load Balancer.
 
 ```terraform
 data "gridscale_loadbalancer" "foo" {
+  project = "default"
 	resource_id   = "xxxx-xxxx-xxxx-xxxx"
 }
 ```
@@ -22,12 +23,15 @@ data "gridscale_loadbalancer" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the loadbalancer.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the loadbalancer.
 * `name` - The human-readable name of the loadbalancer.
 * `algorithm` - The algorithm used to process requests.

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -16,10 +16,12 @@ Using the network datasource for the creation of a server:
 
 ```terraform
 data "gridscale_network" "networkname"{
+  	project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
+	project = "default"
 	name = "terra-server"
 	cores = 2
 	memory = 4
@@ -34,12 +36,15 @@ resource "gridscale_server" "servername"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the network.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the network.
 * `name` - The UUID of the network.
 * `location_uuid` - The UUID of the location, that helps to identify which datacenter the network belongs to.

--- a/website/docs/d/objectstorage.html.md
+++ b/website/docs/d/objectstorage.html.md
@@ -14,9 +14,11 @@ Get data of an access key resource of an object storage.
 
 ```terraform
 resource "gridscale_object_storage_accesskey" "foo" {
+  project = "default"
 }
 
 data "gridscale_object_storage_accesskey" "foo" {
+  project = "default"
 	resource_id   = "${gridscale_object_storage_accesskey.foo.id}"
 }
 ```
@@ -25,12 +27,15 @@ data "gridscale_object_storage_accesskey" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) ID of a resource (access key of an object storage).
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The access key of the object storage.
 * `access_key` - Access key of an object storage.
 * `secret_key` - Secret key of an object storage.

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -16,11 +16,13 @@ Retrieving the PaaS datasource:
 
 ```terraform
 resource "gridscale_paas" "foo" {
+  project = "default"
   name = "foo"
   service_template_uuid = "f9625726-5ca8-4d5c-b9bd-3257e1e2211a"
 }
 
 data "gridscale_paas" "foo" {
+  project = gridscale_paas.foo.project
 	resource_id   = gridscale_paas.foo.id
 }
 ```
@@ -29,12 +31,15 @@ data "gridscale_paas" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the PaaS service.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - The human-readable name of the object.
 * `username` - Username for PaaS service.
 * `password` - Password for PaaS service.

--- a/website/docs/d/publicnetwork.html.md
+++ b/website/docs/d/publicnetwork.html.md
@@ -16,9 +16,11 @@ Using the public network datasource for the creation of a server:
 
 ```terraform
 data "gridscale_public_network" "pubnet"{
+	project = "default"
 }
 
 resource "gridscale_server" "servername"{
+	project = data.gridscale_public_network.pubnet.project
 	name = "terra-server"
 	cores = 2
 	memory = 4
@@ -33,12 +35,15 @@ resource "gridscale_server" "servername"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the public network.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - The UUID of the network.
 * `location_uuid` - The UUID of the location, that helps to identify which datacenter the network belongs to.
 * `l2security` - Defines information about MAC spoofing protection.

--- a/website/docs/d/securityzone.html.md
+++ b/website/docs/d/securityzone.html.md
@@ -16,12 +16,14 @@ Using the security zone datasource for the creation of a paas:
 
 ```terraform
 data "gridscale_paas_securityzone" "foo"{
+  project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 
 resource "gridscale_paas" "foo"{
-	name = "terra-paas-test"
+    project = data.gridscale_paas_securityzone.foo.project
+	  name = "terra-paas-test"
     service_template_uuid = "f9625726-5ca8-4d5c-b9bd-3257e1e2211a"
     security_zone_uuid = data.gridscale_paas_securityzone.foo.id
 }
@@ -31,12 +33,15 @@ resource "gridscale_paas" "foo"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the security zone.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the security zone.
 * `name` - The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -14,16 +14,20 @@ Get data of a server by its UUID.
 
 ```terraform
 resource "gridscale_ipv4" "foo1" {
+  project = "default"
   name   = "newname"
 }
 resource "gridscale_network" "foo" {
+  project = "default"
   name   = "newname"
 }
 resource "gridscale_storage" "foo1" {
+  project = "default"
   name   = "newname"
   capacity = 1
 }
 resource "gridscale_server" "foo" {
+  project = "default"
   name   = "newname"
   cores = 1
   memory = 1
@@ -53,6 +57,7 @@ resource "gridscale_server" "foo" {
 
 
 data "gridscale_server" "foo" {
+  project = gridscale_server.foo.project
 	resource_id   = gridscale_server.foo.id
 }
 ```
@@ -61,12 +66,15 @@ data "gridscale_server" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the firewall.
 
 ## Attributes Reference
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - UUID of the server.
 * `name` - The name of the server.
 * `cores` - The number of server cores.

--- a/website/docs/d/snapshot.html.md
+++ b/website/docs/d/snapshot.html.md
@@ -14,16 +14,19 @@ Get data of a storage snapshot resource.
 
 ```terraform
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshot" "foo" {
+  project = gridscale_storage.foo.project
   name = "snapshot"
   storage_uuid = gridscale_storage.foo.id
 }
 
 data "gridscale_snapshot" "foo" {
-	resource_id   = gridscale_snapshot.foo.id
+	  project   = gridscale_snapshot.foo.project
+	  resource_id   = gridscale_snapshot.foo.id
   	storage_uuid = gridscale_storage.foo.id
 }
 ```
@@ -31,6 +34,8 @@ data "gridscale_snapshot" "foo" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `resource_id` - (Required) ID of a resource (UUID of snapshot).
 

--- a/website/docs/d/snapshotschedule.html.md
+++ b/website/docs/d/snapshotschedule.html.md
@@ -14,10 +14,12 @@ Gets data of a storage snapshot schedule.
 
 ```terraform
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshotschedule" "foo" {
+  project = gridscale_storage.foo.project
   name = "snapshotschedule"
   storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
@@ -25,6 +27,7 @@ resource "gridscale_snapshotschedule" "foo" {
   next_runtime = "2025-12-30 15:04:05"
 }
 data "gridscale_snapshotschedule" "foo" {
+	project   = gridscale_snapshotschedule.foo.project
 	resource_id   = gridscale_snapshotschedule.foo.id
 	storage_uuid   = gridscale_storage.foo.id
 }
@@ -34,6 +37,8 @@ data "gridscale_snapshotschedule" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) UUID of the snapshot schedule.
 
 * `storage_uuid` - (Required) UUID of the storage that the snapshot schedule belongs to.
@@ -42,6 +47,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the snapshot schedule.
 * `storage_uuid` - UUID of the storage that the snapshot schedule belongs to.
 * `status` - The status of the snapshot schedule.

--- a/website/docs/d/sshkey.html.md
+++ b/website/docs/d/sshkey.html.md
@@ -16,14 +16,17 @@ Using the sshkey datasource for the creation of a storage:
 
 ```terraform
 data "gridscale_sshkey" "sshkey-john"{
+	project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 data "gridscale_sshkey" "sshkey-jane"{
+	project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_storage" "storagename"{
+	project = "default"
 	name = "terraform-storage"
 	capacity = 10
 	template {
@@ -40,12 +43,15 @@ resource "gridscale_storage" "storagename"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the SSH key.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the sshkey.
 * `name` - The human-readable name of the sshkey.
 * `sshkey` - The OpenSSH public key string of the sshkey.

--- a/website/docs/d/storage.html.md
+++ b/website/docs/d/storage.html.md
@@ -16,10 +16,12 @@ Using the storage datasource for the creation of a server:
 
 ```terraform
 data "gridscale_storage" "storagename"{
+	project = "default"
 	resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
+	project = "default"
 	name = "terra-server"
 	cores = 2
 	memory = 4
@@ -33,12 +35,15 @@ resource "gridscale_server" "servername"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `resource_id` - (Required) The UUID of the storage.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the storage.
 * `change_time` - Defines the date and time of the last storage change.
 * `location_iata` - The IATA airport code of the location where storage locates.

--- a/website/docs/d/template.html.md
+++ b/website/docs/d/template.html.md
@@ -18,6 +18,7 @@ Get the template:
 
 ```terraform
    data "gridscale_template" "ubuntu" {
+	 project = "default"
      name = "Ubuntu 18.04 LTS"
    }
 ```
@@ -26,6 +27,7 @@ Using the template datasource for the creation of a storage:
 
 ```terraform
 resource "gridscale_storage" "storage-test"{
+	project = "default"
 	name = "terra-storage-test"
 	capacity = 10
 	template {
@@ -39,12 +41,15 @@ resource "gridscale_storage" "storage-test"{
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `name` - (Required) The exact name of the template as show in [the expert panel of gridscale](https://my.gridscale.io/Expert/Template).
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - The name of the template.
 * `id` - The UUID of the template.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -14,6 +14,7 @@ Provides a firewall resource. This can be used to create, modify and delete fire
 
 ```terraform
 resource "gridscale_firewall" "foo" {
+  project = "default"
   name   = "example-firewall"
   rules_v4_in {
 	order = 0
@@ -38,6 +39,8 @@ resource "gridscale_firewall" "foo" {
 The following arguments are supported:
 
 ***Note: `Optional*` means there is at least 1 rule in the firewall. Otherwise, an error will be returned.
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -119,6 +122,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the firewall.
 * `name` - The name of the firewall.
 * `rules_v4_in` - Firewall template rules for inbound traffic - covers ipv4 addresses.

--- a/website/docs/r/ipv4.html.md
+++ b/website/docs/r/ipv4.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add an IPv4 addre
 
 ```terraform
 resource "gridscale_ipv4" "terra-ipv4-test" {
+  project = "default"
 	name = "terra-test"
 }
 ```
@@ -23,6 +24,8 @@ resource "gridscale_ipv4" "terra-ipv4-test" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -36,6 +39,8 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+* `id` - The UUID of the IPv4.
 * `name` - See Argument Reference above.
 * `location_uuid` - See Argument Reference above.
 * `failover` - See Argument Reference above.

--- a/website/docs/r/ipv6.html.md
+++ b/website/docs/r/ipv6.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add an IPv6 addre
 
 ```terraform
 resource "gridscale_ipv6" "terra-ipv6-test" {
+  project = "default"
 	name = "terra-test"
 }
 ```
@@ -23,6 +24,8 @@ resource "gridscale_ipv6" "terra-ipv6-test" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -36,6 +39,8 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+* `id` - The UUID of the IPv6.
 * `name` - See Argument Reference above.
 * `location_uuid` - Helps to identify which datacenter an object belongs to. The location of the resource depends on the location of the project.
 * `failover` - See Argument Reference above.

--- a/website/docs/r/isoimage.html.md
+++ b/website/docs/r/isoimage.html.md
@@ -14,6 +14,7 @@ Provides an ISO Image resource. This can be used to create, modify and delete IS
 
 ```terraform
 resource "gridscale_isoimage" "foo" {
+  project = "default"
   name   = "newname"
   source_url = "http://tinycorelinux.net/10.x/x86/release/TinyCore-current.iso"
 }
@@ -23,6 +24,8 @@ resource "gridscale_isoimage" "foo" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -34,6 +37,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - The name of the ISO Image.
 * `source_url` - Contains the source URL of the ISO Image that it was originally fetched from.
 * `server` - The information about servers which are related to this ISO Image.

--- a/website/docs/r/loadbalancer.html.md
+++ b/website/docs/r/loadbalancer.html.md
@@ -14,6 +14,7 @@ Provides a loadbalancer resource. This can be used to create, modify and delete 
 
 ```terraform
 resource "gridscale_loadbalancer" "foo" {
+  	project = "default"
 	name   = "%s"
 	algorithm = "%s"
 	redirect_http_to_https = false
@@ -36,6 +37,8 @@ resource "gridscale_loadbalancer" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
 * `redirect_http_to_https` - (Required) Whether the loadbalancer is forced to redirect requests from HTTP to HTTPS.
@@ -52,6 +55,7 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the loadbalancer.
 * `location_uuid` - Helps to identify which datacenter an object belongs to. The location of the resource depends on the location of the project.
 * `name` - The human-readable name of the loadbalancer.

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add a network to 
 
 ```terraform
 resource "gridscale_network" "networkname"{
+  project = "default"
 	name = "terraform-network"
 }
 ```
@@ -23,6 +24,8 @@ resource "gridscale_network" "networkname"{
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -35,6 +38,8 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+* `id` - The UUID of the network.
 * `name` - See Argument Reference above.
 * `location_uuid` - Helps to identify which datacenter an object belongs to. The location of the resource depends on the location of the project.
 * `l2security` - See Argument Reference above.

--- a/website/docs/r/objectstorage.html.md
+++ b/website/docs/r/objectstorage.html.md
@@ -14,13 +14,22 @@ Provides an access key resource of an object storage. This can be used to create
 
 ```terraform
 resource "gridscale_object_storage_accesskey" "foo" {
+  project = "default"
 }
 ```
+
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The access key of the object storage.
 * `access_key` - Access key of an object storage.
 * `secret_key` - Secret key of an object storage.

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add a PaaS to gri
 
 ```terraform
 resource "gridscale_paas" "terra-paas-test" {
+  project = "default"
   name = "terra-paas-test"
   service_template_uuid = "f9625726-5ca8-4d5c-b9bd-3257e1e2211a"
 }
@@ -24,6 +25,8 @@ resource "gridscale_paas" "terra-paas-test" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -51,6 +54,7 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - See Argument Reference above.
 * `username` - Username for PaaS service.
 * `password` - Password for PaaS service.

--- a/website/docs/r/securityzone.html.md
+++ b/website/docs/r/securityzone.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add a security zo
 
 ```terraform
 resource "gridscale_paas_securityzone" "foo" {
+  project = "default"
   name = "test"
 }
 ```
@@ -24,13 +25,17 @@ resource "gridscale_paas_securityzone" "foo" {
 
 The following arguments are supported:
 
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
+
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+
 * `location_uuid` - (Optional) Helps to identify which datacenter an object belongs to.
 
 ## Attributes
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the security zone.
 * `name` - The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add a server to g
 
 ```terraform
 resource "gridscale_server" "terra-server-test"{
+    project = "default"
 	name = "terra-server-test"
 	cores = 2
 	memory = 1
@@ -41,6 +42,8 @@ resource "gridscale_server" "terra-server-test"{
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -152,6 +155,7 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - UUID of the server.
 * `name` - The name of the server.
 * `cores` - The number of server cores.

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -14,10 +14,12 @@ Provides a storage snapshot resource. This can be used to create, modify and del
 
 ```terraform
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshot" "foo" {
+  project = gridscale_storage.foo.project
   name = "snapshot"
   storage_uuid = gridscale_storage.foo.id
 }
@@ -26,6 +28,8 @@ resource "gridscale_snapshot" "foo" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The name of the snapshot.
 
@@ -41,6 +45,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the snapshot.
 * `storage_uuid` - See Argument Reference above.
 * `name` - See Argument Reference above.

--- a/website/docs/r/snapshotschedule.html.md
+++ b/website/docs/r/snapshotschedule.html.md
@@ -14,10 +14,12 @@ Provides a storage snapshot schedule resource. This can be used to create, modif
 
 ```terraform
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "storage"
   capacity = 1
 }
 resource "gridscale_snapshotschedule" "foo" {
+  project = gridscale_storage.foo.project
   name = "snapshotschedule"
   storage_uuid = gridscale_storage.foo.id
   keep_snapshots = 1
@@ -29,6 +31,8 @@ resource "gridscale_snapshotschedule" "foo" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) UUID of the snapshot schedule.
 
@@ -46,6 +50,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `id` - The UUID of the snapshot schedule.
 * `storage_uuid` - See Argument Reference above.
 * `status` - The status of the snapshot schedule.

--- a/website/docs/r/sshkey.html.md
+++ b/website/docs/r/sshkey.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add an SSH public
 
 ```terraform
 resource "gridscale_sshkey" "sshkey-john"{
+	project = "default"
 	name = "john's computer"
 	sshkey = "an ssh public key"
 }
@@ -24,6 +25,8 @@ resource "gridscale_sshkey" "sshkey-john"{
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -35,6 +38,7 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - See Argument Reference above.
 * `sshkey` - See Argument Reference above.
 * `labels` - See Argument Reference above.

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -16,6 +16,7 @@ The following example shows how one might use this resource to add a storage to 
 
 ```terraform
 resource "gridscale_storage" "storage-john"{
+	project = "default"
 	name = "john's storage"
 	capacity = 10
 	storage_type = "storage_high"
@@ -31,6 +32,8 @@ resource "gridscale_storage" "storage-john"{
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
 
@@ -58,6 +61,7 @@ The following arguments are supported:
 
 This resource exports the following attributes:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - See Argument Reference above.
 * `capacity` - See Argument Reference above.
 * `storage_type` - See Argument Reference above.

--- a/website/docs/r/template.html.md
+++ b/website/docs/r/template.html.md
@@ -16,16 +16,19 @@ The following example shows how one might use this resource to add a template to
 
 ```terraform
 resource "gridscale_storage" "foo" {
+  project = "default"
   name   = "newname"
   capacity = 1
 }
 
 resource "gridscale_snapshot" "foo" {
+  project = gridscale_storage.foo.project
   name = "newname"
   storage_uuid = gridscale_storage.foo.id
 }
 
 resource "gridscale_template" "foo" {
+  project = gridscale_snapshot.foo.project
   name   = "newname"
   snapshot_uuid = gridscale_snapshot.foo.id
 }
@@ -34,6 +37,8 @@ resource "gridscale_template" "foo" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `project` - (Required) The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 
 * `name` - (Required) The exact name of the template as show in [the expert panel of gridscale](https://my.gridscale.io/Expert/Template).
 
@@ -45,6 +50,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `project` - The name of project which is set in GRIDSCALE_PROJECTS_TOKENS env variable.
 * `name` - The name of the template.
 * `id` - The UUID of the template.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.


### PR DESCRIPTION
This feature allows users to use gridscale terraform provider for multiple projects of one account. 
Note:
- `GRIDSCALE_TOKEN` env variable is no longer used, and it was already replaced with `GRIDSCALE_PROJECTS_TOKENS`.
- `GRIDSCALE_PROJECTS_TOKENS` has to be in form: "project1:token1,project2:token1,project3:token1"
- All resources/datasources have to be declared with a `project` field.


Fixes issue #19 