### PR TITLE
skip 404 when deleting a resource & fix some minor bugs.

### DIFF
--- a/gridscale/error-handler/skipHTTPErrCode.go
+++ b/gridscale/error-handler/skipHTTPErrCode.go
@@ -1,0 +1,24 @@
+package error_handler
+
+import "github.com/gridscale/gsclient-go/v3"
+
+//RemoveErrorContainsHTTPCodes returns nil, if the error of HTTP error
+//has status code that is in the given list of http status codes
+func RemoveErrorContainsHTTPCodes(err error, errorCodes ...int) error {
+	if requestError, ok := err.(gsclient.RequestError); ok {
+		if containsInt(errorCodes, requestError.StatusCode) {
+			err = nil
+		}
+	}
+	return err
+}
+
+//containsInt check if an int array contains a specific int.
+func containsInt(arr []int, target int) bool {
+	for _, a := range arr {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}

--- a/gridscale/error-handler/skipHTTPErrCode.go
+++ b/gridscale/error-handler/skipHTTPErrCode.go
@@ -1,4 +1,4 @@
-package error_handler
+package errorhandler
 
 import "github.com/gridscale/gsclient-go/v3"
 

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -1,4 +1,4 @@
-package relationManager
+package relationmanager
 
 import (
 	"context"

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 //firewallRuleTypes defines all types of firewall rules

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -1,4 +1,4 @@
-package relation_manager
+package relationManager
 
 import (
 	"context"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 )
 
 //firewallRuleTypes defines all types of firewall rules
@@ -236,7 +237,7 @@ func (c *ServerRelationManger) UpdateISOImageRel(ctx context.Context) error {
 		//Unlink it
 		if oldIso != "" {
 			//If 404 or 409, that means ISO image is already deleted => the relation between ISO image and server is deleted automatically
-			err = removeErrorContainsHttpCodes(
+			err = errHandler.RemoveErrorContainsHTTPCodes(
 				client.UnlinkIsoImage(ctx, d.Id(), oldIso.(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -263,7 +264,7 @@ func (c *ServerRelationManger) UpdateIPv4Rel(ctx context.Context) error {
 		//Unlink it
 		if oldIp != "" {
 			//If 404 or 409, that means IP is already deleted => the relation between IP and server is deleted automatically
-			err = removeErrorContainsHttpCodes(
+			err = errHandler.RemoveErrorContainsHTTPCodes(
 				client.UnlinkIP(ctx, d.Id(), oldIp.(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -289,7 +290,7 @@ func (c *ServerRelationManger) UpdateIPv6Rel(ctx context.Context) error {
 		//Unlink it
 		if oldIp != "" {
 			//If 404 or 409, that means IP is already deleted => the relation between IP and server is deleted automatically
-			err = removeErrorContainsHttpCodes(
+			err = errHandler.RemoveErrorContainsHTTPCodes(
 				client.UnlinkIP(ctx, d.Id(), oldIp.(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -316,7 +317,7 @@ func (c *ServerRelationManger) UpdateNetworksRel(ctx context.Context) error {
 			network := value.(map[string]interface{})
 			if network["object_uuid"].(string) != "" {
 				//If 404 or 409, that means network is already deleted => the relation between network and server is deleted automatically
-				err = removeErrorContainsHttpCodes(
+				err = errHandler.RemoveErrorContainsHTTPCodes(
 					client.UnlinkNetwork(ctx, d.Id(), network["object_uuid"].(string)),
 					http.StatusConflict,
 					http.StatusNotFound,
@@ -343,7 +344,7 @@ func (c *ServerRelationManger) UpdateStoragesRel(ctx context.Context) error {
 			storage := value.(map[string]interface{})
 			if storage["object_uuid"].(string) != "" {
 				//If 404 or 409, that means storage is already deleted => the relation between storage and server is deleted automatically
-				err = removeErrorContainsHttpCodes(
+				err = errHandler.RemoveErrorContainsHTTPCodes(
 					client.UnlinkStorage(ctx, d.Id(), storage["object_uuid"].(string)),
 					http.StatusConflict,
 					http.StatusNotFound,
@@ -357,25 +358,4 @@ func (c *ServerRelationManger) UpdateStoragesRel(ctx context.Context) error {
 		err = c.LinkStorages(ctx)
 	}
 	return err
-}
-
-//removeErrorContainsHttpCodes returns nil, if the error of HTTP error
-//has status code that is in the given list of http status codes
-func removeErrorContainsHttpCodes(err error, errorCodes ...int) error {
-	if requestError, ok := err.(gsclient.RequestError); ok {
-		if containsInt(errorCodes, requestError.StatusCode) {
-			err = nil
-		}
-	}
-	return err
-}
-
-//containsInt check if an int array contains a specific int.
-func containsInt(arr []int, target int) bool {
-	for _, a := range arr {
-		if a == target {
-			return true
-		}
-	}
-	return false
 }

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscaleFirewall() *schema.Resource {

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 )
 
 func resourceGridscaleFirewall() *schema.Resource {
@@ -307,7 +309,10 @@ func resourceGridscaleFirewallDelete(d *schema.ResourceData, meta interface{}) e
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteFirewall(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteFirewall(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
 	"github.com/gridscale/gsclient-go/v3"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscaleIpv4() *schema.Resource {

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -232,7 +232,8 @@ func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
 	defer cancel()
 
 	ip, err := client.GetIP(ctx, d.Id())
-	if err != nil {
+	//In case of 404, don't catch the error
+	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 	//Stop the server relating to this IP address if there is one

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -271,10 +271,10 @@ func resourceGridscaleISOImageDelete(d *schema.ResourceData, meta interface{}) e
 	defer cancel()
 
 	isoimage, err := client.GetISOImage(ctx, d.Id())
-	if err != nil {
+	//In case of 404, don't catch the error
+	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
-
 	//Remove all links between this ISO-Image and all servers.
 	for _, server := range isoimage.Properties.Relations.Servers {
 		//No need to unlink when server returns 409 or 404

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscaleISOImage() *schema.Resource {

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscaleLoadBalancer() *schema.Resource {

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -3,12 +3,14 @@ package gridscale
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 )
 
 func resourceGridscaleLoadBalancer() *schema.Resource {
@@ -258,7 +260,10 @@ func resourceGridscaleLoadBalancerDelete(d *schema.ResourceData, meta interface{
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteLoadBalancer(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteLoadBalancer(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -201,7 +201,8 @@ func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
 	net, err := client.GetNetwork(ctx, d.Id())
-	if err != nil {
+	//In case of 404, don't catch the error
+	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 

--- a/gridscale/resource_gridscale_objectstorage.go
+++ b/gridscale/resource_gridscale_objectstorage.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 )
 
 func resourceGridscaleObjectStorage() *schema.Resource {
@@ -82,7 +84,10 @@ func resourceGridscaleObjectStorageDelete(d *schema.ResourceData, meta interface
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteObjectStorageAccessKey(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteObjectStorageAccessKey(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_objectstorage.go
+++ b/gridscale/resource_gridscale_objectstorage.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscaleObjectStorage() *schema.Resource {

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -161,9 +161,9 @@ func resourceGridscalePaaS() *schema.Resource {
 			},
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 	}
 }

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 
 	"log"
 )

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -3,12 +3,14 @@ package gridscale
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 
 	"log"
 )
@@ -383,7 +385,10 @@ func resourceGridscalePaaSServiceDelete(d *schema.ResourceData, meta interface{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeletePaaSService(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeletePaaSService(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_securityzone.go
+++ b/gridscale/resource_gridscale_securityzone.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscalePaaSSecurityZone() *schema.Resource {

--- a/gridscale/resource_gridscale_securityzone.go
+++ b/gridscale/resource_gridscale_securityzone.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 )
 
 func resourceGridscalePaaSSecurityZone() *schema.Resource {
@@ -178,7 +180,10 @@ func resourceGridscalePaaSSecurityZoneDelete(d *schema.ResourceData, meta interf
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeletePaaSSecurityZone(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeletePaaSSecurityZone(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 	relation_manager "github.com/terraform-providers/terraform-provider-gridscale/gridscale/relation-manager"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -676,7 +678,10 @@ func resourceGridscaleServerDelete(d *schema.ResourceData, meta interface{}) err
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
 	//remove the server
-	err := globalServerStatusList.removeServerSynchronously(ctx, client, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		globalServerStatusList.removeServerSynchronously(ctx, client, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 	relation_manager "github.com/terraform-providers/terraform-provider-gridscale/gridscale/relation-manager"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )
@@ -297,7 +299,10 @@ func resourceGridscaleSnapshotDelete(d *schema.ResourceData, meta interface{}) e
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteStorageSnapshot(ctx, storageUUID, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteStorageSnapshot(ctx, storageUUID, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )
@@ -226,7 +228,10 @@ func resourceGridscaleSnapshotScheduleDelete(d *schema.ResourceData, meta interf
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteStorageSnapshotSchedule(ctx, storageUUID, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteStorageSnapshotSchedule(ctx, storageUUID, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )
@@ -148,7 +150,10 @@ func resourceGridscaleSshkeyDelete(d *schema.ResourceData, meta interface{}) err
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteSshkey(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteSshkey(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 
 	"github.com/gridscale/gsclient-go/v3"
 )

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -325,7 +325,8 @@ func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) er
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
 	storage, err := client.GetStorage(ctx, d.Id())
-	if err != nil {
+	//In case of 404, don't catch the error
+	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"net/http"
 	"time"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
 )
 
 func resourceGridscaleTemplate() *schema.Resource {
@@ -248,7 +250,10 @@ func resourceGridscaleTemplateDelete(d *schema.ResourceData, meta interface{}) e
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := client.DeleteTemplate(ctx, d.Id())
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeleteTemplate(ctx, d.Id()),
+		http.StatusNotFound,
+	)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error_handler"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 )
 
 func resourceGridscaleTemplate() *schema.Resource {

--- a/gridscale/server_concurrency_handler.go
+++ b/gridscale/server_concurrency_handler.go
@@ -103,7 +103,8 @@ func (l *serverStatusList) removeServerSynchronously(ctx context.Context, c *gsc
 		}
 		return fmt.Errorf("server (%s) is already deleted", id)
 	}
-	return fmt.Errorf("server (%s) does not exist in current list of servers in terraform", id)
+	log.Printf("server (%s) does not exist in current list of servers in terraform", id)
+	return nil
 }
 
 //startServerSynchronously starts the servers synchronously. That means the server

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -55,9 +55,9 @@ The following arguments are supported:
 Timeouts configuration options (in seconds):
 More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "15m" - 15 minutes) Used for Creating resource.
+* `update` - (Default value is "15m" - 15 minutes) Used for Updating resource.
+* `delete` - (Default value is "15m" - 15 minutes) Used for Deleteing resource.
 
 ## Attributes
 


### PR DESCRIPTION
When a resource is already deleted before applying a delete operation to it, the operation should return success. This can be done by skip 404 HTTP status code. Changes:
- Skip 404 when deleting a resource.
- Skip 404 and 409 when deleting a server-related resource.
- Increase the default timeouts of paas resource's operations to 15 minutes.
- Reconstruct some packages.