### PR TITLE
Custom HTTP headers

### DIFF
--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -27,9 +27,10 @@ const (
 const serverShutdownTimeoutSecs = 120
 
 type Config struct {
-	UserUUID string
-	APIToken string
-	APIUrl   string
+	UserUUID    string
+	APIToken    string
+	APIUrl      string
+	HTTPHeaders map[string]string
 }
 
 func (c *Config) Client() (*gsclient.Client, error) {
@@ -50,6 +51,8 @@ func (c *Config) Client() (*gsclient.Client, error) {
 	)
 
 	client := gsclient.NewClient(config)
+	//Add HTTP headers to gs client
+	client.WithHTTPHeaders(c.HTTPHeaders)
 
 	log.Print("[INFO] gridscale client configured")
 

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -1,6 +1,9 @@
 package gridscale
 
 import (
+	"os"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -69,10 +72,29 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		UserUUID: d.Get("uuid").(string),
-		APIToken: d.Get("token").(string),
-		APIUrl:   d.Get("api_url").(string),
+		UserUUID:    d.Get("uuid").(string),
+		APIToken:    d.Get("token").(string),
+		APIUrl:      d.Get("api_url").(string),
+		HTTPHeaders: convertStrToHeaderMap(os.Getenv("GRIDSCALE_TF_HEADERS")),
 	}
 
 	return config.Client()
+}
+
+// getHeaderMapFromStr converts string (format: "key1:val1,key2:val2")
+// to a HTTP header map
+func convertStrToHeaderMap(str string) map[string]string {
+	result := make(map[string]string)
+	// split string into comma separated headers
+	headers := strings.Split(str, ",")
+	for _, header := range headers {
+		if header != "" {
+			// split each header into a key and a value
+			kv := strings.Split(header, ":")
+			if len(kv) == 2 {
+				result[kv[0]] = kv[1]
+			}
+		}
+	}
+	return result
 }

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -1,7 +1,6 @@
 package gridscale
 
 import (
-	"os"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -28,6 +27,12 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_URL", nil),
 				Description: "the url for the gridscale API.",
+			},
+			"http_headers": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GRIDSCALE_TF_HEADERS", nil),
+				Description: "Custom HTTP headers",
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -75,7 +80,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		UserUUID:    d.Get("uuid").(string),
 		APIToken:    d.Get("token").(string),
 		APIUrl:      d.Get("api_url").(string),
-		HTTPHeaders: convertStrToHeaderMap(os.Getenv("GRIDSCALE_TF_HEADERS")),
+		HTTPHeaders: convertStrToHeaderMap(d.Get("http_headers").(string)),
 	}
 
 	return config.Client()

--- a/gridscale/provider_test.go
+++ b/gridscale/provider_test.go
@@ -2,6 +2,7 @@ package gridscale
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -35,5 +36,35 @@ func testAccPreCheck(t *testing.T) {
 
 	if v := os.Getenv("GRIDSCALE_TOKEN"); v == "" {
 		t.Fatal("GRIDSCALE_TOKEN must be set for acceptance tests")
+	}
+}
+
+func Test_convertStrToHeaderMap(t *testing.T) {
+	type testCase struct {
+		InputStr       string
+		ExpectedOutput map[string]string
+	}
+	testCases := []testCase{
+		{
+			InputStr:       "",
+			ExpectedOutput: make(map[string]string),
+		},
+		{
+			InputStr:       "header",
+			ExpectedOutput: make(map[string]string),
+		},
+		{
+			InputStr: "header1:value1,header2:value2",
+			ExpectedOutput: map[string]string{
+				"header1": "value1",
+				"header2": "value2",
+			},
+		},
+	}
+	for _, tCase := range testCases {
+		result := convertStrToHeaderMap(tCase.InputStr)
+		if !reflect.DeepEqual(result, tCase.ExpectedOutput) {
+			t.Errorf("Output: %v, Expected: %v", result, tCase.ExpectedOutput)
+		}
 	}
 }

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -19,7 +19,7 @@ Use the navigation to the left to read about the available data sources and reso
 provider "gridscale" {
 	uuid = var.gridscale_uuid
 	token = var.gridscale_token
-
+  
 }
 
 # Create a server
@@ -37,3 +37,4 @@ The following arguments are supported:
 * `uuid` - (Required) This is the User-UUID for the gridscale API. It can be found [in the panel](https://my.gridscale.io/APIs/). If omitted, the GRIDSCALE_UUID environment variable is used.
 * `token` - (Required) This is an API-Token for the gridscale API. It can be created [in the panel](https://my.gridscale.io/APIs/). The created token needs to have full access to be usable by Terraform. If omitted, the GRIDSCALE_TOKEN environment variable is used.
 * `api_url` - (Optional) The URL for the API. By default this is set to "https://api.gridscale.io". Do not add a "/" character at the end.
+* `http_headers` - (Optional) Custom HTTP headers sent to gridscale server. If omitted, the GRIDSCALE_TF_HEADERS environment variable is used. 


### PR DESCRIPTION
Add a functionality that allows user to set custom HTTP headers. 
Reopen of https://github.com/terraform-providers/terraform-provider-gridscale/pull/78 