### PR TITLE
Remove redundant types & fix storage update operation

### DIFF
--- a/gridscale/datasource_gridscale_firewall.go
+++ b/gridscale/datasource_gridscale_firewall.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleFirewall() *schema.Resource {
 		Read: dataSourceGridscaleFirewallRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_ipv4.go
+++ b/gridscale/datasource_gridscale_ipv4.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 		Read: dataSourceGridscaleIpv4Read,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_ipv6.go
+++ b/gridscale/datasource_gridscale_ipv6.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 		Read: dataSourceGridscaleIpv6Read,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_loadbalancer.go
+++ b/gridscale/datasource_gridscale_loadbalancer.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleLoadBalancer() *schema.Resource {
 		Read: dataSourceGridscaleLoadBalancerRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_network.go
+++ b/gridscale/datasource_gridscale_network.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 		Read: dataSourceGridscaleNetworkRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_objectstorage.go
+++ b/gridscale/datasource_gridscale_objectstorage.go
@@ -13,7 +13,7 @@ func dataSourceGridscaleObjectStorage() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGridscaleObjectStorageRead,
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -14,7 +14,7 @@ func dataSourceGridscalePaaS() *schema.Resource {
 		Read: dataSourceGridscalePaaSRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_securityzone.go
+++ b/gridscale/datasource_gridscale_securityzone.go
@@ -13,7 +13,7 @@ func dataSourceGridscalePaaSSecurityZone() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGridscalePaaSSecurityZoneRead,
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_server.go
+++ b/gridscale/datasource_gridscale_server.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleServer() *schema.Resource {
 		Read: dataSourceGridscaleServerRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_snapshotschedule.go
+++ b/gridscale/datasource_gridscale_snapshotschedule.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleStorageSnapshotSchedule() *schema.Resource {
 		Read: dataSourceGridscaleSnapshotScheduleRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_sshkey.go
+++ b/gridscale/datasource_gridscale_sshkey.go
@@ -14,7 +14,7 @@ func dataSourceGridscaleSshkey() *schema.Resource {
 		Read: dataSourceGridscaleSshkeyRead,
 
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_storage.go
+++ b/gridscale/datasource_gridscale_storage.go
@@ -13,7 +13,7 @@ func dataSourceGridscaleStorage() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceGridscaleStorageRead,
 		Schema: map[string]*schema.Schema{
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "ID of a resource",

--- a/gridscale/datasource_gridscale_template.go
+++ b/gridscale/datasource_gridscale_template.go
@@ -16,7 +16,7 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 		Read: dataSourceGridscaleTemplateRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				Description:  "name of the domain",

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -35,7 +35,6 @@ func resourceGridscaleStorage() *schema.Resource {
 				Type:         schema.TypeInt,
 				Description:  "The capacity of a storage in GB.",
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validation.IntAtLeast(1),
 			},
 			"location_uuid": {

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -250,8 +250,18 @@ func resourceGridscaleStorageUpdate(d *schema.ResourceData, meta interface{}) er
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.StorageUpdateRequest{
-		Name:   d.Get("name").(string),
-		Labels: &labels,
+		Name:     d.Get("name").(string),
+		Capacity: d.Get("capacity").(int),
+		Labels:   &labels,
+	}
+
+	storageType := d.Get("storage_type").(string)
+	if storageType == "storage" {
+		requestBody.StorageType = gsclient.DefaultStorageType
+	} else if storageType == "storage_high" {
+		requestBody.StorageType = gsclient.HighStorageType
+	} else if storageType == "storage_insane" {
+		requestBody.StorageType = gsclient.InsaneStorageType
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -46,7 +46,6 @@ func resourceGridscaleStorage() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "(one of storage, storage_high, storage_insane)",
 				Optional:    true,
-				ForceNew:    true,
 				Default:     "storage",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					valid := false


### PR DESCRIPTION
- Remove redundant types (already defined in array).
- Capacity and type of storage instances can be modified via storage update.
- Update capacity and storage type won't force to create a new storage.