### PR TITLE
Travis ignores md files and all files in website directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,10 @@ install:
 # packages that live there.
 # See: https://github.com/golang/go/issues/12933
 - bash scripts/gogetcookie.sh
-
+ignore:
+  - *.md
+  - website/*
+  
 script:
 - make test
 - make vet


### PR DESCRIPTION
Travis won't trigger a build when `.md` files or files in `website` directory are updated.