### PR TITLE
Fix bug #89

### DIFF
--- a/gridscale/datasource_gridscale_firewall.go
+++ b/gridscale/datasource_gridscale_firewall.go
@@ -3,6 +3,7 @@ package gridscale
 import (
 	"context"
 	"fmt"
+	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -174,7 +175,8 @@ func dataSourceGridscaleFirewallRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	//Get rules_v4_in
-	rulesV4In := convFirewallRuleSliceToInterfaceSlice(props.Rules.RulesV4In)
+	rulesV4InWODefaultRules := fwu.RemoveDefaultFirewallInboundRules(props.Rules.RulesV4In)
+	rulesV4In := convFirewallRuleSliceToInterfaceSlice(rulesV4InWODefaultRules)
 	if err = d.Set("rules_v4_in", rulesV4In); err != nil {
 		return fmt.Errorf("%s error setting rules_v4_in: %v", errorPrefix, err)
 	}
@@ -186,7 +188,8 @@ func dataSourceGridscaleFirewallRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	//Get rules_v6_in
-	rulesV6In := convFirewallRuleSliceToInterfaceSlice(props.Rules.RulesV6In)
+	rulesV6InWODefaultRules := fwu.RemoveDefaultFirewallInboundRules(props.Rules.RulesV6In)
+	rulesV6In := convFirewallRuleSliceToInterfaceSlice(rulesV6InWODefaultRules)
 	if err = d.Set("rules_v6_in", rulesV6In); err != nil {
 		return fmt.Errorf("%s error setting rules_v6_in: %v", errorPrefix, err)
 	}

--- a/gridscale/firewall-utils/defaultRuleUtils.go
+++ b/gridscale/firewall-utils/defaultRuleUtils.go
@@ -2,6 +2,7 @@ package fwu
 
 import "github.com/gridscale/gsclient-go/v3"
 
+// AddDefaultFirewallInboundRules adds default fw rules
 func AddDefaultFirewallInboundRules(rules []gsclient.FirewallRuleProperties, forIPv6 bool) []gsclient.FirewallRuleProperties {
 	srcCidr := "0.0.0.0/0"
 	DHCPDstPort := "67:68"
@@ -78,6 +79,8 @@ func getNextFWRuleOrder(rules []gsclient.FirewallRuleProperties) int {
 	return max + 1
 }
 
+// RemoveDefaultFirewallInboundRules removes default fw rules
+// It is used when we don't want to display the default fw rules in tf
 func RemoveDefaultFirewallInboundRules(rules []gsclient.FirewallRuleProperties) []gsclient.FirewallRuleProperties {
 	defaultRulesNames := map[string]int{
 		"DHCP IPv4":          0,

--- a/gridscale/firewall-utils/defaultRuleUtils.go
+++ b/gridscale/firewall-utils/defaultRuleUtils.go
@@ -1,0 +1,97 @@
+package fwu
+
+import "github.com/gridscale/gsclient-go/v3"
+
+func AddDefaultFirewallInboundRules(rules []gsclient.FirewallRuleProperties, forIPv6 bool) []gsclient.FirewallRuleProperties {
+	srcCidr := "0.0.0.0/0"
+	DHCPDstPort := "67:68"
+	DHCPComment := "DHCP IPv4"
+	nextOrder := getNextFWRuleOrder(rules)
+	if forIPv6 {
+		srcCidr = "::/0"
+		DHCPDstPort = "546:547"
+		DHCPComment = "DHCP IPv6"
+	}
+	defaultInboundRules := []gsclient.FirewallRuleProperties{
+		{
+			Protocol: gsclient.UDPTransport,
+			DstPort:  DHCPDstPort,
+			SrcPort:  "",
+			SrcCidr:  srcCidr,
+			Action:   "accept",
+			Comment:  DHCPComment,
+			DstCidr:  "",
+			Order:    nextOrder,
+		},
+		{
+			Protocol: gsclient.TCPTransport,
+			DstPort:  "32768:65535",
+			SrcPort:  "",
+			SrcCidr:  srcCidr,
+			Action:   "accept",
+			Comment:  "Highports TCP",
+			DstCidr:  "",
+			Order:    nextOrder + 1,
+		},
+		{
+			Protocol: gsclient.UDPTransport,
+			DstPort:  "32768:65535",
+			SrcPort:  "",
+			SrcCidr:  srcCidr,
+			Action:   "accept",
+			Comment:  "Highports UDP",
+			DstCidr:  "",
+			Order:    nextOrder + 2,
+		},
+		{
+			Protocol: gsclient.UDPTransport,
+			DstPort:  "1:65535",
+			SrcPort:  "",
+			SrcCidr:  srcCidr,
+			Action:   "drop",
+			Comment:  "Drop all other UDP",
+			DstCidr:  "",
+			Order:    nextOrder + 3,
+		},
+		{
+			Protocol: gsclient.TCPTransport,
+			DstPort:  "1:65535",
+			SrcPort:  "",
+			SrcCidr:  srcCidr,
+			Action:   "drop",
+			Comment:  "Drop all other TCP",
+			DstCidr:  "",
+			Order:    nextOrder + 4,
+		},
+	}
+	rules = append(rules, defaultInboundRules...)
+	return rules
+}
+
+func getNextFWRuleOrder(rules []gsclient.FirewallRuleProperties) int {
+	var max int
+	for _, v := range rules {
+		if max < v.Order {
+			max = v.Order
+		}
+	}
+	return max + 1
+}
+
+func RemoveDefaultFirewallInboundRules(rules []gsclient.FirewallRuleProperties) []gsclient.FirewallRuleProperties {
+	defaultRulesNames := map[string]int{
+		"DHCP IPv4":          0,
+		"DHCP IPv6":          0,
+		"Highports TCP":      0,
+		"Highports UDP":      0,
+		"Drop all other UDP": 0,
+		"Drop all other TCP": 0,
+	}
+	for i := 0; i < len(rules); i++ {
+		if _, ok := defaultRulesNames[rules[i].Comment]; ok {
+			rules = append(rules[:i], rules[i+1:]...)
+			i-- // As we've just deleted rules[i], we'd to redo that index
+		}
+	}
+	return rules
+}

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -3,6 +3,7 @@ package relationmanager
 import (
 	"context"
 	"fmt"
+	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 	"net/http"
 
 	"github.com/gridscale/gsclient-go/v3"
@@ -188,11 +189,11 @@ func readCustomFirewallRules(netData map[string]interface{}) gsclient.FirewallRu
 
 		//Based on rule type to place the rules in the right property of fwRules variable
 		if ruleType == "rules_v4_in" {
-			fwRules.RulesV4In = rules
+			fwRules.RulesV4In = fwu.AddDefaultFirewallInboundRules(rules, false) // add default rules
 		} else if ruleType == "rules_v4_out" {
 			fwRules.RulesV4Out = rules
 		} else if ruleType == "rules_v6_in" {
-			fwRules.RulesV6In = rules
+			fwRules.RulesV6In = fwu.AddDefaultFirewallInboundRules(rules, true) // add default rules
 		} else if ruleType == "rules_v6_out" {
 			fwRules.RulesV6Out = rules
 		}

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -3,11 +3,12 @@ package gridscale
 import (
 	"context"
 	"fmt"
-	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 
 	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
 	relation_manager "github.com/terraform-providers/terraform-provider-gridscale/gridscale/relation-manager"
@@ -303,7 +304,7 @@ func getFirewallRuleCommonSchema() map[string]*schema.Schema {
 			Description: `The order at which the firewall will compare packets against its rules. 
 A packet will be compared against the first rule, it will either allow it to pass or block it 
 and it won't be matched against any other rules. However, if it does no match the rule, 
-then it will proceed onto rule 2.`,
+then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).`,
 			Required: true,
 		},
 		"action": {

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -3,6 +3,7 @@ package gridscale
 import (
 	"context"
 	"fmt"
+	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 	"log"
 	"net/http"
 	"strings"
@@ -470,7 +471,14 @@ func resourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) error
 	}
 
 	//Get networks
-	networks := readServerNetworkRels(server.Properties.Relations.Networks)
+	netWODefaultRules := server.Properties.Relations.Networks
+	for i := 0; i < len(netWODefaultRules); i++ { // Remove all default rules, we don't want to display them
+		netWODefaultRules[i].
+			Firewall.RulesV4In = fwu.RemoveDefaultFirewallInboundRules(netWODefaultRules[i].Firewall.RulesV4In)
+		netWODefaultRules[i].
+			Firewall.RulesV6In = fwu.RemoveDefaultFirewallInboundRules(netWODefaultRules[i].Firewall.RulesV6In)
+	}
+	networks := readServerNetworkRels(netWODefaultRules)
 	if err = d.Set("network", networks); err != nil {
 		return fmt.Errorf("%s error setting network: %v", errorPrefix, err)
 	}

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -50,7 +50,7 @@ The following attributes are exported:
 * `id` - The UUID of the firewall.
 * `name` - The name of the firewall.
 * `rules_v4_in` - Firewall template rules for inbound traffic - covers ipv4 addresses.
-    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
     * `action` - This defines what the firewall will do. Either accept or drop.
     * `protocol` - Either 'udp' or 'tcp'.
     * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.
@@ -68,7 +68,7 @@ The following attributes are exported:
     * `dst_cidr` - Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
     * `comment` - Comment.
 * `rules_v6_in` - Firewall template rules for inbound traffic - covers ipv6 addresses.
-    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
     * `action` - This defines what the firewall will do. Either accept or drop.
     * `protocol` - Either 'udp' or 'tcp'.
     * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -97,7 +97,7 @@ This resource exports the following attributes:
     * `mac` - network_mac defines the MAC address of the network interface.
     * `firewall_template_uuid` - The UUID of firewall template.
     * `rules_v4_in` - Firewall template rules for inbound traffic - covers ipv4 addresses.
-        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
         * `action` - This defines what the firewall will do. Either accept or drop.
         * `protocol` - Either 'udp' or 'tcp'.
         * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.
@@ -115,7 +115,7 @@ This resource exports the following attributes:
         * `dst_cidr` - Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
         * `comment` - Comment.
     * `rules_v6_in` - Firewall template rules for inbound traffic - covers ipv6 addresses.
-        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
         * `action` - This defines what the firewall will do. Either accept or drop.
         * `protocol` - Either 'udp' or 'tcp'.
         * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 * `rules_v4_in` - (Optional*) Firewall template rules for inbound traffic - covers ipv4 addresses.
 
-    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
 
     * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
@@ -82,7 +82,7 @@ The following arguments are supported:
 
 * `rules_v6_in` - (Optional*) Firewall template rules for inbound traffic - covers ipv6 addresses.
 
-    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
 
     * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
@@ -134,7 +134,7 @@ The following attributes are exported:
 * `id` - The UUID of the firewall.
 * `name` - The name of the firewall.
 * `rules_v4_in` - Firewall template rules for inbound traffic - covers ipv4 addresses.
-    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
     * `action` - This defines what the firewall will do. Either accept or drop.
     * `protocol` - Either 'udp' or 'tcp'.
     * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.
@@ -152,7 +152,7 @@ The following attributes are exported:
     * `dst_cidr` - Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
     * `comment` - Comment.
 * `rules_v6_in` - Firewall template rules for inbound traffic - covers ipv6 addresses.
-    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+    * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
     * `action` - This defines what the firewall will do. Either accept or drop.
     * `protocol` - Either 'udp' or 'tcp'.
     * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -81,7 +81,7 @@ The following arguments are supported:
 
     * `rules_v4_in` - (Optional) Firewall template rules for inbound traffic - covers ipv4 addresses.
 
-        * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+        * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
 
         * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
@@ -117,7 +117,7 @@ The following arguments are supported:
 
     * `rules_v6_in` - (Optional) Firewall template rules for inbound traffic - covers ipv6 addresses.
 
-        * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+        * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
 
         * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
@@ -194,7 +194,7 @@ This resource exports the following attributes:
     * `mac` - network_mac defines the MAC address of the network interface.
     * `firewall_template_uuid` - The UUID of firewall template.
     * `rules_v4_in` - Firewall template rules for inbound traffic - covers ipv4 addresses.
-        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
         * `action` - This defines what the firewall will do. Either accept or drop.
         * `protocol` - Either 'udp' or 'tcp'.
         * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.
@@ -212,7 +212,7 @@ This resource exports the following attributes:
         * `dst_cidr` - Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
         * `comment` - Comment.
     * `rules_v6_in` - Firewall template rules for inbound traffic - covers ipv6 addresses.
-        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+        * `order` - The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
         * `action` - This defines what the firewall will do. Either accept or drop.
         * `protocol` - Either 'udp' or 'tcp'.
         * `dst_port` - A Number between 1 and 65535, port ranges are separated by a colon for FTP.


### PR DESCRIPTION
Fix bug https://github.com/gridscale/terraform-provider-gridscale/issues/89. Changes:
- Default firewall rules will be added automatically.
- Default fw rules are hidden from tf (due to limitation of tf: If we modify a property while tf is applying the change, we cause inconsistency error. And because we want our tf provider to behave as it does previously).
- Update documentation.