### PR TITLE
Automate goreleaser via GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
 
     - name: Cache GPG passphrase
       env:
-        - GPG_PASSPHRASE = ${{ secrets.GPG_PASSPHRASE }}
-        - GPG_FINGERPRINT = ${{ secrets.GPG_FINGERPRINT }}
+        GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
       run: |
         gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE --armor --detach-sign --local-user "${GPG_FINGERPRINT}" README.md
         rm -f README.md.asc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+
+  build:
+    name: Publish
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+    steps:
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Prepare GPG key
+      run: |
+        touch ~/secret.gpg && echo "${{ secrets.GPG_SECRET }}" > ~/secret.gpg
+        touch ~/.gnupg/gpg-agent.conf && echo -e "default-cache-ttl 7200\nmax-cache-ttl 31536000\nallow-preset-passphrase" ~/.gnupg/gpg-agent.conf
+        gpg --batch --import ~/secret.gpg
+
+    - name: Cache GPG passphrase
+      env:
+        - GPG_PASSPHRASE = ${{ secrets.GPG_PASSPHRASE }}
+        - GPG_FINGERPRINT = ${{ secrets.GPG_FINGERPRINT }}
+      run: |
+        gpg --pinentry-mode=loopback --passphrase $GPG_PASSPHRASE --armor --detach-sign --local-user "${GPG_FINGERPRINT}" README.md
+        rm -f README.md.asc
+    
+    - name: Build executable files
+      env:
+        GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        GPG_FINGERPRINT: ${{ secrets.GPG_FINGERPRINT }}
+      run: |
+        curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+        export PATH="./bin:$PATH"
+        goreleaser release --rm-dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Go
+name: Test
 
 on:
   push:


### PR DESCRIPTION
Changes:
- Rename the workflow used for testing to "Test".
- Add "Build" workflow that automatically runs goreleaser (and does gpg signing).



**Required** changes in repo's settings:
- Add `GPG_SECRET` as a secret variable, and put string content of the gpg private key in it.
- Add `GPG_PASSPHRASE` as a secret variable, and put passphrase of the gpg private key in it.
- Add `GPG_FINGERPRINT` as a secret variable, and put fingerprint of the gpg private key in it.
- Add `GH_TOKEN` as a secret variable, and put github token in it. (We don't use `GITHUB_TOKEN` as github doesn't allow to set this key).