### PR TITLE
Allow the ordering of networks in a server's relation to be set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.3 (Nov 02, 2020)
+
+BUG FIXES:
+
+* The ordering of networks in a server's relation now can be set. See [#95](https://github.com/gridscale/terraform-provider-gridscale/issues/95).
+
 ## 1.7.2 (Oct 29, 2020)
 
 CHANGES:

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -3,8 +3,9 @@ package relationmanager
 import (
 	"context"
 	"fmt"
-	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 	"net/http"
+
+	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 
 	"github.com/gridscale/gsclient-go/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -135,7 +136,7 @@ func (c *ServerRelationManger) LinkNetworks(ctx context.Context) error {
 				network["object_uuid"].(string),
 				network["firewall_template_uuid"].(string),
 				network["bootdevice"].(bool),
-				0,
+				network["ordering"].(int),
 				nil,
 				&customFwRules,
 			)

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -189,7 +189,8 @@ func resourceGridscaleServer() *schema.Resource {
 						},
 						"ordering": {
 							Type:     schema.TypeInt,
-							Computed: true,
+							Optional: true,
+							Default:  0,
 						},
 						"create_time": {
 							Type:     schema.TypeString,

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -75,6 +75,9 @@ The following arguments are supported:
 
     * `object_uuid` - (Required) The object UUID or id of the network.
 
+    * `ordering` - (Optional) Defines the ordering of the network interfaces. Lower numbers have lower PCI-IDs. The default value is 0, that means the ordering will be automatically defined
+    by the gridscale's backend.
+
     * `bootdevice` - (Optional, Computed) Make this network the boot device. This can only be set for one network.
 
     * `firewall_template_uuid` - (Optional) The UUID of firewall template.


### PR DESCRIPTION
Fixed [#95](https://github.com/gridscale/terraform-provider-gridscale/issues/95). Changes:
- `server.network.ordering` is optional. The default value is 0, that means the ordering will be automatically defined by the gridscale's backend.
- Update changelog & docs.