### PR TITLE
Documentation brush up

### DIFF
--- a/gridscale/datasource_gridscale_firewall.go
+++ b/gridscale/datasource_gridscale_firewall.go
@@ -3,6 +3,7 @@ package gridscale
 import (
 	"context"
 	"fmt"
+
 	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 
 	"github.com/gridscale/gsclient-go/v3"
@@ -23,7 +24,7 @@ func dataSourceGridscaleFirewall() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"rules_v4_in": {
@@ -109,7 +110,7 @@ func dataSourceGridscaleFirewall() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"labels": {

--- a/gridscale/datasource_gridscale_ipv4.go
+++ b/gridscale/datasource_gridscale_ipv4.go
@@ -22,12 +22,12 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 			},
 			"ip": {
 				Type:        schema.TypeString,
-				Description: "Defines the IP Address.",
+				Description: "Defines the IP address.",
 				Computed:    true,
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"prefix": {
@@ -46,7 +46,7 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 			},
 			"reverse_dns": {
 				Type:        schema.TypeString,
-				Description: "Defines the reverse DNS entry for the IP Address (PTR Resource Record).",
+				Description: "Defines the reverse DNS entry for the IP address (PTR Resource Record).",
 				Computed:    true,
 			},
 			"location_country": {
@@ -61,7 +61,7 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {

--- a/gridscale/datasource_gridscale_ipv6.go
+++ b/gridscale/datasource_gridscale_ipv6.go
@@ -22,12 +22,12 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 			},
 			"ip": {
 				Type:        schema.TypeString,
-				Description: "Defines the IP Address.",
+				Description: "Defines the IP address.",
 				Computed:    true,
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"prefix": {
@@ -46,7 +46,7 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 			},
 			"reverse_dns": {
 				Type:        schema.TypeString,
-				Description: "Defines the reverse DNS entry for the IP Address (PTR Resource Record).",
+				Description: "Defines the reverse DNS entry for the IP address (PTR Resource Record).",
 				Computed:    true,
 			},
 			"location_country": {
@@ -61,7 +61,7 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {

--- a/gridscale/datasource_gridscale_isoimage.go
+++ b/gridscale/datasource_gridscale_isoimage.go
@@ -24,12 +24,12 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"source_url": {
 				Type:        schema.TypeString,
-				Description: "Contains the source URL of the ISO Image that it was originally fetched from.",
+				Description: "Contains the source URL of the ISO image that it was originally fetched from.",
 				Computed:    true,
 			},
 			"server": {
@@ -74,7 +74,7 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {
@@ -84,7 +84,7 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 			},
 			"version": {
 				Type:        schema.TypeString,
-				Description: "Upstream version of the ISO Image release",
+				Description: "Upstream version of the ISO image release",
 				Computed:    true,
 			},
 			"private": {
@@ -104,7 +104,7 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Description: "Description of the ISO Image.",
+				Description: "Description of the ISO image.",
 				Computed:    true,
 			},
 			"labels": {
@@ -120,7 +120,7 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 			},
 			"capacity": {
 				Type:        schema.TypeInt,
-				Description: "The capacity of a storage/ISO Image/template/snapshot in GB.",
+				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
 			"current_price": {

--- a/gridscale/datasource_gridscale_loadbalancer.go
+++ b/gridscale/datasource_gridscale_loadbalancer.go
@@ -22,7 +22,7 @@ func dataSourceGridscaleLoadBalancer() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"location_uuid": {

--- a/gridscale/datasource_gridscale_marketplace_app.go
+++ b/gridscale/datasource_gridscale_marketplace_app.go
@@ -21,7 +21,7 @@ func dataSourceGridscaleMarketplaceApplication() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"category": {

--- a/gridscale/datasource_gridscale_network.go
+++ b/gridscale/datasource_gridscale_network.go
@@ -22,7 +22,7 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"l2security": {
@@ -57,7 +57,7 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"delete_block": {

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -22,7 +22,7 @@ func dataSourceGridscalePaaS() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"username": {

--- a/gridscale/datasource_gridscale_publicnetwork.go
+++ b/gridscale/datasource_gridscale_publicnetwork.go
@@ -15,7 +15,7 @@ func dataSourceGridscalePublicNetwork() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"l2security": {
@@ -50,7 +50,7 @@ func dataSourceGridscalePublicNetwork() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"delete_block": {

--- a/gridscale/datasource_gridscale_server.go
+++ b/gridscale/datasource_gridscale_server.go
@@ -3,6 +3,7 @@ package gridscale
 import (
 	"context"
 	"fmt"
+
 	fwu "github.com/terraform-providers/terraform-provider-gridscale/gridscale/firewall-utils"
 
 	"github.com/gridscale/gsclient-go/v3"
@@ -23,7 +24,7 @@ func dataSourceGridscaleServer() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"memory": {

--- a/gridscale/datasource_gridscale_snapshot.go
+++ b/gridscale/datasource_gridscale_snapshot.go
@@ -73,7 +73,7 @@ func dataSourceGridscaleStorageSnapshot() *schema.Resource {
 			"license_product_no": {
 				Type:     schema.TypeInt,
 				Computed: true,
-				Description: `If a template has been used that requires a license key (e.g. Windows Servers) this shows 
+				Description: `If a template has been used that requires a license key (e.g. Windows Servers) this shows
 the product_no of the license (see the /prices endpoint for more details)`,
 			},
 			"current_price": {
@@ -84,7 +84,7 @@ the product_no of the license (see the /prices endpoint for more details)`,
 			"capacity": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The capacity of a storage/ISO Image/template/snapshot in GB",
+				Description: "The capacity of a storage/ISO image/template/snapshot in GB",
 			},
 			"labels": {
 				Type:        schema.TypeList,

--- a/gridscale/datasource_gridscale_sshkey.go
+++ b/gridscale/datasource_gridscale_sshkey.go
@@ -22,7 +22,7 @@ func dataSourceGridscaleSshkey() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true},
 			"sshkey": {
 				Type:        schema.TypeString,

--- a/gridscale/datasource_gridscale_storage.go
+++ b/gridscale/datasource_gridscale_storage.go
@@ -21,7 +21,7 @@ func dataSourceGridscaleStorage() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"capacity": {
@@ -69,7 +69,7 @@ func dataSourceGridscaleStorage() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"location_country": {

--- a/gridscale/datasource_gridscale_template.go
+++ b/gridscale/datasource_gridscale_template.go
@@ -39,7 +39,7 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {
@@ -78,12 +78,12 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 			},
 			"distro": {
 				Type:        schema.TypeString,
-				Description: "The OS distrobution that the Template contains.",
+				Description: "The OS distribution that the template contains.",
 				Computed:    true,
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Description: "Description of the Template.",
+				Description: "Description of the template.",
 				Computed:    true,
 			},
 			"labels": {
@@ -99,7 +99,7 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 			},
 			"capacity": {
 				Type:        schema.TypeInt,
-				Description: "The capacity of a storage/ISO Image/template/snapshot in GB.",
+				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
 			"current_price": {

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -29,7 +29,7 @@ func resourceGridscaleFirewall() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
-				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -118,7 +118,7 @@ func resourceGridscaleFirewall() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"labels": {

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -26,12 +26,12 @@ func resourceGridscaleIpv4() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"ip": {
 				Type:        schema.TypeString,
-				Description: "Defines the IP Address.",
+				Description: "Defines the IP address.",
 				Computed:    true,
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Optional:    true,
 			},
 			"prefix": {
@@ -51,7 +51,7 @@ func resourceGridscaleIpv4() *schema.Resource {
 			},
 			"reverse_dns": {
 				Type:        schema.TypeString,
-				Description: "Defines the reverse DNS entry for the IP Address (PTR Resource Record).",
+				Description: "Defines the reverse DNS entry for the IP address (PTR Resource Record).",
 				Optional:    true,
 				Computed:    true,
 			},
@@ -67,7 +67,7 @@ func resourceGridscaleIpv4() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {

--- a/gridscale/resource_gridscale_ipv6.go
+++ b/gridscale/resource_gridscale_ipv6.go
@@ -22,12 +22,12 @@ func resourceGridscaleIpv6() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"ip": {
 				Type:        schema.TypeString,
-				Description: "Defines the IP Address.",
+				Description: "Defines the IP address.",
 				Computed:    true,
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Optional:    true,
 			},
 			"prefix": {
@@ -47,7 +47,7 @@ func resourceGridscaleIpv6() *schema.Resource {
 			},
 			"reverse_dns": {
 				Type:        schema.TypeString,
-				Description: "Defines the reverse DNS entry for the IP Address (PTR Resource Record).",
+				Description: "Defines the reverse DNS entry for the IP address (PTR Resource Record).",
 				Optional:    true,
 				Computed:    true,
 			},
@@ -63,7 +63,7 @@ func resourceGridscaleIpv6() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -25,12 +25,12 @@ func resourceGridscaleISOImage() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Required:    true,
 			},
 			"source_url": {
 				Type:        schema.TypeString,
-				Description: "Contains the source URL of the ISO Image that it was originally fetched from.",
+				Description: "Contains the source URL of the ISO image that it was originally fetched from.",
 				Required:    true,
 				ForceNew:    true,
 			},
@@ -76,7 +76,7 @@ func resourceGridscaleISOImage() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {
@@ -86,7 +86,7 @@ func resourceGridscaleISOImage() *schema.Resource {
 			},
 			"version": {
 				Type:        schema.TypeString,
-				Description: "Upstream version of the ISO Image release",
+				Description: "Upstream version of the ISO image release",
 				Computed:    true,
 			},
 			"private": {
@@ -106,7 +106,7 @@ func resourceGridscaleISOImage() *schema.Resource {
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Description: "Description of the ISO Image.",
+				Description: "Description of the ISO image.",
 				Computed:    true,
 			},
 			"labels": {
@@ -122,7 +122,7 @@ func resourceGridscaleISOImage() *schema.Resource {
 			},
 			"capacity": {
 				Type:        schema.TypeInt,
-				Description: "The capacity of a storage/ISO Image/template/snapshot in GB.",
+				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
 			"current_price": {

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -26,7 +26,7 @@ func resourceGridscaleLoadBalancer() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
-				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -48,7 +48,7 @@ func resourceGridscaleLoadBalancer() *schema.Resource {
 						}
 					}
 					if !valid {
-						errors = append(errors, fmt.Errorf("%v is not a valid loadbalancer algorithm. Valid loadbalancer algorithms are: %v", v.(string), strings.Join(loadbalancerAlgs, ",")))
+						errors = append(errors, fmt.Errorf("%v is not a valid load balancer algorithm. Valid load balancer algorithms are: %v", v.(string), strings.Join(loadbalancerAlgs, ",")))
 					}
 					return
 				},

--- a/gridscale/resource_gridscale_marketplace_app.go
+++ b/gridscale/resource_gridscale_marketplace_app.go
@@ -27,7 +27,7 @@ func resourceGridscaleMarketplaceApplication() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Required:    true,
 			},
 			"category": {

--- a/gridscale/resource_gridscale_marketplace_app_import.go
+++ b/gridscale/resource_gridscale_marketplace_app_import.go
@@ -32,7 +32,7 @@ func resourceGridscaleImportedMarketplaceApplication() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"category": {

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -26,7 +26,7 @@ func resourceGridscaleNetwork() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Required:    true,
 			},
 			"l2security": {
@@ -62,7 +62,7 @@ func resourceGridscaleNetwork() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"delete_block": {

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -27,7 +27,7 @@ func resourceGridscalePaaS() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
-				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -32,7 +32,7 @@ func resourceGridscaleServer() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
-				Description:  "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -302,9 +302,9 @@ func getFirewallRuleCommonSchema() map[string]*schema.Schema {
 	commonSchema := map[string]schema.Schema{
 		"order": {
 			Type: schema.TypeInt,
-			Description: `The order at which the firewall will compare packets against its rules. 
-A packet will be compared against the first rule, it will either allow it to pass or block it 
-and it won't be matched against any other rules. However, if it does no match the rule, 
+			Description: `The order at which the firewall will compare packets against its rules.
+A packet will be compared against the first rule, it will either allow it to pass or block it
+and it won't be matched against any other rules. However, if it does no match the rule,
 then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).`,
 			Required: true,
 		},

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -73,7 +73,7 @@ func resourceGridscaleStorageSnapshot() *schema.Resource {
 			"license_product_no": {
 				Type:     schema.TypeInt,
 				Computed: true,
-				Description: `If a template has been used that requires a license key (e.g. Windows Servers) this shows 
+				Description: `If a template has been used that requires a license key (e.g. Windows Servers) this shows
 the product_no of the license (see the /prices endpoint for more details)`,
 			},
 			"current_price": {
@@ -84,7 +84,7 @@ the product_no of the license (see the /prices endpoint for more details)`,
 			"capacity": {
 				Type:        schema.TypeInt,
 				Computed:    true,
-				Description: "The capacity of a storage/ISO Image/template/snapshot in GB",
+				Description: "The capacity of a storage/ISO image/template/snapshot in GB",
 			},
 			"storage_uuid": {
 				Type:        schema.TypeString,

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -26,7 +26,7 @@ func resourceGridscaleSshkey() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Required:    true,
 			},
 			"sshkey": {

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -28,7 +28,7 @@ func resourceGridscaleStorage() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Required:    true,
 			},
 			"capacity": {
@@ -91,7 +91,7 @@ func resourceGridscaleStorage() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"location_country": {

--- a/gridscale/resource_gridscale_storage_clone.go
+++ b/gridscale/resource_gridscale_storage_clone.go
@@ -33,7 +33,7 @@ func resourceGridscaleStorageClone() *schema.Resource {
 			},
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Optional:    true,
 				Computed:    true,
 			},
@@ -97,7 +97,7 @@ func resourceGridscaleStorageClone() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Computed:    true,
 			},
 			"location_country": {

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -25,7 +25,7 @@ func resourceGridscaleTemplate() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.",
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
 				Required:    true,
 			},
 			"snapshot_uuid": {
@@ -51,7 +51,7 @@ func resourceGridscaleTemplate() *schema.Resource {
 			},
 			"location_name": {
 				Type:        schema.TypeString,
-				Description: "The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters",
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters",
 				Computed:    true,
 			},
 			"status": {
@@ -90,12 +90,12 @@ func resourceGridscaleTemplate() *schema.Resource {
 			},
 			"distro": {
 				Type:        schema.TypeString,
-				Description: "The OS distrobution that the Template contains.",
+				Description: "The OS distribution that the template contains.",
 				Computed:    true,
 			},
 			"description": {
 				Type:        schema.TypeString,
-				Description: "Description of the Template.",
+				Description: "Description of the template.",
 				Computed:    true,
 			},
 			"labels": {
@@ -111,7 +111,7 @@ func resourceGridscaleTemplate() *schema.Resource {
 			},
 			"capacity": {
 				Type:        schema.TypeInt,
-				Description: "The capacity of a storage/ISO Image/template/snapshot in GB.",
+				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
 			"current_price": {

--- a/website/docs/d/backup.html.md
+++ b/website/docs/d/backup.html.md
@@ -14,7 +14,7 @@ Gets a backup list of a specific storage.
 
 ```terraform
 data "gridscale_backup_list" "foo" {
-  	storage_uuid = "XXXX-XXXX-XXXX-XXXX"
+    storage_uuid = "XXXX-XXXX-XXXX-XXXX"
 }
 ```
 
@@ -30,7 +30,7 @@ The following attributes are exported:
 
 * `storage_uuid` - UUID of the storage that the backups belong to.
 * `storage_backups` - Backups of the given storage.
-    * `name` - Name of the backup.
-    * `object_uuid` - UUID of the backup.
-    * `create_time` - The date and time the backup was initially created.
-    * `capacity` - The size of a backup in GB.
+  * `name` - Name of the backup.
+  * `object_uuid` - UUID of the backup.
+  * `create_time` - The date and time the backup was initially created.
+  * `capacity` - The size of a backup in GB.

--- a/website/docs/d/backupschedule.html.md
+++ b/website/docs/d/backupschedule.html.md
@@ -54,6 +54,6 @@ The following attributes are exported:
 * `create_time` - The date and time the backup schedule was initially created.
 * `change_time` - The date and time of the last backup schedule change.
 * `storage_backups` - Related backups.
-    * `name` - Name of the backup.
-    * `object_uuid` - UUID of the backup.
-    * `create_time` - The date and time the backup was initially created.
+  * `name` - Name of the backup.
+  * `object_uuid` - UUID of the backup.
+  * `create_time` - The date and time the backup was initially created.

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -16,26 +16,25 @@ Get data of a firewall by its UUID.
 resource "gridscale_firewall" "foo" {
   name   = "example-firewall"
   rules_v4_in {
-	order = 0
-	protocol = "tcp"
-	action = "drop"
-	dst_port = "20:80"
-	comment = "some comments"
+    order = 0
+    protocol = "tcp"
+    action = "drop"
+    dst_port = "20:80"
+    comment = "some comments"
   }
   rules_v6_in {
-	order = 0
-	protocol = "tcp"
-	action = "drop"
-	dst_port = "2000:3000"
-	comment = "some comments"
+    order = 0
+    protocol = "tcp"
+    action = "drop"
+    dst_port = "2000:3000"
+    comment = "some comments"
   }
 }
 
 data "gridscale_firewall" "foo" {
-	resource_id   = gridscale_firewall.foo.id
+  resource_id   = gridscale_firewall.foo.id
 }
 ```
-
 
 ## Argument Reference
 
@@ -91,7 +90,7 @@ The following attributes are exported:
     * `network_uuid` - The object UUID or id of the network.
     * `network_name` - Name of the network.
     * `create_time` - The date and time the object was initially created.
-* `location_name` - The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `location_name` - The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `status` - Status indicates the status of the object.
 * `private` - The object is private, the value will be true. Otherwise the value will be false.
 * `create_time` - The date and time the object was initially created.

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_ip
 
-Get data of an IP address resource. This can be used to link ip addresses to a server.
+Get data of an IP address resource. This can be used to assign IP addresses to a server.
 
 ## Example Usage
 
@@ -16,21 +16,22 @@ Using ip datasource for the creation of a server:
 
 ```terraform
 data "gridscale_ipv4" "ipv4name"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 data "gridscale_ipv6" "ipv6name"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
-	name = "terra-server"
-	cores = 2
-	memory = 4
-	ipv4 = data.gridscale_ipv4.ipv4name.id
-	ipv6 = data.gridscale_ipv6.ipv6name.id
+  name = "terra-server"
+  cores = 2
+  memory = 4
+  ipv4 = data.gridscale_ipv4.ipv4name.id
+  ipv6 = data.gridscale_ipv6.ipv6name.id
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -41,19 +42,19 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The UUID of the ip.
-* `ip` - Defines the IP Address (v4 or v6) the ip.
-* `prefix` - The IP prefix of the ip.
+* `id` - The UUID of the IP.
+* `ip` - Defines the IP address (v4 or v6).
+* `prefix` - The prefix of the IP or subnet.
 * `location_uuid` - The UUID of the location, that helps to identify which datacenter an object belongs to.
-* `failover` - failover mode of this ip. If true, then this IP is no longer available for DHCP and can no longer be related to any server..
-* `status` - The status of the ip.
-* `reverse_dns` - The reverse DNS of the ip.
+* `failover` - failover mode of this ip. If true, then this IP is no longer available for DHCP and can no longer be related to any server.
+* `status` - The status of the IP.
+* `reverse_dns` - The reverse DNS of the IP.
 * `location_iata` - The IATA airport code, which works as a location identifier.
-* `location_country` - The human-readable name of the country of the ip.
-* `location_name` - The human-readable name of the location of the ip.
-* `create_time` - The date and time the ip was initially created.
+* `location_country` - The human-readable name of the country of the IP.
+* `location_name` - The human-readable name of the location of the IP.
+* `create_time` - The date and time the IP was initially created.
 * `change_time` - The date and time of the last ip change.
-* `delete_block` - Defines if the ip is administratively blocked.
-* `usage_in_minutes` - Total minutes the ip has been running.
+* `delete_block` - Defines if the IP is administratively blocked.
+* `usage_in_minutes` - Total minutes the IP has been running.
 * `current_price` - The price for the current period since the last bill.
 * `labels` - The list of labels.

--- a/website/docs/d/isoimage.html.md
+++ b/website/docs/d/isoimage.html.md
@@ -19,10 +19,9 @@ resource "gridscale_isoimage" "foo" {
 }
 
 data "gridscale_isoimage" "foo" {
-	resource_id   = gridscale_isoimage.foo.id
+  resource_id   = gridscale_isoimage.foo.id
 }
 ```
-
 
 ## Argument Reference
 
@@ -37,21 +36,21 @@ The following attributes are exported:
 * `name` - The name of the ISO Image.
 * `source_url` - Contains the source URL of the ISO Image that it was originally fetched from.
 * `server` - The information about servers which are related to this ISO Image.
-    * `object_uuid` - The object UUID or id of the server.
-    * `object_name` - Name of the server.
-    * `create_time` - The date and time the object was initially created.
-    * `bootdevice` - True if the ISO Image is a boot device of this server.
+  * `object_uuid` - The object UUID or id of the server.
+  * `object_name` - Name of the server.
+  * `create_time` - The date and time the object was initially created.
+  * `bootdevice` - True if the ISO Image is a boot device of this server.
 * `id` - The UUID of the ISO Image.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.
 * `location_country` - Formatted by the 2 digit country code (ISO 3166-2) of the host country.
 * `location_iata` - Uses IATA airport code, which works as a location identifier.
-* `location_name` - The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `location_name` - The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `status` - Status indicates the status of the object.
 * `version` - The version of the ISO Image.
 * `private` - The object is private, the value will be true. Otherwise the value will be false.
 * `create_time` - The date and time the object was initially created.
 * `change_time` - The date and time of the last object change.
-* `description` - Description of the Template.
+* `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/ISO Image/snapshot in GB.
 * `current_price` - Defines the price for the current period since the last bill.

--- a/website/docs/d/loadbalancer.html.md
+++ b/website/docs/d/loadbalancer.html.md
@@ -14,7 +14,7 @@ Get the data of a Load Balancer.
 
 ```terraform
 data "gridscale_loadbalancer" "foo" {
-	resource_id   = "xxxx-xxxx-xxxx-xxxx"
+  resource_id   = "xxxx-xxxx-xxxx-xxxx"
 }
 ```
 
@@ -22,19 +22,19 @@ data "gridscale_loadbalancer" "foo" {
 
 The following arguments are supported:
 
-* `resource_id` - (Required) The UUID of the loadbalancer.
+* `resource_id` - (Required) The UUID of the load balancer.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `id` - The UUID of the loadbalancer.
-* `name` - The human-readable name of the loadbalancer.
+* `id` - The UUID of the load balancer.
+* `name` - The human-readable name of the load balancer.
 * `algorithm` - The algorithm used to process requests.
-* `status` - The status of the loadbalancer.
+* `status` - The status of the load balancer.
 * `redirect_http_to_https` - Whether the Load balancer is forced to redirect requests from HTTP to HTTPS.
-* `listen_ipv4_uuid` - The UUID of the IPv4 address the loadbalancer will listen to for incoming requests.
-* `listen_ipv6_uuid` - The UUID of the IPv6 address the loadbalancer will listen to for incoming requests.
-* `forwarding_rule` - The forwarding rules of the loadbalancer.
-* `backend_server` - The servers that the loadbalancer can communicate with.
+* `listen_ipv4_uuid` - The UUID of the IPv4 address the load balancer will listen to for incoming requests.
+* `listen_ipv6_uuid` - The UUID of the IPv6 address the load balancer will listen to for incoming requests.
+* `forwarding_rule` - The forwarding rules of the load balancer.
+* `backend_server` - The servers that the load balancer can communicate with.
 * `labels` - The list of labels.

--- a/website/docs/d/marketplaceApp.html.md
+++ b/website/docs/d/marketplaceApp.html.md
@@ -16,9 +16,10 @@ Get data of a specific marketplace application:
 
 ```terraform
 data "gridscale_marketplace_application" "foo" {
-	resource_id   = "XXX-XXX-XXX-XXX"
+  resource_id   = "XXX-XXX-XXX-XXX"
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -16,17 +16,17 @@ Using the network datasource for the creation of a server:
 
 ```terraform
 data "gridscale_network" "networkname"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
-	name = "terra-server"
-	cores = 2
-	memory = 4
-	network {
-		object_uuid = data.gridscale_network.networkname.id
-		bootdevice = true
-	}
+  name = "terra-server"
+  cores = 2
+  memory = 4
+  network {
+    object_uuid = data.gridscale_network.networkname.id
+    bootdevice = true
+  }
 }
 ```
 

--- a/website/docs/d/objectstorage.html.md
+++ b/website/docs/d/objectstorage.html.md
@@ -17,7 +17,7 @@ resource "gridscale_object_storage_accesskey" "foo" {
 }
 
 data "gridscale_object_storage_accesskey" "foo" {
-	resource_id   = "${gridscale_object_storage_accesskey.foo.id}"
+  resource_id   = "${gridscale_object_storage_accesskey.foo.id}"
 }
 ```
 

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -21,7 +21,7 @@ resource "gridscale_paas" "foo" {
 }
 
 data "gridscale_paas" "foo" {
-	resource_id   = gridscale_paas.foo.id
+  resource_id   = gridscale_paas.foo.id
 }
 ```
 
@@ -39,8 +39,8 @@ The following attributes are exported:
 * `username` - Username for PaaS service.
 * `password` - Password for PaaS service.
 * `listen_port` - Ports that PaaS service listens to.
-    * `name` - Name of a port.
-    * `listen_port` - Port number.
+  * `name` - Name of a port.
+  * `listen_port` - Port number.
 * `security_zone_uuid` - The UUID of the security zone that the service is running in.
 * `network_uuid` - Network UUID containing security zone.
 * `service_template_uuid` - The template used to create the service.
@@ -50,10 +50,10 @@ The following attributes are exported:
 * `create_time` - Time of the creation.
 * `status` - Current status of PaaS service.
 * `parameter` - Contains the service parameters for the service.
-    * `param` - Name of parameter.
-    * `value` - Value of the corresponding parameter.
-    * `type` - Primitive type of the parameter.
+  * `param` - Name of parameter.
+  * `value` - Value of the corresponding parameter.
+  * `type` - Primitive type of the parameter.
 * `resource_limit` - A list of service resource limits.
-    * `resource` - The name of the resource you would like to cap.
-    * `limit` - The maximum number of the specific resource your service can use.
+  * `resource` - The name of the resource you would like to cap.
+  * `limit` - The maximum number of the specific resource your service can use.
 * `labels` - List of labels in the format [ "label1", "label2" ].

--- a/website/docs/d/publicnetwork.html.md
+++ b/website/docs/d/publicnetwork.html.md
@@ -19,13 +19,13 @@ data "gridscale_public_network" "pubnet"{
 }
 
 resource "gridscale_server" "servername"{
-	name = "terra-server"
-	cores = 2
-	memory = 4
-	network {
-		object_uuid = data.gridscale_public_network.pubnet.id
-		bootdevice = true
-	}
+  name = "terra-server"
+  cores = 2
+  memory = 4
+  network {
+    object_uuid = data.gridscale_public_network.pubnet.id
+    bootdevice = true
+  }
 }
 ```
 

--- a/website/docs/d/securityzone.html.md
+++ b/website/docs/d/securityzone.html.md
@@ -16,14 +16,14 @@ Using the security zone datasource for the creation of a paas:
 
 ```terraform
 data "gridscale_paas_securityzone" "foo"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 
 resource "gridscale_paas" "foo"{
-	name = "terra-paas-test"
-    service_template_uuid = "f9625726-5ca8-4d5c-b9bd-3257e1e2211a"
-    security_zone_uuid = data.gridscale_paas_securityzone.foo.id
+  name = "terra-paas-test"
+  service_template_uuid = "f9625726-5ca8-4d5c-b9bd-3257e1e2211a"
+  security_zone_uuid = data.gridscale_paas_securityzone.foo.id
 }
 ```
 
@@ -38,7 +38,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The UUID of the security zone.
-* `name` - The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.
 * `location_country` - The human-readable name of the location's country.
 * `location_iata` - Uses IATA airport code, which works as a location identifier.

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -30,30 +30,30 @@ resource "gridscale_server" "foo" {
   power = true
   ipv4 = gridscale_ipv4.foo1.id
   network {
-		object_uuid = gridscale_network.foo.id
-		rules_v4_in {
-				order = 0
-				protocol = "tcp"
-				action = "drop"
-				dst_port = "20:80"
-				comment = "test"
-		}
-		rules_v6_in	{
-				order = 1
-				protocol = "tcp"
-				action = "drop"
-				dst_port = "10:20"
-				comment = "test1"
-		}
-  	}
+    object_uuid = gridscale_network.foo.id
+    rules_v4_in {
+      order = 0
+      protocol = "tcp"
+      action = "drop"
+      dst_port = "20:80"
+      comment = "test"
+    }
+    rules_v6_in {
+      order = 1
+      protocol = "tcp"
+      action = "drop"
+      dst_port = "10:20"
+      comment = "test1"
+    }
+  }
   storage {
-  	object_uuid = gridscale_storage.foo1.id
+    object_uuid = gridscale_storage.foo1.id
   }
 }
 
 
 data "gridscale_server" "foo" {
-	resource_id   = gridscale_server.foo.id
+  resource_id   = gridscale_server.foo.id
 }
 ```
 
@@ -139,7 +139,7 @@ This resource exports the following attributes:
 * `availability_zone` - Defines which Availability-Zone the Server is placed.
 * `auto_recovery` - If the server should be auto-started in case of a failure.
 * `console_token` - The token used by the panel to open the websocket VNC connection to the server console.
-* `legacy` - Legacy-Hardware emulation instead of virtio hardware. If enabled, hotplugging cores, memory, storage, network, etc. will not work, but the server will most likely run every x86 compatible operating system. This mode comes with a performance penalty, as emulated hardware does not benefit from the virtio driver infrastructure.
+* `legacy` - Legacy-Hardware emulation instead of virtio hardware. If enabled, hot-plugging cores, memory, storage, network, etc. will not work, but the server will most likely run every x86 compatible operating system. This mode comes with a performance penalty, as emulated hardware does not benefit from the virtio driver infrastructure.
 * `status` - Status indicates the status of the object.
 * `usage_in_minutes_memory` - Total minutes of memory used.
 * `usage_in_minutes_cores` - Total minutes of cores used.

--- a/website/docs/d/snapshot.html.md
+++ b/website/docs/d/snapshot.html.md
@@ -23,8 +23,8 @@ resource "gridscale_snapshot" "foo" {
 }
 
 data "gridscale_snapshot" "foo" {
-	resource_id   = gridscale_snapshot.foo.id
-  	storage_uuid = gridscale_storage.foo.id
+  resource_id   = gridscale_snapshot.foo.id
+    storage_uuid = gridscale_storage.foo.id
 }
 ```
 

--- a/website/docs/d/snapshotschedule.html.md
+++ b/website/docs/d/snapshotschedule.html.md
@@ -25,8 +25,8 @@ resource "gridscale_snapshotschedule" "foo" {
   next_runtime = "2025-12-30 15:04:05"
 }
 data "gridscale_snapshotschedule" "foo" {
-	resource_id   = gridscale_snapshotschedule.foo.id
-	storage_uuid   = gridscale_storage.foo.id
+  resource_id   = gridscale_snapshotschedule.foo.id
+  storage_uuid   = gridscale_storage.foo.id
 }
 ```
 
@@ -53,6 +53,6 @@ The following attributes are exported:
 * `change_time` - The date and time of the last snapshot schedule change.
 * `labels` - The list of labels.
 * `snapshot` - Related snapshots.
-    * `name` - Name of the snapshot.
-    * `object_uuid` - UUID of the snapshot.
-    * `create_time` - The date and time the snapshot was initially created.
+  * `name` - Name of the snapshot.
+  * `object_uuid` - UUID of the snapshot.
+  * `create_time` - The date and time the snapshot was initially created.

--- a/website/docs/d/sshkey.html.md
+++ b/website/docs/d/sshkey.html.md
@@ -3,7 +3,7 @@ layout: "gridscale"
 page_title: "gridscale: sshkey"
 sidebar_current: "docs-gridscale-datasource-sshkey"
 description: |-
-  Gets data of an sshkey.
+  Gets data of an SSH key.
 ---
 
 # gridscale_sshkey
@@ -16,23 +16,23 @@ Using the sshkey datasource for the creation of a storage:
 
 ```terraform
 data "gridscale_sshkey" "sshkey-john"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 data "gridscale_sshkey" "sshkey-jane"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_storage" "storagename"{
-	name = "terraform-storage"
-	capacity = 10
-	template {
-		sshkeys = [
-		    data.gridscale_sshkey.sshkey-john.id,
-		    data.gridscale_sshkey.sshkey-jane.id
-		]
-		template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
-	}
+  name = "terraform-storage"
+  capacity = 10
+  template {
+    sshkeys = [
+      data.gridscale_sshkey.sshkey-john.id,
+      data.gridscale_sshkey.sshkey-jane.id
+    ]
+    template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
+  }
 }
 ```
 
@@ -46,10 +46,10 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `id` - The UUID of the sshkey.
-* `name` - The human-readable name of the sshkey.
-* `sshkey` - The OpenSSH public key string of the sshkey.
-* `status` - The status of the sshkey.
-* `create_time` - The date and time of the sshkey was initially created.
-* `change_time` - The date and time of the last sshkey change.
+* `id` - The UUID of the SSH key.
+* `name` - The human-readable name of the SSH key.
+* `sshkey` - The OpenSSH public key string of the SSH key.
+* `status` - The status of the SSH key.
+* `create_time` - The date and time that this SSH key was initially created.
+* `change_time` - The date and time of the last change.
 * `labels` - The list of labels.

--- a/website/docs/d/storage.html.md
+++ b/website/docs/d/storage.html.md
@@ -16,16 +16,16 @@ Using the storage datasource for the creation of a server:
 
 ```terraform
 data "gridscale_storage" "storagename"{
-	resource_id = "xxxx-xxxx-xxxx-xxxx"
+  resource_id = "xxxx-xxxx-xxxx-xxxx"
 }
 
 resource "gridscale_server" "servername"{
-	name = "terra-server"
-	cores = 2
-	memory = 4
-	storage {
-		object_uuid = data.gridscale_storage.storagename.id
-	}
+  name = "terra-server"
+  cores = 2
+  memory = 4
+  storage {
+    object_uuid = data.gridscale_storage.storagename.id
+  }
 }
 ```
 

--- a/website/docs/d/template.html.md
+++ b/website/docs/d/template.html.md
@@ -26,12 +26,12 @@ Using the template datasource for the creation of a storage:
 
 ```terraform
 resource "gridscale_storage" "storage-test"{
-	name = "terra-storage-test"
-	capacity = 10
-	template {
-		sshkeys = [ "e17e8fd2-0797-4a00-a85d-eb9a612a6e4e" ]
-		template_uuid = data.gridscale_template.ubuntu.id
-	}
+  name = "terra-storage-test"
+  capacity = 10
+  template {
+    sshkeys = [ "e17e8fd2-0797-4a00-a85d-eb9a612a6e4e" ]
+    template_uuid = data.gridscale_template.ubuntu.id
+  }
 }
 ```
 
@@ -50,7 +50,7 @@ The following attributes are exported:
 * `location_uuid` - Helps to identify which datacenter an object belongs to.
 * `location_country` - Formatted by the 2 digit country code (ISO 3166-2) of the host country.
 * `location_iata` - Uses IATA airport code, which works as a location identifier.
-* `location_name` - The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `location_name` - The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `status` - Status indicates the status of the object.
 * `ostype` - The operating system installed in the template.
 * `version` - The version of the template.
@@ -58,8 +58,8 @@ The following attributes are exported:
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `create_time` - The date and time the object was initially created.
 * `change_time` - The date and time of the last object change.
-* `distro` - The OS distrobution that the Template contains.
-* `description` - Description of the Template.
+* `distro` - The OS distribution that the template contains.
+* `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/template/snapshot in GB.
 * `current_price` - Defines the price for the current period since the last bill.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     gridscale = {
       source = "gridscale/gridscale"
-      version = "1.6.4"
+      version = "1.7.3"
     }
   }
 }
@@ -29,29 +29,27 @@ terraform {
 
 # Configure the gridscale provider
 provider "gridscale" {
-	uuid = var.gridscale_uuid
-	token = var.gridscale_token
-  
+  uuid = var.gridscale_uuid
+  token = var.gridscale_token
 }
 
 # Create a server
 resource "gridscale_server" "servername"{
-  # ...
+  # …
 }
 ```
 
 Also make sure to check out our other Terraform examples over at [github.com/gridscale/terraform_examples](https://github.com/gridscale/terraform_examples).
 
-~> **Note** To verify that you are using the official released version of gridscale terraform provider, you just need to check the format of the `source` whether it is `<NAMESPACE>/<NAME>/<PROVIDER>`. For more information, visit https://registry.terraform.io/providers/gridscale/gridscale/latest
+~> **Note** To verify that you are using the official released version of gridscale terraform provider, you just need to check the format of the `source` whether it is `<NAMESPACE>/<NAME>/<PROVIDER>`. For more information, visit [registry.terraform.io/providers/gridscale/gridscale/](https://registry.terraform.io/providers/gridscale/gridscale/latest).
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `source` - (Required) The global source address for the provider you intend to use. In this case, we use `gridscale/gridscale`
+* `source` - (Required) The global source address for the provider you intend to use. In this case, we use `gridscale/gridscale`.
 * `version` - (Optional) A version constraint specifying which subset of available provider versions the module is compatible with.
-
 * `uuid` - (Optional) This is the User-UUID for the gridscale API. It can be found [in the panel](https://my.gridscale.io/APIs/). If omitted, the GRIDSCALE_UUID environment variable is used.
 * `token` - (Optional) This is an API-Token for the gridscale API. It can be created [in the panel](https://my.gridscale.io/APIs/). The created token needs to have full access to be usable by Terraform. If omitted, the GRIDSCALE_TOKEN environment variable is used.
 * `api_url` - (Optional) The URL for the API. By default this is set to "https://api.gridscale.io". Do not add a "/" character at the end.
-* `http_headers` - (Optional) Custom HTTP headers sent to gridscale server. If omitted, the GRIDSCALE_TF_HEADERS environment variable is used. 
+* `http_headers` - (Optional) Custom HTTP headers sent to gridscale API. If omitted, the GRIDSCALE_TF_HEADERS environment variable may be used.

--- a/website/docs/r/backupschedule.html.md
+++ b/website/docs/r/backupschedule.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_backupschedule
 
-Provides a storage backup schedule resource. This can be used to create, modify and delete backup schedules.
+Provides a storage backup schedule resource. This can be used to create, modify, and delete backup schedules.
 
 ## Example Usage
 
@@ -49,11 +49,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 
@@ -71,6 +71,6 @@ The following attributes are exported:
 * `create_time` - The date and time the backup schedule was initially created.
 * `change_time` - The date and time of the last backup schedule change.
 * `storage_backups` - Related backups.
-    * `name` - Name of the backup.
-    * `object_uuid` - UUID of the backup.
-    * `create_time` - The date and time the backup was initially created.
+  * `name` - Name of the backup.
+  * `object_uuid` - UUID of the backup.
+  * `create_time` - The date and time the backup was initially created.

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_firewall
 
-Provides a firewall resource. This can be used to create, modify and delete firewalls.
+Provides a firewall resource. This can be used to create, modify, and delete firewalls.
 
 ## Example Usage
 
@@ -16,18 +16,18 @@ Provides a firewall resource. This can be used to create, modify and delete fire
 resource "gridscale_firewall" "foo" {
   name   = "example-firewall"
   rules_v4_in {
-	order = 0
-	protocol = "tcp"
-	action = "drop"
-	dst_port = "20:80"
-	comment = "some comments"
+    order = 0
+    protocol = "tcp"
+    action = "drop"
+    dst_port = "20:80"
+    comment = "some comments"
   }
   rules_v6_in {
-	order = 0
-	protocol = "tcp"
-	action = "drop"
-	dst_port = "2000:3000"
-	comment = "some comments"
+    order = 0
+    protocol = "tcp"
+    action = "drop"
+    dst_port = "2000:3000"
+    comment = "some comments"
   }
   timeouts {
       create="10m"
@@ -35,54 +35,53 @@ resource "gridscale_firewall" "foo" {
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are supported:
 
 ***Note: `Optional*` means there is at least 1 rule in the firewall. Otherwise, an error will be returned.
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `rules_v4_in` - (Optional*) Firewall template rules for inbound traffic - covers ipv4 addresses.
 
-    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
+  * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
 
-    * `action` - (Required) This defines what the firewall will do. Either accept or drop.
+  * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
-    * `protocol` - (Required) Either 'udp' or 'tcp'.
+  * `protocol` - (Required) Either 'udp' or 'tcp'.
 
-    * `dst_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
+  * `dst_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
 
-    * `src_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
+  * `src_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
 
-    * `src_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
+  * `src_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
 
-    * `dst_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
+  * `dst_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
 
-    * `comment` - (Optional) Comment.
-        
+  * `comment` - (Optional) Comment.
+
 * `rules_v4_out` - (Optional*) Firewall template rules for outbound traffic - covers ipv4 addresses.
 
-    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+  * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
 
-    * `action` - (Required) This defines what the firewall will do. Either accept or drop.
+  * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
-    * `protocol` - (Required) Either 'udp' or 'tcp'.
+  * `protocol` - (Required) Either 'udp' or 'tcp'.
 
-    * `dst_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
+  * `dst_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
 
-    * `src_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
+  * `src_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
 
-    * `src_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
+  * `src_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
 
-    * `dst_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
+  * `dst_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
 
-    * `comment` - (Optional) Comment.
+  * `comment` - (Optional) Comment.
 
 * `rules_v6_in` - (Optional*) Firewall template rules for inbound traffic - covers ipv6 addresses.
 
-    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
+  * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2. Packets that do not match any rules are blocked by default (Only for inbound).
 
     * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
@@ -100,32 +99,32 @@ The following arguments are supported:
 
 * `rules_v6_out` - (Optional*) Firewall template rules for outbound traffic - covers ipv6 addresses.
 
-    * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
+  * `order` - (Required) The order at which the firewall will compare packets against its rules. A packet will be compared against the first rule, it will either allow it to pass or block it and it won't be matched against any other rules. However, if it does no match the rule, then it will proceed onto rule 2.
 
-    * `action` - (Required) This defines what the firewall will do. Either accept or drop.
+  * `action` - (Required) This defines what the firewall will do. Either accept or drop.
 
-    * `protocol` - (Required) Either 'udp' or 'tcp'.
+  * `protocol` - (Required) Either 'udp' or 'tcp'.
 
-    * `dst_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
+  * `dst_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
 
-    * `src_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
+  * `src_port` - (Optional) A Number between 1 and 65535, port ranges are separated by a colon for FTP.
 
-    * `src_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
+  * `src_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
 
-    * `dst_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
+  * `dst_cidr` - (Optional) Either an IPv4/6 address or and IP Network in CIDR format. If this field is empty then this service has access to all IPs.
 
-    * `comment` - (Optional) Comment. 
+  * `comment` - (Optional) Comment.
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 
@@ -175,7 +174,7 @@ The following attributes are exported:
     * `network_uuid` - The object UUID or id of the network.
     * `network_name` - Name of the network.
     * `create_time` - The date and time the object was initially created.
-* `location_name` - The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `location_name` - The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `status` - Status indicates the status of the object.
 * `private` - The object is private, the value will be true. Otherwise the value will be false.
 * `create_time` - The date and time the object was initially created.

--- a/website/docs/r/ipv4.html.md
+++ b/website/docs/r/ipv4.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_ipv4
 
-Provides an IPv4 address resource. This can be used to create, modify and delete IPv4 addresses.
+Provides an IPv4 address resource. This can be used to create, modify, and delete IPv4 addresses.
 
 ## Example Usage
 
@@ -16,7 +16,7 @@ The following example shows how one might use this resource to add an IPv4 addre
 
 ```terraform
 resource "gridscale_ipv4" "terra-ipv4-test" {
-	name = "terra-test"
+  name = "terra-test"
   timeouts {
       create="10m"
   }
@@ -27,22 +27,22 @@ resource "gridscale_ipv4" "terra-ipv4-test" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `failover` - (Optional) Sets failover mode for this IP. If true, then this IP is no longer available for DHCP and can no longer be related to any server.
 
-* `reverse_dns` - (Optional) Defines the reverse DNS entry for the IP Address (PTR Resource Record).
+* `reverse_dns` - (Optional) Defines the reverse DNS entry for the IP address (PTR Resource Record).
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 
@@ -53,7 +53,7 @@ This resource exports the following attributes:
 * `failover` - See Argument Reference above.
 * `reverse_dns` - See Argument Reference above.
 * `labels` - See Argument Reference above.
-* `ip` - Defines the IP Address.
+* `ip` - Defines the IP address.
 * `prefix` - The network address and the subnet.
 * `status` - status indicates the status of the object.
 * `create_time` - The time the object was created.

--- a/website/docs/r/ipv6.html.md
+++ b/website/docs/r/ipv6.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_ipv6
 
-Provides an IPv6 address resource. This can be used to create, modify and delete IPv6 addresses.
+Provides an IPv6 address resource. This can be used to create, modify, and delete IPv6 addresses.
 
 ## Example Usage
 
@@ -16,7 +16,7 @@ The following example shows how one might use this resource to add an IPv6 addre
 
 ```terraform
 resource "gridscale_ipv6" "terra-ipv6-test" {
-	name = "terra-test"
+  name = "terra-test"
   timeouts {
       create="10m"
   }
@@ -27,22 +27,22 @@ resource "gridscale_ipv6" "terra-ipv6-test" {
 
 The following arguments are supported:
 
-* `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Optional) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `failover` - (Optional) Sets failover mode for this IP. If true, then this IP is no longer available for DHCP and can no longer be related to any server.
 
-* `reverse_dns` - (Optional) Defines the reverse DNS entry for the IP Address (PTR Resource Record).
+* `reverse_dns` - (Optional) Defines the reverse DNS entry for the IP address (PTR Resource Record).
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 
@@ -53,7 +53,7 @@ This resource exports the following attributes:
 * `failover` - See Argument Reference above.
 * `reverse_dns` - See Argument Reference above.
 * `labels` - See Argument Reference above.
-* `ip` - Defines the IP Address.
+* `ip` - Defines the IP address.
 * `prefix` - The network address and the subnet.
 * `status` - status indicates the status of the object.
 * `create_time` - The time the object was created.

--- a/website/docs/r/isoimage.html.md
+++ b/website/docs/r/isoimage.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_isoimage
 
-Provides an ISO Image resource. This can be used to create, modify and delete ISO Images.
+Provides an ISO Image resource. This can be used to create, modify, and delete ISO Images.
 
 ## Example Usage
 
@@ -22,12 +22,11 @@ resource "gridscale_isoimage" "foo" {
 }
 ```
 
-
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `source_url` - (Required) Contains the source URL of the ISO Image that it was originally fetched from.
 
@@ -36,11 +35,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 
@@ -49,21 +48,21 @@ The following attributes are exported:
 * `name` - The name of the ISO Image.
 * `source_url` - Contains the source URL of the ISO Image that it was originally fetched from.
 * `server` - The information about servers which are related to this ISO Image.
-    * `object_uuid` - The object UUID or id of the server.
-    * `object_name` - Name of the server.
-    * `create_time` - The date and time the object was initially created.
-    * `bootdevice` - True if the ISO Image is a boot device of this server.
+  * `object_uuid` - The object UUID or id of the server.
+  * `object_name` - Name of the server.
+  * `create_time` - The date and time the object was initially created.
+  * `bootdevice` - True if the ISO Image is a boot device of this server.
 * `id` - The UUID of the ISO Image.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.
 * `location_country` - Formatted by the 2 digit country code (ISO 3166-2) of the host country.
 * `location_iata` - Uses IATA airport code, which works as a location identifier.
-* `location_name` - The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `location_name` - The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `status` - Status indicates the status of the object.
 * `version` - The version of the ISO Image.
 * `private` - The object is private, the value will be true. Otherwise the value will be false.
 * `create_time` - The date and time the object was initially created.
 * `change_time` - The date and time of the last object change.
-* `description` - Description of the Template.
+* `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/ISO Image/snapshot in GB.
 * `current_price` - Defines the price for the current period since the last bill.

--- a/website/docs/r/loadbalancer.html.md
+++ b/website/docs/r/loadbalancer.html.md
@@ -8,28 +8,28 @@ description: |-
 
 # gridscale_loadbalancer
 
-Provides a loadbalancer resource. This can be used to create, modify and delete loadbalancers.
+Provides a loadbalancer resource. This can be used to create, modify, and delete load balancers.
 
 ## Example Usage
 
 ```terraform
 resource "gridscale_loadbalancer" "foo" {
-	name   = "%s"
-	algorithm = "%s"
-	redirect_http_to_https = false
-	listen_ipv4_uuid = gridscale_ipv4.lb.id
-	listen_ipv6_uuid = gridscale_ipv6.lb.id
-	labels = []
-	backend_server {
-		weight = 100
-		host   = gridscale_ipv4.server.ip
-	}
-	forwarding_rule {
-		listen_port =  80
-		mode        =  "http"
-		target_port =  80
-	}
-	timeouts {
+  name   = "%s"
+  algorithm = "%s"
+  redirect_http_to_https = false
+  listen_ipv4_uuid = gridscale_ipv4.lb.id
+  listen_ipv6_uuid = gridscale_ipv6.lb.id
+  labels = []
+  backend_server {
+    weight = 100
+    host   = gridscale_ipv4.server.ip
+  }
+  forwarding_rule {
+    listen_port =  80
+    mode        =  "http"
+    target_port =  80
+  }
+  timeouts {
       create="10m"
   }
 }
@@ -39,13 +39,13 @@ resource "gridscale_loadbalancer" "foo" {
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
-* `redirect_http_to_https` - (Required) Whether the loadbalancer is forced to redirect requests from HTTP to HTTPS.
+* `redirect_http_to_https` - (Required) Whether the load balancer is forced to redirect requests from HTTP to HTTPS.
 
-* `listen_ipv4_uuid` - (Required) The UUID of the IPv4 address the loadbalancer will listen to for incoming requests.
+* `listen_ipv4_uuid` - (Required) The UUID of the IPv4 address the load balancer will listen to for incoming requests.
 
-* `listen_ipv6_uuid` - (Required) The UUID of the IPv6 address the loadbalancer will listen to for incoming requests.
+* `listen_ipv6_uuid` - (Required) The UUID of the IPv6 address the load balancer will listen to for incoming requests.
 
 * `algorithm` - (Required) The algorithm used to process requests. Accepted values: roundrobin/leastconn.
 
@@ -54,24 +54,24 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 
 This resource exports the following attributes:
 
-* `id` - The UUID of the loadbalancer.
+* `id` - The UUID of the load balancer.
 * `location_uuid` - Helps to identify which datacenter an object belongs to. The location of the resource depends on the location of the project.
-* `name` - The human-readable name of the loadbalancer.
+* `name` - The human-readable name of the load balancer.
 * `algorithm` - The algorithm used to process requests.
-* `status` - The status of the loadbalancer.
+* `status` - The status of the load balancer.
 * `redirect_http_to_https` - Whether the Load balancer is forced to redirect requests from HTTP to HTTPS.
-* `listen_ipv4_uuid` - The UUID of the IPv4 address the loadbalancer will listen to for incoming requests.
-* `listen_ipv6_uuid` - The UUID of the IPv6 address the loadbalancer will listen to for incoming requests.
-* `forwarding_rule` - The forwarding rules of the loadbalancer.
-* `backend_server` - The servers that the loadbalancer can communicate with.
+* `listen_ipv4_uuid` - The UUID of the IPv4 address the load balancer will listen to for incoming requests.
+* `listen_ipv6_uuid` - The UUID of the IPv6 address the load balancer will listen to for incoming requests.
+* `forwarding_rule` - The forwarding rules of the load balancer.
+* `backend_server` - The servers that the load balancer can communicate with.
 * `labels` - The list of labels.

--- a/website/docs/r/marketplaceApp.html.md
+++ b/website/docs/r/marketplaceApp.html.md
@@ -8,25 +8,26 @@ description: |-
 
 # gridscale_marketplace_application
 
-Provides a marketplace application resource. This can be used to create, modify and delete marketplace applications.
+Provides a marketplace application resource. This can be used to create, modify, and delete marketplace applications.
 
 ## Example Usage
 
 ```terraform
 resource "gridscale_marketplace_application" "foo" {
-	name = "example"
-	object_storage_path = "s3://testsnapshot/test.gz"
-	category = "Archiving"
-	setup_cores = 1
-	setup_memory = 1
-	setup_storage_capacity = 1
+  name = "example"
+  object_storage_path = "s3://testsnapshot/test.gz"
+  category = "Archiving"
+  setup_cores = 1
+  setup_memory = 1
+  setup_storage_capacity = 1
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `object_storage_path` - (Required) Path to the images for the application, must be in .gz format and started with s3//.
 
@@ -59,11 +60,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/marketplaceAppImport.html.md
+++ b/website/docs/r/marketplaceAppImport.html.md
@@ -14,18 +14,19 @@ Provides an imported marketplace application resource. This can be used to impor
 
 ```terraform
 resource "gridscale_marketplace_application" "foo" {
-	name = "example"
-	object_storage_path = "s3://testsnapshot/test.gz"
-	category = "Archiving"
-	setup_cores = 1
-	setup_memory = 1
-	setup_storage_capacity = 1
+  name = "example"
+  object_storage_path = "s3://testsnapshot/test.gz"
+  category = "Archiving"
+  setup_cores = 1
+  setup_memory = 1
+  setup_storage_capacity = 1
 }
 
 resource "gridscale_marketplace_application_import" "importedFoo" {
-	import_unique_hash = gridscale_marketplace_application.foo.unique_hash
+  import_unique_hash = gridscale_marketplace_application.foo.unique_hash
 }
 ```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -35,10 +36,10 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_network
 
-Provides a network resource. This can be used to create, modify and delete networks.
+Provides a network resource. This can be used to create, modify, and delete networks.
 
 ## Example Usage
 
@@ -16,7 +16,7 @@ The following example shows how one might use this resource to add a network to 
 
 ```terraform
 resource "gridscale_network" "networkname"{
-	name = "terraform-network"
+  name = "terraform-network"
   timeouts {
       create="10m"
   }
@@ -27,7 +27,7 @@ resource "gridscale_network" "networkname"{
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `l2security` - (Optional) Defines information about MAC spoofing protection (filters layer2 and ARP traffic based on MAC source). It can only be (de-)activated on a private network - the public network always has l2security enabled. It will be true if the network is public, and false if the network is private.
 
@@ -36,11 +36,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 

--- a/website/docs/r/objectstorage.html.md
+++ b/website/docs/r/objectstorage.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_object_storage_accesskey
 
-Provides an access key resource of an object storage. This can be used to create, modify and delete object storages' access keys. 
+Provides an access key resource of an object storage. This can be used to create, modify, and delete object storages' access keys.
 
 ## Example Usage
 
@@ -23,10 +23,10 @@ resource "gridscale_object_storage_accesskey" "foo" {
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_paas
 
-Provides a PaaS resource. This can be used to create, modify and delete PaaS.
+Provides a PaaS resource. This can be used to create, modify, and delete PaaS instances.
 
 ## Example
 
@@ -28,7 +28,7 @@ resource "gridscale_paas" "terra-paas-test" {
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `service_template_uuid` - (Required) The template used to create the service.
 
@@ -37,27 +37,27 @@ The following arguments are supported:
 * `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
 
 * `parameters` - (Optional) Contains the service parameters for the service.
-    
-    * `param` - (Required) Name of parameter.
 
-    * `value` - (Required) Value of the corresponding parameter.
-    
+  * `param` - (Required) Name of parameter.
+
+  * `value` - (Required) Value of the corresponding parameter.
+
 * `resource_limit` - (Optional) A list of service resource limits..
-    
-    * `resource` - (Required) The name of the resource you would like to cap.
 
-    * `limit` - (Required) The maximum number of the specific resource your service can use.
+  * `resource` - (Required) The name of the resource you would like to cap.
 
-    * `type` - (Required) Primitive type of the parameter: bool, int (better use float for int case), float, string.
+  * `limit` - (Required) The maximum number of the specific resource your service can use.
+
+  * `type` - (Required) Primitive type of the parameter: bool, int (better use float for int case), float, string.
 
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "15m" - 15 minutes) Used for Creating resource.
-* `update` - (Default value is "15m" - 15 minutes) Used for Updating resource.
-* `delete` - (Default value is "15m" - 15 minutes) Used for Deleteing resource.
+* `create` - (Default value is "15m" - 15 minutes) Used for creating a resource.
+* `update` - (Default value is "15m" - 15 minutes) Used for updating a resource.
+* `delete` - (Default value is "15m" - 15 minutes) Used for deleting a resource.
 
 ## Attributes
 
@@ -67,8 +67,8 @@ This resource exports the following attributes:
 * `username` - Username for PaaS service.
 * `password` - Password for PaaS service.
 * `listen_port` - Ports that PaaS service listens to.
-    * `name` - Name of a port.
-    * `listen_port` - Port number.
+  * `name` - Name of a port.
+  * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.
 * `service_template_uuid` - See Argument Reference above.
@@ -78,10 +78,10 @@ This resource exports the following attributes:
 * `create_time` - Time of the creation.
 * `status` - Current status of PaaS service.
 * `parameter` - See Argument Reference above.
-    * `param` - See Argument Reference above.
-    * `value` - See Argument Reference above.
-    * `type` - See Argument Reference above.
+  * `param` - See Argument Reference above.
+  * `value` - See Argument Reference above.
+  * `type` - See Argument Reference above.
 * `resource_limit` - See Argument Reference above.
-    * `resource` - See Argument Reference above.
-    * `limit` - See Argument Reference above.
+  * `resource` - See Argument Reference above.
+  * `limit` - See Argument Reference above.
 * `labels` - See Argument Reference above.

--- a/website/docs/r/securityzone.html.md
+++ b/website/docs/r/securityzone.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_paas_securityzone
 
-Provides a security zone resource. This can be used to create, modify and delete security zones. 
+Provides a security zone resource. This can be used to create, modify, and delete security zones.
 
 ## Example Usage
 
@@ -27,24 +27,24 @@ resource "gridscale_paas_securityzone" "foo" {
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `location_uuid` - (Optional) Helps to identify which datacenter an object belongs to.
 
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 
 This resource exports the following attributes:
 
 * `id` - The UUID of the security zone.
-* `name` - The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `location_uuid` - Helps to identify which datacenter an object belongs to.
 * `location_country` - The human-readable name of the location's country.
 * `location_iata` - Uses IATA airport code, which works as a location identifier.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -8,33 +8,33 @@ description: |-
 
 # gridscale_server
 
-Provides a server resource. This can be used to create, modify and delete servers.
+Provides a server resource. This can be used to create, modify, and delete servers.
 
 ## Example
 
 The following example shows how one might use this resource to add a server to gridscale:
 
 ```terraform
-resource "gridscale_server" "terra-server-test"{
-	name = "terra-server-test"
-	cores = 2
-	memory = 1
-	storage {
-		object_uuid = gridscale_storage.terra-storage-test.id
-	}
-	storage {
-    		object_uuid = "UUID of storage 2",
-    	}
-	network {
-		object_uuid = gridscale_network.terra-network-test.id
-		bootdevice = true
-	}
-	network {
-    		object_uuid = "UUID of network 2"
-    }
-	ipv4 = gridscale_ipv4.terra-ipv4-test.id}
-	ipv6 = "UUID of ipv6 address"
-	isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
+resource "gridscale_server" "terra-server-test" {
+  name = "terra-server-test"
+  cores = 2
+  memory = 1
+  storage {
+    object_uuid = gridscale_storage.terra-storage-test.id
+  }
+  storage {
+    object_uuid = "UUID of storage 2",
+  }
+  network {
+    object_uuid = gridscale_network.terra-network-test.id
+    bootdevice = true
+  }
+  network {
+    object_uuid = "UUID of network 2"
+  }
+  ipv4 = gridscale_ipv4.terra-ipv4-test.id}
+  ipv6 = "UUID of ipv6 address"
+  isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
     timeouts {
       create="10m"
   }
@@ -45,7 +45,7 @@ resource "gridscale_server" "terra-server-test"{
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `cores` - (Required) The number of server cores.
 
@@ -157,11 +157,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 
@@ -239,7 +239,7 @@ This resource exports the following attributes:
 * `availability_zone` - Defines which Availability-Zone the Server is placed.
 * `auto_recovery` - If the server should be auto-started in case of a failure.
 * `console_token` - The token used by the panel to open the websocket VNC connection to the server console.
-* `legacy` - Legacy-Hardware emulation instead of virtio hardware. If enabled, hotplugging cores, memory, storage, network, etc. will not work, but the server will most likely run every x86 compatible operating system. This mode comes with a performance penalty, as emulated hardware does not benefit from the virtio driver infrastructure.
+* `legacy` - Legacy-Hardware emulation instead of virtio hardware. If enabled, hot-plugging cores, memory, storage, network, etc. will not work, but the server will most likely run every x86 compatible operating system. This mode comes with a performance penalty, as emulated hardware does not benefit from the virtio driver infrastructure.
 * `status` - Status indicates the status of the object.
 * `usage_in_minutes_memory` - Total minutes of memory used.
 * `usage_in_minutes_cores` - Total minutes of cores used.

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_snapshot
 
-Provides a storage snapshot resource. This can be used to create, modify and delete storage snapshots.
+Provides a storage snapshot resource. This can be used to create, modify, and delete storage snapshots.
 
 ## Example Usage
 
@@ -17,6 +17,7 @@ resource "gridscale_storage" "foo" {
   name   = "storage"
   capacity = 1
 }
+
 resource "gridscale_snapshot" "foo" {
   name = "snapshot"
   storage_uuid = gridscale_storage.foo.id
@@ -38,7 +39,7 @@ The following arguments are supported:
 
 * `object_storage_export` - (Optional) Export snapshot to a object storage.
 
-    * `host` - (Required) Host of object storage. Must be of URL type. E.g: https://gos3.io
+    * `host` - (Required) Host of object storage. Must be of URL type, e.g., https://gos3.io
 
     * `access_key` - (Required) Access key.
 
@@ -50,18 +51,18 @@ The following arguments are supported:
 
     * `private` - (Required) Privacy.
 
-* `rollback` - (Optional) Returns a storage to the state of the selected Snapshot. 
+* `rollback` - (Optional) Returns a storage to the state of the selected Snapshot.
 
-    * `id` - (Required) ID of the rollback request. It can be any string value. Each rollback request has to have a UNIQUE id. 
+    * `id` - (Required) ID of the rollback request. It can be any string value. Each rollback request has to have a UNIQUE id.
 
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 
@@ -90,7 +91,7 @@ The following attributes are exported:
     * `private` - See Argument Reference above.
     * `status` - Status of the export request.
 * `rollback` - See Argument Reference above.
-    * `id` - See Argument Reference above. 
+    * `id` - See Argument Reference above.
     * `rollback_time` - The time when rollback request is fulfilled.
     * `status` - Status of the rollback request.
 * `labels` - See Argument Reference above.

--- a/website/docs/r/snapshotschedule.html.md
+++ b/website/docs/r/snapshotschedule.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_snapshotschedule
 
-Provides a storage snapshot schedule resource. This can be used to create, modify and delete snapshot schedules.
+Provides a storage snapshot schedule resource. This can be used to create, modify, and delete snapshot schedules.
 
 ## Example Usage
 
@@ -48,11 +48,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 
@@ -70,6 +70,6 @@ The following attributes are exported:
 * `change_time` - The date and time of the last snapshot schedule change.
 * `labels` - See Argument Reference above.
 * `snapshot` - Related snapshots.
-    * `name` - Name of the snapshot.
-    * `object_uuid` - UUID of the snapshot.
-    * `create_time` - The date and time the snapshot was initially created.
+  * `name` - Name of the snapshot.
+  * `object_uuid` - UUID of the snapshot.
+  * `create_time` - The date and time the snapshot was initially created.

--- a/website/docs/r/sshkey.html.md
+++ b/website/docs/r/sshkey.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_sshkey
 
-Provides an SSH public key resource. This can be used to create, modify and delete SSH public keys.
+Provides an SSH public key resource. This can be used to create, modify, and delete SSH public keys.
 
 ## Example Usage
 
@@ -16,11 +16,11 @@ The following example shows how one might use this resource to add an SSH public
 
 ```terraform
 resource "gridscale_sshkey" "sshkey-john"{
-	name = "john's computer"
-	sshkey = "an ssh public key"
-	timeouts {
-      create="10m"
-  	}
+  name = "john's computer"
+  sshkey = "an ssh public key"
+  timeouts {
+    create="10m"
+  }
 }
 ```
 
@@ -28,7 +28,7 @@ resource "gridscale_sshkey" "sshkey-john"{
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `sshkey` - (Required) This is the OpenSSH public key string (all key types are supported => ed25519, ecdsa, dsa, rsa, rsa1).
 
@@ -37,11 +37,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -8,26 +8,26 @@ description: |-
 
 # gridscale_storage
 
-Provides a storage resource. This can be used to create, modify and delete storages.
+Provides a storage resource. This can be used to create, modify, and delete storages.
 
 ## Example Usage
 
 The following example shows how one might use this resource to add a storage to gridscale:
 
 ```terraform
-resource "gridscale_storage" "storage-john"{
-	name = "john's storage"
-	capacity = 10
-	storage_type = "storage_high"
-	template {
-	    template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
-	    password = var.gridscale_password-john
-	    password_type = "plain"
-	    hostname = "Ubuntu"
-	}
-	timeouts {
-      create="10m"
-  	}
+resource "gridscale_storage" "storage-john" {
+  name = "john's storage"
+  capacity = 10
+  storage_type = "storage_high"
+  template {
+    template_uuid = "4db64bfc-9fb2-4976-80b5-94ff43b1233a"
+    password = var.gridscale_password-john
+    password_type = "plain"
+    hostname = "Ubuntu"
+  }
+  timeouts {
+    create="10m"
+  }
 }
 ```
 
@@ -35,7 +35,7 @@ resource "gridscale_storage" "storage-john"{
 
 The following arguments are supported:
 
-* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `capacity` - (Required) required (integer - minimum: 1 - maximum: 4096).
 
@@ -59,15 +59,14 @@ The following arguments are supported:
 
 ~> **Note** When using official templates using either a password and password_type or at least one SSH public key is required. This is not the case when using custom templates. For official templates password authentication for SSH is enabled by default, so be sure to pick a strong password.
 
-
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 

--- a/website/docs/r/storageclone.html.md
+++ b/website/docs/r/storageclone.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_storage_clone
 
-Clone a storage instance. This can be used to create, modify and delete the storage clones.
+Clone a storage instance. This can be used to create, modify, and delete the storage clones.
 
 ## Example Usage
 
@@ -16,20 +16,20 @@ The following example shows how to clone a storage instance in gridscale:
 
 ```terraform
 resource "gridscale_storage" "storage-john"{
-	name = "john's storage"
-	capacity = 10
-	storage_type = "storage_high"
-	timeouts {
-      create="10m"
-  	}
+  name = "john's storage"
+  capacity = 10
+  storage_type = "storage_high"
+  timeouts {
+    create="10m"
+  }
 }
 
 resource "gridscale_storage_clone" "storage-clone-john"{
-    source_storage_id = gridscale_storage.storage-clone-john.id
-	name = "john's storage clone"
-	timeouts {
-      create="10m"
-  	}
+  source_storage_id = gridscale_storage.storage-clone-john.id
+  name = "john's storage clone"
+  timeouts {
+    create="10m"
+  }
 }
 ```
 
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `source_storage_id` - (Required) The ID of a storage instance which will be cloned.
 
-* `name` - (Optional) The default value is inherited from the source storage instance. A desired name is possible. The human-readable name of the object. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `name` - (Optional) The default value is inherited from the source storage instance. A desired name is possible. The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
 * `capacity` - (Optional) The default value is inherited from the source storage instance. A desired capacity is possible. Required (integer - minimum: 1 - maximum: 4096).
 
@@ -47,15 +47,14 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes
 

--- a/website/docs/r/template.html.md
+++ b/website/docs/r/template.html.md
@@ -8,7 +8,7 @@ description: |-
 
 # gridscale_template
 
-Provides a template resource. This can be used to create, modify and delete template.
+Provides a template resource. This can be used to create, modify, and delete template.
 
 ## Example Usage
 
@@ -47,11 +47,11 @@ The following arguments are supported:
 ## Timeouts
 
 Timeouts configuration options (in seconds):
-More info: https://www.terraform.io/docs/configuration/resources.html#operation-timeouts
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
 
-* `create` - (Default value is "5m" - 5 minutes) Used for Creating resource.
-* `update` - (Default value is "5m" - 5 minutes) Used for Updating resource.
-* `delete` - (Default value is "5m" - 5 minutes) Used for Deleteing resource.
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
 
 ## Attributes Reference
 
@@ -62,7 +62,7 @@ The following attributes are exported:
 * `location_uuid` - Helps to identify which datacenter an object belongs to.
 * `location_country` - Formatted by the 2 digit country code (ISO 3166-2) of the host country.
 * `location_iata` - Uses IATA airport code, which works as a location identifier.
-* `location_name` - The human-readable name of the location. It supports the full UTF-8 charset, with a maximum of 64 characters.
+* `location_name` - The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `status` - Status indicates the status of the object.
 * `ostype` - The operating system installed in the template.
 * `version` - The version of the template.
@@ -70,8 +70,8 @@ The following attributes are exported:
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `create_time` - The date and time the object was initially created.
 * `change_time` - The date and time of the last object change.
-* `distro` - The OS distrobution that the Template contains.
-* `description` - Description of the Template.
+* `distro` - The OS distribution that the template contains.
+* `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/template/snapshot in GB.
 * `current_price` - Defines the price for the current period since the last bill.


### PR DESCRIPTION
Some work for docs at https://registry.terraform.io/providers/gridscale/gridscale/latest/docs after release.

- Fix typos, capitalization errors, wrong abbreviations
- Normalize white space in Terraform examples
- Also fix `Description` fields for data sources and resurces
