### PR TITLE
Fix ordering of network interface & fix firewall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.7.4 (Nov 03, 2020)
+
+IMPROVEMENTS:
+
+* Reword docs.
+* Add an example (and explanation) about firewall rules in server-network relation.
+* Explain how ordering of network interfaces works.
+
+BUG FIXES:
+
+* Fix ordering of network interfaces on the host is NOT the same as defined in the Terraform definition (top-down order). See [#99](https://github.com/gridscale/terraform-provider-gridscale/issues/99).
+* Enable firewall only when at least one firewall rule is set. In previous version, when no firewall rules are set, the default firewall rules are added. This makes all ports blocked. See [#100](https://github.com/gridscale/terraform-provider-gridscale/issues/100)
+
 ## 1.7.3 (Nov 02, 2020)
 
 BUG FIXES:

--- a/gridscale/firewall-utils/defaultRuleUtils.go
+++ b/gridscale/firewall-utils/defaultRuleUtils.go
@@ -4,6 +4,9 @@ import "github.com/gridscale/gsclient-go/v3"
 
 // AddDefaultFirewallInboundRules adds default fw rules
 func AddDefaultFirewallInboundRules(rules []gsclient.FirewallRuleProperties, forIPv6 bool) []gsclient.FirewallRuleProperties {
+	if len(rules) == 0 { // If no custom fw rules are added, no need to add default ones
+		return rules
+	}
 	srcCidr := "0.0.0.0/0"
 	DHCPDstPort := "67:68"
 	DHCPComment := "DHCP IPv4"

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -126,7 +126,7 @@ func (c *ServerRelationManger) LinkNetworks(ctx context.Context) error {
 	d := c.getData()
 	client := c.getGSClient()
 	if attrNetRel, ok := d.GetOk("network"); ok {
-		for _, value := range attrNetRel.(*schema.Set).List() {
+		for _, value := range attrNetRel.([]interface{}) {
 			network := value.(map[string]interface{})
 			//Read custom firewall rules from `network` property (field)
 			customFwRules := readCustomFirewallRules(network)
@@ -315,7 +315,7 @@ func (c *ServerRelationManger) UpdateNetworksRel(ctx context.Context) error {
 	if d.HasChange("network") {
 		oldNetworks, _ := d.GetChange("network")
 		//Unlink all old networks if there are any networks linked to the server
-		for _, value := range oldNetworks.(*schema.Set).List() {
+		for _, value := range oldNetworks.([]interface{}) {
 			network := value.(map[string]interface{})
 			if network["object_uuid"].(string) != "" {
 				//If 404 or 409, that means network is already deleted => the relation between network and server is deleted automatically

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -133,7 +133,7 @@ func resourceGridscaleServer() *schema.Resource {
 			},
 
 			"network": {
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 7,
 				Elem: &schema.Resource{

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -22,18 +22,14 @@ resource "gridscale_server" "terra-server-test" {
   storage {
     object_uuid = gridscale_storage.terra-storage-test.id
   }
-  storage {
-    object_uuid = "UUID of storage 2"
-  }
   network {
     object_uuid = gridscale_network.terra-network-test.id
     bootdevice = true
   }
   network {
-    object_uuid = "UUID of network 2"
+    object_uuid = gridscale_network.terra-network-test-2.id
   }
   ipv4 = gridscale_ipv4.terra-ipv4-test.id
-  ipv6 = "UUID of ipv6 address"
   isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
   timeouts {
       create="10m"
@@ -51,9 +47,6 @@ resource "gridscale_server" "terra-server-test" {
   memory = 1
   storage {
     object_uuid = gridscale_storage.terra-storage-test.id
-  }
-  storage {
-    object_uuid = "UUID of storage 2"
   }
   network {
     object_uuid = gridscale_network.terra-network-test.id
@@ -73,10 +66,9 @@ resource "gridscale_server" "terra-server-test" {
     }
   }
   network {
-    object_uuid = "UUID of network 2"
+    object_uuid = gridscale_network.terra-network-test-2.id
   }
   ipv4 = gridscale_ipv4.terra-ipv4-test.id
-  ipv6 = "UUID of ipv6 address"
   isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
   timeouts {
       create="10m"

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -23,7 +23,7 @@ resource "gridscale_server" "terra-server-test" {
     object_uuid = gridscale_storage.terra-storage-test.id
   }
   storage {
-    object_uuid = "UUID of storage 2",
+    object_uuid = "UUID of storage 2"
   }
   network {
     object_uuid = gridscale_network.terra-network-test.id
@@ -32,14 +32,58 @@ resource "gridscale_server" "terra-server-test" {
   network {
     object_uuid = "UUID of network 2"
   }
-  ipv4 = gridscale_ipv4.terra-ipv4-test.id}
+  ipv4 = gridscale_ipv4.terra-ipv4-test.id
   ipv6 = "UUID of ipv6 address"
   isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
-    timeouts {
+  timeouts {
       create="10m"
   }
 }
 ```
+
+**NOTE: If no firewall rules are set, the firewall is INACTIVE. If (a) firewall rule(s) is(are) set (the firewall is ACTIVE), 
+packets that do not match any rules are blocked by default. E.g:
+
+```terraform
+resource "gridscale_server" "terra-server-test" {
+  name = "terra-server-test"
+  cores = 2
+  memory = 1
+  storage {
+    object_uuid = gridscale_storage.terra-storage-test.id
+  }
+  storage {
+    object_uuid = "UUID of storage 2"
+  }
+  network {
+    object_uuid = gridscale_network.terra-network-test.id
+    rules_v4_in {
+        order = 0
+        protocol = "tcp"
+        action = "accept"
+        dst_port = "22"
+        comment = "ssh"
+    }
+    rules_v6_in	{
+        order = 1
+        protocol = "tcp"
+        action = "accept"
+        dst_port = "22"
+        comment = "ssh"
+    }
+  }
+  network {
+    object_uuid = "UUID of network 2"
+  }
+  ipv4 = gridscale_ipv4.terra-ipv4-test.id
+  ipv6 = "UUID of ipv6 address"
+  isoimage = "9be3e0a3-42ac-4207-8887-3383c405724d"
+  timeouts {
+      create="10m"
+  }
+}
+```
+In this case, the inbound packets that do not match 2 rules above will be blocked.
 
 ## Argument Reference
 
@@ -71,12 +115,11 @@ The following arguments are supported:
 
     * `object_uuid` - (Required) The object UUID or id of the storage.
 
-* `network` - (Optional) Connects a network to the server.
+* `network` - (Optional) Connects a network to the server. **NOTE: Ordering of network interfaces on the host is the same as defined in the Terraform definition (top-down order), if `ordering` is not set.
 
     * `object_uuid` - (Required) The object UUID or id of the network.
 
-    * `ordering` - (Optional) Defines the ordering of the network interfaces. Lower numbers have lower PCI-IDs. The default value is 0, that means the ordering will be automatically defined
-    by the gridscale's backend.
+    * `ordering` - (Optional) Defines the ordering of the network interfaces. Lower numbers have lower PCI-IDs.
 
     * `bootdevice` - (Optional, Computed) Make this network the boot device. This can only be set for one network.
 


### PR DESCRIPTION
Changes:
- Fix ordering of network interfaces on the host is NOT the same as defined in the Terraform definition (top-down order). See [#99](https://github.com/gridscale/terraform-provider-gridscale/issues/99).
- Enable firewall only when at least one firewall rule is set. In previous version, when no firewall rules are set, the default firewall rules are added. This makes all ports blocked. See [#100](https://github.com/gridscale/terraform-provider-gridscale/issues/100)
- Add an example (and explanation) about firewall rules in server-network relation to docs.
- Explain how ordering of network interfaces works in docs.