### PR TITLE
Add storage import feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-gridscale
 
 require (
 	github.com/google/uuid v1.1.2 // indirect
-	github.com/gridscale/gsclient-go/v3 v3.3.0
+	github.com/gridscale/gsclient-go/v3 v3.3.1
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/terraform-providers/terraform-provider-gridscale
 
 require (
 	github.com/google/uuid v1.1.2 // indirect
-	github.com/gridscale/gsclient-go/v3 v3.2.2
+	github.com/gridscale/gsclient-go/v3 v3.3.0
 	github.com/hashicorp/terraform-plugin-sdk v1.0.0
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	golang.org/x/sys v0.0.0-20201028094953-708e7fb298ac // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gridscale/gsclient-go/v3 v3.2.2 h1:ngvJle4yH72rCt6y3aBOkRpcN5Tl3QfUUpq4/0mFSTk=
-github.com/gridscale/gsclient-go/v3 v3.2.2/go.mod h1:hXZrJ+mDDcI2Xw+BhfrbYfiyA2xZNCDSOpB9XwEk19o=
+github.com/gridscale/gsclient-go/v3 v3.3.0 h1:uCO6+x2T3wb4lH9qT43FX+uiViemmzWYLu+SNpOYZR4=
+github.com/gridscale/gsclient-go/v3 v3.3.0/go.mod h1:hXZrJ+mDDcI2Xw+BhfrbYfiyA2xZNCDSOpB9XwEk19o=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gridscale/gsclient-go/v3 v3.3.0 h1:uCO6+x2T3wb4lH9qT43FX+uiViemmzWYLu+SNpOYZR4=
-github.com/gridscale/gsclient-go/v3 v3.3.0/go.mod h1:hXZrJ+mDDcI2Xw+BhfrbYfiyA2xZNCDSOpB9XwEk19o=
+github.com/gridscale/gsclient-go/v3 v3.3.1 h1:WXfncln3YkkC8wlLZ7UfI12O3T6DvFdPxOh1CGf1edE=
+github.com/gridscale/gsclient-go/v3 v3.3.1/go.mod h1:hXZrJ+mDDcI2Xw+BhfrbYfiyA2xZNCDSOpB9XwEk19o=
 github.com/hashicorp/errwrap v0.0.0-20180715044906-d6c0cd880357/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -60,6 +60,7 @@ func Provider() terraform.ResourceProvider {
 			"gridscale_server":                         resourceGridscaleServer(),
 			"gridscale_storage":                        resourceGridscaleStorage(),
 			"gridscale_storage_clone":                  resourceGridscaleStorageClone(),
+			"gridscale_storage_import":                 resourceGridscaleStorageImport(),
 			"gridscale_network":                        resourceGridscaleNetwork(),
 			"gridscale_ipv4":                           resourceGridscaleIpv4(),
 			"gridscale_ipv6":                           resourceGridscaleIpv6(),

--- a/gridscale/resource_gridscale_storage_import.go
+++ b/gridscale/resource_gridscale_storage_import.go
@@ -1,0 +1,165 @@
+package gridscale
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+
+	"github.com/gridscale/gsclient-go/v3"
+)
+
+func resourceGridscaleStorageImport() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGridscaleStorageImportFromBackup,
+		Read:   resourceGridscaleStorageRead,
+		Delete: resourceGridscaleStorageDelete,
+		Update: resourceGridscaleStorageUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"storage_backup_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				Description:  "ID of the storage backup that will be used to create a new storage from.",
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"name": {
+				Type:        schema.TypeString,
+				Description: "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+				Required:    true,
+			},
+			"capacity": {
+				Type:        schema.TypeInt,
+				Description: "The capacity of a storage in GB.",
+				Optional:    true,
+				Computed:    true,
+			},
+			"location_uuid": {
+				Type:        schema.TypeString,
+				Description: "Identifies the data center this object belongs to.",
+				Computed:    true,
+			},
+			"storage_type": {
+				Type:        schema.TypeString,
+				Description: "(one of storage, storage_high, storage_insane)",
+				Optional:    true,
+				Computed:    true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					valid := false
+					for _, stype := range storageTypes {
+						if v.(string) == stype {
+							valid = true
+							break
+						}
+					}
+					if !valid {
+						errors = append(errors, fmt.Errorf("%v is not a valid storage type. Valid types are: %v", v.(string), strings.Join(storageTypes, ",")))
+					}
+					return
+				},
+			},
+			"license_product_no": {
+				Type:        schema.TypeInt,
+				Description: "If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).",
+				Computed:    true,
+			},
+			"last_used_template": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"parent_uuid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "status indicates the status of the object.",
+				Computed:    true,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Description: "Defines the date and time the object was initially created.",
+				Computed:    true,
+			},
+			"change_time": {
+				Type:        schema.TypeString,
+				Description: "Defines the date and time of the last object change.",
+				Computed:    true,
+			},
+			"location_name": {
+				Type:        schema.TypeString,
+				Description: "The human-readable name of the location. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+				Computed:    true,
+			},
+			"location_country": {
+				Type:        schema.TypeString,
+				Description: "Formatted by the 2 digit country code (ISO 3166-2) of the host country.",
+				Computed:    true,
+			},
+			"location_iata": {
+				Type:        schema.TypeString,
+				Description: "Uses IATA airport code, which works as a location identifier.",
+				Computed:    true,
+			},
+			"current_price": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+			"usage_in_minutes": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"labels": {
+				Type:        schema.TypeSet,
+				Description: "List of labels.",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+	}
+}
+
+func resourceGridscaleStorageImportFromBackup(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	storageBackupID := d.Get("storage_backup_id").(string)
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
+	defer cancel()
+	response, err := client.CreateStorageFromBackup(ctx, storageBackupID, d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(response.ObjectUUID)
+
+	log.Printf("A new storage %s has been created from backup %s", response.ObjectUUID, storageBackupID)
+
+	// If the user wants a new storage type and new capacity for the storage clone
+	// instead of the default values inherited from the storage backup,
+	// change storage type and capacity of the storage clone to the desired ones.
+	newStorage, err := client.GetStorage(ctx, response.ObjectUUID)
+	if err != nil {
+		return err
+	}
+	if newStorage.Properties.Capacity != d.Get("capacity").(int) ||
+		newStorage.Properties.StorageType != d.Get("storage_type").(string) {
+		err = resourceGridscaleStorageUpdate(d, meta)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceGridscaleStorageRead(d, meta)
+}

--- a/website/docs/r/storageimport.html.md
+++ b/website/docs/r/storageimport.html.md
@@ -1,0 +1,67 @@
+---
+layout: "gridscale"
+page_title: "gridscale: gridscale_storage_import"
+sidebar_current: "docs-gridscale-resource-storage-import"
+description: |-
+  Make a clone of an existing storage instance.
+---
+
+# gridscale_storage_import
+
+Create a new storage via a storage backup. This can be used to create, modify, and delete the imported storages.
+
+## Example Usage
+
+The following example shows how to clone a storage instance in gridscale:
+
+```terraform
+resource "gridscale_storage_import" "foo" {
+  storage_backup_id   = "xxx-xxx-xxx-xxx-xxx"
+  name = "imported storage"
+  storage_type = "storage_high"
+  capacity = 20
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `storage_backup_id` - (Required) ID of the storage backup that will be used to create a new storage from.
+
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+
+* `capacity` - (Optional) The default value is inherited from the source storage instance. A desired capacity is possible. Required (integer - minimum: 1 - maximum: 4096).
+
+* `storage_type` - (Optional) The default value is inherited from the source storage instance. A desired storage type is possible. (one of storage, storage_high, storage_insane).
+
+* `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+## Timeouts
+
+Timeouts configuration options (in seconds):
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
+
+* `create` - (Default value is "5m" - 5 minutes) Used for creating a resource.
+* `update` - (Default value is "5m" - 5 minutes) Used for updating a resource.
+* `delete` - (Default value is "5m" - 5 minutes) Used for deleting a resource.
+
+## Attributes
+
+This resource exports the following attributes:
+
+* `name` - See Argument Reference above.
+* `capacity` - See Argument Reference above.
+* `storage_type` - See Argument Reference above.
+* `location_uuid` - Helps to identify which datacenter an object belongs to. The location of the resource depends on the location of the project.
+* `labels` - See Argument Reference above.
+* `status` - status indicates the status of the object.
+* `create_time` - The time the object was created.
+* `change_time` - Defines the date and time of the last object change.
+* `location_country` - Formatted by the 2 digit country code (ISO 3166-2) of the host country.
+* `location_iata` - Uses IATA airport code, which works as a location identifier.
+* `location_name` - The location name.
+* `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
+* `last_used_template` - Indicates the UUID of the last used template on this storage (inherited from snapshots).
+* `usage_in_minutes` - The amount of minutes the IP address has been in use.
+* `current_price` - The price for the current period since the last bill.

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -116,6 +116,9 @@
             <li<%= sidebar_current("docs-gridscale-resource-storage-clone") %>>
               <a href="/docs/providers/gridscale/r/storageclone.html">gridscale_storage_clone</a>
             </li>
+            <li<%= sidebar_current("docs-gridscale-resource-storage-import") %>>
+              <a href="/docs/providers/gridscale/r/storageimport.html">gridscale_storage_import</a>
+            </li>
             <li<%= sidebar_current("docs-gridscale-resource-template") %>>
               <a href="/docs/providers/gridscale/r/template.html">gridscale_template</a>
             </li>


### PR DESCRIPTION
- Update gsclient-go v3.3.0.
- Add storage import (from storage backups) feature.
- Update docs.
Note: there is no acceptance test since the storage backup can only be created by a backup schedule.