### PR TITLE
Trim space of ssh pub key before storing it to state

### DIFF
--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -34,6 +34,9 @@ func resourceGridscaleSshkey() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "sshkey_string is the OpenSSH public key string (all key types are supported => ed25519, ecdsa, dsa, rsa, rsa1)",
 				Required:    true,
+				StateFunc: func(val interface{}) string {
+					return strings.TrimSpace((val.(string)))
+				},
 			},
 			"status": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
- Solve issue #116 
This will make sure there are no diff if the same ssh pub key is set, and one of the updates has some leading/trailing space. 
e.g. "sshpubkey" is the previous value. If the value is "  sshpubkey \n ", tf will not trigger update.