### PR TITLE
Fix inconsistency issue of PaaS service resource, when the resource is updated outside of terraform

### DIFF
--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -41,6 +41,11 @@ func resourceGridscalePaaS() *schema.Resource {
 				Description: "Password for PaaS service",
 				Computed:    true,
 			},
+			"kubeconfig": {
+				Type:        schema.TypeString,
+				Description: "K8s config data",
+				Computed:    true,
+			},
 			"listen_port": {
 				Type:        schema.TypeSet,
 				Description: "Ports that PaaS service listens to",
@@ -196,6 +201,9 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 		}
 		if err = d.Set("password", creds[0].Password); err != nil {
 			return fmt.Errorf("%s error setting password: %v", errorPrefix, err)
+		}
+		if err = d.Set("kubeconfig", creds[0].KubeConfig); err != nil {
+			return fmt.Errorf("%s error setting kubeconfig: %v", errorPrefix, err)
 		}
 	}
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -76,6 +76,11 @@ func resourceGridscalePaaS() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,
 			},
+			"service_template_uuid_computed": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Template that PaaS service uses. The `service_template_uuid_computed` will be different from `service_template_uuid`, when `service_template_uuid` is updated outside of terraform.",
+			},
 			"usage_in_minute": {
 				Type:        schema.TypeInt,
 				Description: "Number of minutes that PaaS service is in use",
@@ -196,8 +201,8 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
-	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
-		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	if err = d.Set("service_template_uuid_computed", props.ServiceTemplateUUID); err != nil {
+		return fmt.Errorf("%s error setting service_template_uuid_computed: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minute", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minute: %v", errorPrefix, err)

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -344,9 +344,13 @@ func resourceGridscalePaaSServiceUpdate(d *schema.ResourceData, meta interface{}
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
-		Name:                    d.Get("name").(string),
-		Labels:                  &labels,
-		PaaSServiceTemplateUUID: d.Get("service_template_uuid").(string),
+		Name:   d.Get("name").(string),
+		Labels: &labels,
+	}
+
+	// Only update service_template_uuid, when it is changed
+	if d.HasChange("service_template_uuid") {
+		requestBody.PaaSServiceTemplateUUID = d.Get("service_template_uuid").(string)
 	}
 
 	params := make(map[string]interface{}, 0)

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -72,6 +72,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.
 * `service_template_uuid` - See Argument Reference above.
+* `service_template_uuid_computed` - Template that PaaS service uses. The `service_template_uuid_computed` will be different from `service_template_uuid`, when `service_template_uuid` is updated outside of terraform.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.
 * `current_price` - Current price of PaaS service.
 * `change_time` - Time of the last change.


### PR DESCRIPTION
Solved #123. The changes that happen outside of tf will be discarded by tf (tf will says "no change", if we type `terraform plan` or `terraform apply`). Changes:
- Add `service_template_uuid_computed` field.
- Update PaaS docs.
- Add a missing field "kubeconfig" to paas service resource.