### PR TITLE
fix `gridscale_backupschedule` and `gridscale_snapshotschedule` resources force to update `next_runtime` when updating other fields

### DIFF
--- a/gridscale/resource_gridscale_backup_schedule.go
+++ b/gridscale/resource_gridscale_backup_schedule.go
@@ -202,15 +202,18 @@ func resourceGridscaleBackupScheduleUpdate(d *schema.ResourceData, meta interfac
 	}
 	active := d.Get("active").(bool)
 	requestBody.Active = &active
-	nextRuntime, err := time.Parse(timeLayout, d.Get("next_runtime").(string))
-	if err != nil {
-		return fmt.Errorf("%s error: %v", errorPrefix, err)
+
+	if d.HasChange("next_runtime") {
+		nextRuntime, err := time.Parse(timeLayout, d.Get("next_runtime").(string))
+		if err != nil {
+			return fmt.Errorf("%s error: %v", errorPrefix, err)
+		}
+		requestBody.NextRuntime = &gsclient.GSTime{Time: nextRuntime}
 	}
-	requestBody.NextRuntime = &gsclient.GSTime{Time: nextRuntime}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
 	defer cancel()
-	err = client.UpdateStorageBackupSchedule(ctx, storageUUID, d.Id(), requestBody)
+	err := client.UpdateStorageBackupSchedule(ctx, storageUUID, d.Id(), requestBody)
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -208,12 +208,15 @@ func resourceGridscaleSnapshotScheduleUpdate(d *schema.ResourceData, meta interf
 		RunInterval:   d.Get("run_interval").(int),
 		KeepSnapshots: d.Get("keep_snapshots").(int),
 	}
-	if strings.TrimSpace(d.Get("next_runtime").(string)) != "" {
-		nextRuntime, err := time.Parse(timeLayout, d.Get("next_runtime").(string))
-		if err != nil {
-			return fmt.Errorf("%s error: %v", errorPrefix, err)
+
+	if d.HasChange("next_runtime") {
+		if strings.TrimSpace(d.Get("next_runtime").(string)) != "" {
+			nextRuntime, err := time.Parse(timeLayout, d.Get("next_runtime").(string))
+			if err != nil {
+				return fmt.Errorf("%s error: %v", errorPrefix, err)
+			}
+			requestBody.NextRuntime = &gsclient.GSTime{Time: nextRuntime}
 		}
-		requestBody.NextRuntime = &gsclient.GSTime{Time: nextRuntime}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))


### PR DESCRIPTION
Fix issue #126 (and the same issue happening with `gridscale_snapshotschedule`). Changes:
- In `resourceGridscale...ScheduleUpdate` function, check if `d.HasChange("next_runtime")` is true. If it is true, add `next_runtime` to the body of the update request.