### PR TITLE
Fix network ordering causing server resource update

### DIFF
--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -174,7 +174,7 @@ func readCustomFirewallRules(netData map[string]interface{}) gsclient.FirewallRu
 		//Check if the firewall rule type is declared in the current network
 		if rulesInTypeAttr, ok := netData[ruleType]; ok {
 			//Loop through all rules in the current firewall type
-			for _, rulesInType := range rulesInTypeAttr.([]interface{}) {
+			for _, rulesInType := range rulesInTypeAttr.(*schema.Set).List() {
 				ruleProps := rulesInType.(map[string]interface{})
 				ruleProperties := gsclient.FirewallRuleProperties{
 					DstPort: ruleProps["dst_port"].(string),

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -192,6 +192,11 @@ func resourceGridscaleServer() *schema.Resource {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
+						"ordering_computed": {
+							Type:        schema.TypeInt,
+							Computed:    true,
+							Description: "The ordering of the networks set by gridscale backend (if the ordering is not specified by the user)",
+						},
 						"create_time": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -529,6 +534,7 @@ func readServerNetworkRels(serverNetRels []gsclient.ServerNetworkRelationPropert
 			"firewall_template_uuid": rel.FirewallTemplateUUID,
 			"object_name":            rel.ObjectName,
 			"network_type":           rel.NetworkType,
+			"ordering_computed":      rel.Ordering,
 		}
 		//Init all types of firewall rule
 		v4InRuleProps := make([]interface{}, 0)

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -531,7 +531,6 @@ func readServerNetworkRels(serverNetRels []gsclient.ServerNetworkRelationPropert
 			"firewall_template_uuid": rel.FirewallTemplateUUID,
 			"object_name":            rel.ObjectName,
 			"network_type":           rel.NetworkType,
-			"ordering":               rel.Ordering,
 		}
 		//Init all types of firewall rule
 		v4InRuleProps := make([]interface{}, 0)

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -190,7 +191,6 @@ func resourceGridscaleServer() *schema.Resource {
 						"ordering": {
 							Type:     schema.TypeInt,
 							Optional: true,
-							Default:  0,
 						},
 						"create_time": {
 							Type:     schema.TypeString,
@@ -514,6 +514,13 @@ func resourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) error
 
 //readServerNetworkRels extract relationships between server and networks
 func readServerNetworkRels(serverNetRels []gsclient.ServerNetworkRelationProperties) []interface{} {
+	// Sort the server-network relation slice by order
+	sort.Slice(serverNetRels, func(i, j int) bool {
+		return serverNetRels[i].Ordering < serverNetRels[j].Ordering
+	})
+	for _, v := range serverNetRels {
+		log.Println("serverNetRels", v.ObjectUUID, v.Ordering)
+	}
 	networks := make([]interface{}, 0)
 	for _, rel := range serverNetRels {
 		network := map[string]interface{}{

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -157,28 +157,28 @@ func resourceGridscaleServer() *schema.Resource {
 							Computed: true,
 						},
 						"rules_v4_in": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: getFirewallRuleCommonSchema(),
 							},
 						},
 						"rules_v4_out": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: getFirewallRuleCommonSchema(),
 							},
 						},
 						"rules_v6_in": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: getFirewallRuleCommonSchema(),
 							},
 						},
 						"rules_v6_out": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: getFirewallRuleCommonSchema(),

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -518,9 +518,7 @@ func readServerNetworkRels(serverNetRels []gsclient.ServerNetworkRelationPropert
 	sort.Slice(serverNetRels, func(i, j int) bool {
 		return serverNetRels[i].Ordering < serverNetRels[j].Ordering
 	})
-	for _, v := range serverNetRels {
-		log.Println("serverNetRels", v.ObjectUUID, v.Ordering)
-	}
+
 	networks := make([]interface{}, 0)
 	for _, rel := range serverNetRels {
 		network := map[string]interface{}{

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -227,6 +227,7 @@ This resource exports the following attributes:
     * `bootdevice` - Make this network the boot device. This can only be set for one network.
     * `object_name` - Name of the network.
     * `ordering` - Defines the ordering of the network interfaces. Lower numbers have lower PCI-IDs.
+    * `ordering_computed` - The ordering of the networks set by gridscale backend (if the ordering is not specified by the user).
     * `create_time` - Defines the date and time the object was initially created.
     * `network_type` - One of network, network_high, network_insane.
     * `mac` - network_mac defines the MAC address of the network interface.


### PR DESCRIPTION
Fix network ordering causing server resource update (when mult. networks are attached to a server). Ref #142. Changes:
- Add `ordering_computed` field.
- Stop write `ordering` info of a network-server relation to `ordering` (instead, write to `ordering_computed`).
- Update docs of server resource.
- Type of fw rule list is changed to TypeSet.

@bkircher I really want to add deprecation note for `ordering` field, since I want to use the ordering defined in the tf file instead of in the field `ordering`. What do you think?