### PR TITLE
Do not use "default" hardware profile

### DIFF
--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -58,7 +58,7 @@ func resourceGridscaleServer() *schema.Resource {
 				Description: "The number of server cores.",
 				Optional:    true,
 				ForceNew:    true,
-				Default:     "default",
+				Computed:    true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					valid := false
 					for _, profile := range hardwareProfiles {
@@ -604,21 +604,29 @@ func resourceGridscaleServerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	profile := d.Get("hardware_profile").(string)
-	if profile == "legacy" {
+	switch profile {
+	case string(gsclient.LegacyServerHardware):
 		requestBody.HardwareProfile = gsclient.LegacyServerHardware
-	} else if profile == "nested" {
+
+	case string(gsclient.NestedServerHardware):
 		requestBody.HardwareProfile = gsclient.NestedServerHardware
-	} else if profile == "cisco_csr" {
+
+	case string(gsclient.CiscoCSRServerHardware):
 		requestBody.HardwareProfile = gsclient.CiscoCSRServerHardware
-	} else if profile == "sophos_utm" {
+
+	case string(gsclient.SophosUTMServerHardware):
 		requestBody.HardwareProfile = gsclient.SophosUTMServerHardware
-	} else if profile == "f5_bigip" {
+
+	case string(gsclient.F5BigipServerHardware):
 		requestBody.HardwareProfile = gsclient.F5BigipServerHardware
-	} else if profile == "q35" {
+
+	case string(gsclient.Q35ServerHardware):
 		requestBody.HardwareProfile = gsclient.Q35ServerHardware
-	} else if profile == "q35_nested" {
+
+	case string(gsclient.Q35NestedServerHardware):
 		requestBody.HardwareProfile = gsclient.Q35NestedServerHardware
-	} else {
+
+	case string(gsclient.DefaultServerHardware):
 		requestBody.HardwareProfile = gsclient.DefaultServerHardware
 	}
 

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional) If the server should be auto-started in case of a failure (default=true).
 
-* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. When `hardware_profile` is not set, the hard profile is set to "q35".
+* `hardware_profile` - (Optional, ForceNew) The hardware profile of the server. Possible values are q35, default, legacy, nested, cisco_csr, sophos_utm, and f5_bigip. When not set, the profile used for the server is 'q35' which is almost always what you want. A change necessitates the re-creation of the resource.
 
 * `ipv4` - (Optional) The UUID of the IPv4 address of the server. (***NOTE: The server will NOT automatically be connected to the public network; to give it access to the internet, please add server to the public network.)
 

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional) If the server should be auto-started in case of a failure (default=true).
 
-* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. Check the
+* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. When `hardware_profile` is not set, the hard profile is set to "q35".
 
 * `ipv4` - (Optional) The UUID of the IPv4 address of the server. (***NOTE: The server will NOT automatically be connected to the public network; to give it access to the internet, please add server to the public network.)
 


### PR DESCRIPTION
Ref #141 . The server's field `hardware_profile` is now computed. The property `Default` of the field is removed, so that if `hardware_profile` is empty (not set), the default hardware profile will be determined by the gridscale backend (which is `q35` at the moment of writing). Back-compat is kept. However, @bkircher @itakouna  please test on your machines to make sure the back-compat works as expected.
Changes:
- Update server rs docs.
- Remove property `Default` of field `hardware_profile` in server rs.
- Set field `hardware_profile` to be `computed`.