### PR TITLE
Add MS SQL server resource

### DIFF
--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -1,0 +1,40 @@
+name: Test MS SQL rs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**.go"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "**gridscale_mssql**"
+      - "gridscale/error-handler/**"
+      - "gridscale/common.go"
+      - "gridscale/config.go"
+      - "gridscale/provider.go"
+      - "gridscale/provider_test.go"
+
+jobs:
+  build:
+    name: GS PostgreSQLAccTest
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+      GRIDSCALE_UUID: ${{ secrets.CI_USER_UUID }}
+      GRIDSCALE_TOKEN: ${{ secrets.CI_API_TOKEN }}
+      GRIDSCALE_URL: https://api.gridscale.cloud
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run TestAccResourceGridscaleMSSQLServer_Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMSSQLServer_Basic'

--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -18,6 +18,7 @@ var firewallActionTypes = []string{"accept", "drop"}
 var firewallRuleProtocols = []string{"udp", "tcp"}
 var marketplaceAppCategories = []string{"CMS", "project management", "Adminpanel", "Collaboration", "Cloud Storage", "Archiving"}
 var postgreSQLPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
+var msSQLServerPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
 
 const timeLayout = "2006-01-02 15:04:05"
 const (

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -92,7 +92,7 @@ func Provider() *schema.Provider {
 			"gridscale_k8s":                            resourceGridscaleK8s(),
 			"gridscale_paas_securityzone":              resourceGridscalePaaSSecurityZone(),
 			"gridscale_postgresql":                     resourceGridscalePostgreSQL(),
-			"gridscale_sqlserver":                      resourceGridscaleMSSQLServer(),
+			"gridscale_mssql":                          resourceGridscaleMSSQLServer(),
 			"gridscale_object_storage_accesskey":       resourceGridscaleObjectStorage(),
 			"gridscale_template":                       resourceGridscaleTemplate(),
 			"gridscale_isoimage":                       resourceGridscaleISOImage(),

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -92,6 +92,7 @@ func Provider() *schema.Provider {
 			"gridscale_k8s":                            resourceGridscaleK8s(),
 			"gridscale_paas_securityzone":              resourceGridscalePaaSSecurityZone(),
 			"gridscale_postgresql":                     resourceGridscalePostgreSQL(),
+			"gridscale_sqlserver":                      resourceGridscaleMSSQLServer(),
 			"gridscale_object_storage_accesskey":       resourceGridscaleObjectStorage(),
 			"gridscale_template":                       resourceGridscaleTemplate(),
 			"gridscale_isoimage":                       resourceGridscaleISOImage(),

--- a/gridscale/resource_gridscale_mssql.go
+++ b/gridscale/resource_gridscale_mssql.go
@@ -35,7 +35,7 @@ func resourceGridscaleMSSQLServer() *schema.Resource {
 			},
 			"release": {
 				Type: schema.TypeString,
-				Description: `The MSSQLServer release of this instance.\n
+				Description: `The MS SQL Server release of this instance.\n
 				For convenience, please use gscloud https://github.com/gridscale/gscloud to get the list of available MS SQL Server releases.`,
 				Required:     true,
 				ValidateFunc: validation.NoZeroValues,

--- a/gridscale/resource_gridscale_mssql.go
+++ b/gridscale/resource_gridscale_mssql.go
@@ -350,7 +350,7 @@ func resourceGridscaleMSSQLServerUpdate(d *schema.ResourceData, meta interface{}
 		Labels: &labels,
 	}
 
-	// Only update templateUUID, when `release` is changed
+	// Only update templateUUID, when `release` or `performance_class` is changed.
 	if d.HasChange("performance_class") || d.HasChange("release") {
 		// get ms sql template UUID
 		release := d.Get("release").(string)

--- a/gridscale/resource_gridscale_mssql.go
+++ b/gridscale/resource_gridscale_mssql.go
@@ -1,0 +1,337 @@
+package gridscale
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
+
+	"log"
+)
+
+const msSQLTemplateFlavourName = "mssql"
+
+func resourceGridscaleMSSQLServer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGridscaleMSSQLServerCreate,
+		Read:   resourceGridscaleMSSQLServerRead,
+		Delete: resourceGridscaleMSSQLServerDelete,
+		Update: resourceGridscaleMSSQLServerUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"release": {
+				Type: schema.TypeString,
+				Description: `The MSSQLServer release of this instance.\n
+				For convenience, please use gscloud https://github.com/gridscale/gscloud to get the list of available MS SQL Server releases.`,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"performance_class": {
+				Type:        schema.TypeString,
+				Description: "Performance class of MS SQL Server.",
+				Required:    true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					valid := false
+					for _, class := range msSQLServerPerformanceClasses {
+						if v.(string) == class {
+							valid = true
+							break
+						}
+					}
+					if !valid {
+						errors = append(errors, fmt.Errorf("%v is not a valid MS SQL Server performance class. Valid values are: %v", v.(string), strings.Join(postgreSQLPerformanceClasses, ",")))
+					}
+					return
+				},
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Description: "Username for MS SQL Server . It is used to connect to the MS SQL Server instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Description: "Password for MS SQL Server. It is used to connect to the MS SQL Server instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"listen_port": {
+				Type:        schema.TypeSet,
+				Description: "The port numbers where this MS SQL Server accepts connections.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"security_zone_uuid": {
+				Type:        schema.TypeString,
+				Description: "Security zone UUID linked to MS SQL Server.",
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+			},
+			"network_uuid": {
+				Type:        schema.TypeString,
+				Description: "Network UUID containing security zone.",
+				Computed:    true,
+			},
+			"service_template_uuid": {
+				Type:        schema.TypeString,
+				Description: "PaaS service template that MS SQL Server uses.",
+				Computed:    true,
+			},
+			"usage_in_minutes": {
+				Type:        schema.TypeInt,
+				Description: "Number of minutes that MS SQL Server is in use.",
+				Computed:    true,
+			},
+			"change_time": {
+				Type:        schema.TypeString,
+				Description: "Time of the last change.",
+				Computed:    true,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Description: "Date time this service has been created.",
+				Computed:    true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "Current status of MS SQL Server.",
+				Computed:    true,
+			},
+			"labels": {
+				Type:        schema.TypeSet,
+				Description: "List of labels.",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+	}
+}
+
+func resourceGridscaleMSSQLServerRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	paas, err := client.GetPaaSService(context.Background(), d.Id())
+	if err != nil {
+		if requestError, ok := err.(gsclient.RequestError); ok {
+			if requestError.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	props := paas.Properties
+	creds := props.Credentials
+	if err = d.Set("name", props.Name); err != nil {
+		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
+	}
+	if len(creds) > 0 {
+		if err = d.Set("username", creds[0].Username); err != nil {
+			return fmt.Errorf("%s error setting username: %v", errorPrefix, err)
+		}
+		if err = d.Set("password", creds[0].Password); err != nil {
+			return fmt.Errorf("%s error setting password: %v", errorPrefix, err)
+		}
+	}
+	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
+		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
+		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
+		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
+	}
+	if err = d.Set("change_time", props.ChangeTime.String()); err != nil {
+		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("create_time", props.CreateTime.String()); err != nil {
+		return fmt.Errorf("%s error setting create_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("status", props.Status); err != nil {
+		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
+	}
+
+	//Get listen ports
+	listenPorts := make([]interface{}, 0)
+	for _, value := range props.ListenPorts {
+		for k, portValue := range value {
+			port := map[string]interface{}{
+				"name": k,
+				"port": portValue,
+			}
+			listenPorts = append(listenPorts, port)
+		}
+	}
+	if err = d.Set("listen_port", listenPorts); err != nil {
+		return fmt.Errorf("%s error setting listen ports: %v", errorPrefix, err)
+	}
+
+	//Get core count's limit
+	for _, value := range props.ResourceLimits {
+		if value.Resource == "cores" {
+			if err = d.Set("max_core_count", value.Limit); err != nil {
+				return fmt.Errorf("%s error setting max_core_count: %v", errorPrefix, err)
+			}
+		}
+	}
+
+	//Set labels
+	if err = d.Set("labels", props.Labels); err != nil {
+		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
+	}
+
+	//Get all available networks
+	networks, err := client.GetNetworkList(context.Background())
+	if err != nil {
+		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
+	}
+	//look for a network that the MSSQLServer service is in
+	for _, network := range networks {
+		securityZones := network.Properties.Relations.PaaSSecurityZones
+		//Each network can contain only one security zone
+		if len(securityZones) >= 1 {
+			if securityZones[0].ObjectUUID == props.SecurityZoneUUID {
+				if err = d.Set("network_uuid", network.Properties.ObjectUUID); err != nil {
+					return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func resourceGridscaleMSSQLServerCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+
+	// Validate ms sql release
+	templateUUID, err := validateMSSQLRelease(client, d)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+
+	requestBody := gsclient.PaaSServiceCreateRequest{
+		Name:                    d.Get("name").(string),
+		PaaSServiceTemplateUUID: templateUUID,
+		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
+		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
+	defer cancel()
+	response, err := client.CreatePaaSService(ctx, requestBody)
+	if err != nil {
+		return err
+	}
+	d.SetId(response.ObjectUUID)
+	log.Printf("The id for MSSQLServer service %s has been set to %v", requestBody.Name, response.ObjectUUID)
+	return resourceGridscaleMSSQLServerRead(d, meta)
+}
+
+func resourceGridscaleMSSQLServerUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+
+	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
+	requestBody := gsclient.PaaSServiceUpdateRequest{
+		Name:   d.Get("name").(string),
+		Labels: &labels,
+	}
+
+	// Only update templateUUID, when `release` is changed
+	if d.HasChange("release") {
+		// Validate the ms sql release
+		templateUUID, err := validateMSSQLRelease(client, d)
+		if err != nil {
+			return fmt.Errorf("%s error: %v", errorPrefix, err)
+		}
+		requestBody.PaaSServiceTemplateUUID = templateUUID
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
+	defer cancel()
+	err := client.UpdatePaaSService(ctx, d.Id(), requestBody)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return resourceGridscaleMSSQLServerRead(d, meta)
+}
+
+func resourceGridscaleMSSQLServerDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	defer cancel()
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeletePaaSService(ctx, d.Id()),
+		http.StatusNotFound,
+	)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return nil
+}
+
+// validateMSSQLRelease validate input ms SQL release.
+// It returns the UUID of the ms SQL service template, if the validation is successful.
+// Otherwise, an error will be returned.
+func validateMSSQLRelease(client *gsclient.Client, d *schema.ResourceData) (string, error) {
+	paasTemplates, err := client.GetPaaSTemplateList(context.Background())
+	if err != nil {
+		return "", err
+	}
+	// Check if the postgres release number exists
+	release := d.Get("release").(string)
+	performanceClass := d.Get("performance_class").(string)
+	var isReleaseValid bool
+	var releases []string
+	var uTemplate gsclient.PaaSTemplate
+	for _, template := range paasTemplates {
+		if template.Properties.Flavour == msSQLTemplateFlavourName {
+			releases = append(releases, template.Properties.Release)
+			if template.Properties.Release == release && template.Properties.PerformanceClass == performanceClass {
+				isReleaseValid = true
+				uTemplate = template
+			}
+		}
+	}
+	if !isReleaseValid {
+		return "", fmt.Errorf("%v is not a valid MS SQL Server release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+	}
+
+	return uTemplate.Properties.ObjectUUID, nil
+}

--- a/gridscale/resource_gridscale_mssql_test.go
+++ b/gridscale/resource_gridscale_mssql_test.go
@@ -22,17 +22,17 @@ func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
 			{
 				Config: testAccCheckResourceGridscaleMSSQLServerConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceGridscalePaaSExists("gridscale_sqlserver.test", &object),
+					testAccCheckResourceGridscalePaaSExists("gridscale_mssql.test", &object),
 					resource.TestCheckResourceAttr(
-						"gridscale_sqlserver.test", "name", name),
+						"gridscale_mssql.test", "name", name),
 				),
 			},
 			{
 				Config: testAccCheckResourceGridscaleMSSQLServerConfig_basic_update(),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckResourceGridscalePaaSExists("gridscale_sqlserver.test", &object),
+					testAccCheckResourceGridscalePaaSExists("gridscale_mssql.test", &object),
 					resource.TestCheckResourceAttr(
-						"gridscale_sqlserver.test", "name", "newname"),
+						"gridscale_mssql.test", "name", "newname"),
 				),
 			},
 		},
@@ -41,7 +41,7 @@ func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
 
 func testAccCheckResourceGridscaleMSSQLServerConfig_basic(name string) string {
 	return fmt.Sprintf(`
-resource "gridscale_sqlserver" "test" {
+resource "gridscale_mssql" "test" {
 	name = "%s"
 	release = "2019"
 	performance_class = "standard"
@@ -51,7 +51,7 @@ resource "gridscale_sqlserver" "test" {
 
 func testAccCheckResourceGridscaleMSSQLServerConfig_basic_update() string {
 	return fmt.Sprintf(`
-resource "gridscale_sqlserver" "test" {
+resource "gridscale_mssql" "test" {
 	name = "newname"
 	release = "2019"
 	performance_class = "standard"

--- a/gridscale/resource_gridscale_mssql_test.go
+++ b/gridscale/resource_gridscale_mssql_test.go
@@ -1,0 +1,61 @@
+package gridscale
+
+import (
+	"fmt"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"testing"
+)
+
+func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
+	var object gsclient.PaaSService
+	name := fmt.Sprintf("postgres-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourceGridscaleMSSQLServerConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_sqlserver.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_sqlserver.test", "name", name),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleMSSQLServerConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_sqlserver.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_sqlserver.test", "name", "newname"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceGridscaleMSSQLServerConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "gridscale_sqlserver" "test" {
+	name = "%s"
+	release = "2019"
+	performance_class = "standard"
+}
+`, name)
+}
+
+func testAccCheckResourceGridscaleMSSQLServerConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_sqlserver" "test" {
+	name = "newname"
+	release = "2019"
+	performance_class = "standard"
+	labels = ["test"]
+}
+`)
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/compose.go
@@ -1,0 +1,75 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// All returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs and returns all of the errors produced.
+//
+// If one function produces an error, functions after it are still run.
+// If this is not desirable, use function Sequence instead.
+//
+// If multiple functions returns errors, the result is a multierror.
+//
+// For example:
+//
+//     &schema.Resource{
+//         // ...
+//         CustomizeDiff: customdiff.All(
+//             customdiff.ValidateChange("size", func (old, new, meta interface{}) error {
+//                 // If we are increasing "size" then the new value must be
+//                 // a multiple of the old value.
+//                 if new.(int) <= old.(int) {
+//                     return nil
+//                 }
+//                 if (new.(int) % old.(int)) != 0 {
+//                     return fmt.Errorf("new size value must be an integer multiple of old value %d", old.(int))
+//                 }
+//                 return nil
+//             }),
+//             customdiff.ForceNewIfChange("size", func (old, new, meta interface{}) bool {
+//                 // "size" can only increase in-place, so we must create a new resource
+//                 // if it is decreased.
+//                 return new.(int) < old.(int)
+//             }),
+//             customdiff.ComputedIf("version_id", func (d *schema.ResourceDiff, meta interface{}) bool {
+//                 // Any change to "content" causes a new "version_id" to be allocated.
+//                 return d.HasChange("content")
+//             }),
+//         ),
+//     }
+//
+func All(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		var err error
+		for _, f := range funcs {
+			thisErr := f(ctx, d, meta)
+			if thisErr != nil {
+				err = multierror.Append(err, thisErr)
+			}
+		}
+		return err
+	}
+}
+
+// Sequence returns a CustomizeDiffFunc that runs all of the given
+// CustomizeDiffFuncs in sequence, stopping at the first one that returns
+// an error and returning that error.
+//
+// If all functions succeed, the combined function also succeeds.
+func Sequence(funcs ...schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		for _, f := range funcs {
+			err := f(ctx, d, meta)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/computed.go
@@ -1,0 +1,18 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ComputedIf returns a CustomizeDiffFunc that sets the given key's new value
+// as computed if the given condition function returns true.
+func ComputedIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			d.SetNewComputed(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/condition.go
@@ -1,0 +1,62 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ResourceConditionFunc is a function type that makes a boolean decision based
+// on an entire resource diff.
+type ResourceConditionFunc func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool
+
+// ValueChangeConditionFunc is a function type that makes a boolean decision
+// by comparing two values.
+type ValueChangeConditionFunc func(ctx context.Context, old, new, meta interface{}) bool
+
+// ValueConditionFunc is a function type that makes a boolean decision based
+// on a given value.
+type ValueConditionFunc func(ctx context.Context, value, meta interface{}) bool
+
+// If returns a CustomizeDiffFunc that calls the given condition
+// function and then calls the given CustomizeDiffFunc only if the condition
+// function returns true.
+//
+// This can be used to include conditional customizations when composing
+// customizations using All and Sequence, but should generally be used only in
+// simple scenarios. Prefer directly writing a CustomizeDiffFunc containing
+// a conditional branch if the given CustomizeDiffFunc is already a
+// locally-defined function, since this avoids obscuring the control flow.
+func If(cond ResourceConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValueChange returns a CustomizeDiffFunc that calls the given condition
+// function with the old and new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValueChange(key string, cond ValueChangeConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if cond(ctx, old, new, meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}
+
+// IfValue returns a CustomizeDiffFunc that calls the given condition
+// function with the new values of the given key and then calls the
+// given CustomizeDiffFunc only if the condition function returns true.
+func IfValue(key string, cond ValueConditionFunc, f schema.CustomizeDiffFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if cond(ctx, d.Get(key), meta) {
+			return f(ctx, d, meta)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/doc.go
@@ -1,0 +1,11 @@
+// Package customdiff provides a set of reusable and composable functions
+// to enable more "declarative" use of the CustomizeDiff mechanism available
+// for resources in package helper/schema.
+//
+// The intent of these helpers is to make the intent of a set of diff
+// customizations easier to see, rather than lost in a sea of Go function
+// boilerplate. They should _not_ be used in situations where they _obscure_
+// intent, e.g. by over-using the composition functions where a single
+// function containing normal Go control flow statements would be more
+// straightforward.
+package customdiff

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/force_new.go
@@ -1,0 +1,42 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ForceNewIf returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values of the field compare equal, since no attribute diff is generated in
+// that case.
+func ForceNewIf(key string, f ResourceConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		if f(ctx, d, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}
+
+// ForceNewIfChange returns a CustomizeDiffFunc that flags the given key as
+// requiring a new resource if the given condition function returns true.
+//
+// The return value of the condition function is ignored if the old and new
+// values compare equal, since no attribute diff is generated in that case.
+//
+// This function is similar to ForceNewIf but provides the condition function
+// only the old and new values of the given key, which leads to more compact
+// and explicit code in the common case where the decision can be made with
+// only the specific field value.
+func ForceNewIfChange(key string, f ValueChangeConditionFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		if f(ctx, old, new, meta) {
+			d.ForceNew(key)
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
+++ b/vendor/github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff/validate.go
@@ -1,0 +1,40 @@
+package customdiff
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// ValueChangeValidationFunc is a function type that validates the difference
+// (or lack thereof) between two values, returning an error if the change
+// is invalid.
+type ValueChangeValidationFunc func(ctx context.Context, old, new, meta interface{}) error
+
+// ValueValidationFunc is a function type that validates a particular value,
+// returning an error if the value is invalid.
+type ValueValidationFunc func(ctx context.Context, value, meta interface{}) error
+
+// ValidateChange returns a CustomizeDiffFunc that applies the given validation
+// function to the change for the given key, returning any error produced.
+func ValidateChange(key string, f ValueChangeValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		old, new := d.GetChange(key)
+		return f(ctx, old, new, meta)
+	}
+}
+
+// ValidateValue returns a CustomizeDiffFunc that applies the given validation
+// function to value of the given key, returning any error produced.
+//
+// This should generally not be used since it is functionally equivalent to
+// a validation function applied directly to the schema attribute in question,
+// but is provided for situations where composing multiple CustomizeDiffFuncs
+// together makes intent clearer than spreading that validation across the
+// schema.
+func ValidateValue(key string, f ValueValidationFunc) schema.CustomizeDiffFunc {
+	return func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+		val := d.Get(key)
+		return f(ctx, val, meta)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,6 +131,7 @@ github.com/hashicorp/terraform-plugin-go/tftypes
 ## explicit
 github.com/hashicorp/terraform-plugin-sdk/v2/diag
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest
+github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource
 github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema

--- a/website/docs/r/mssql.html.md
+++ b/website/docs/r/mssql.html.md
@@ -1,12 +1,12 @@
 ---
 layout: "gridscale"
-page_title: "gridscale: gridscale_sqlserver"
-sidebar_current: "docs-gridscale-resource-sqlserver"
+page_title: "gridscale: gridscale_mssql"
+sidebar_current: "docs-gridscale-resource-mssql"
 description: |-
   Manage a MS SQL server service in gridscale.
 ---
 
-# gridscale_sqlserver
+# gridscale_mssql
 
 Provides a MS SQL server resource. This can be used to create, modify, and delete MS SQL server instances.
 
@@ -15,7 +15,7 @@ Provides a MS SQL server resource. This can be used to create, modify, and delet
 The following example shows how one might use this resource to add a MS SQL server service to gridscale:
 
 ```terraform
-resource "gridscale_sqlserver" "terra-sqlserver-test" {
+resource "gridscale_mssql" "terra-mssql-test" {
   name = "test"
   release = "2019"
   performance_class = "standard"

--- a/website/docs/r/mssql.html.md
+++ b/website/docs/r/mssql.html.md
@@ -37,6 +37,15 @@ The following arguments are supported:
 
 * `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
 
+* `s3_backup` - (Optional) Allow backup/restore MS SQL server to/from a S3 bucket.
+
+  * `backup_bucket` - (Required) Object Storage bucket to upload backups to and restore backups from.
+
+  * `backup_access_key` - (Required) Access key used to authenticate against Object Storage server.
+
+  * `backup_secret_key` - (Required) Secret key used to authenticate against Object Storage server.
+
+  * `backup_server_url` - (Required) Object Storage server URL the bucket is located on.
 
 ## Timeouts
 
@@ -59,6 +68,11 @@ This resource exports the following attributes:
 * `listen_port` - The port numbers where this MS SQL server service accepts connections.
   * `name` - Name of a port.
   * `listen_port` - Port number.
+* `s3_backup` - See Argument Reference above.
+  * `backup_bucket` - See Argument Reference above.
+  * `backup_access_key` - See Argument Reference above.
+  * `backup_secret_key` - See Argument Reference above.
+  * `backup_server_url` - See Argument Reference above.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that MS SQL server service uses.

--- a/website/docs/r/sqlserver.html.md
+++ b/website/docs/r/sqlserver.html.md
@@ -1,0 +1,69 @@
+---
+layout: "gridscale"
+page_title: "gridscale: gridscale_sqlserver"
+sidebar_current: "docs-gridscale-resource-sqlserver"
+description: |-
+  Manage a MS SQL server service in gridscale.
+---
+
+# gridscale_sqlserver
+
+Provides a MS SQL server resource. This can be used to create, modify, and delete MS SQL server instances.
+
+## Example
+
+The following example shows how one might use this resource to add a MS SQL server service to gridscale:
+
+```terraform
+resource "gridscale_sqlserver" "terra-sqlserver-test" {
+  name = "test"
+  release = "2019"
+  performance_class = "standard"
+  labels = ["test"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+
+* `release` - (Required) The MS SQL server release of this instance. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available MS SQL server service releases.
+
+* `performance_class` - (Required) Performance class of MS SQL server service. Available performance classes at the time of writing: `standard`, `high`, `insane`, `ultra`.
+
+* `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+
+
+## Timeouts
+
+Timeouts configuration options (in seconds):
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
+
+* `create` - (Default value is "15m" - 15 minutes) Used for creating a resource.
+* `update` - (Default value is "15m" - 15 minutes) Used for updating a resource.
+* `delete` - (Default value is "15m" - 15 minutes) Used for deleting a resource.
+
+## Attributes
+
+This resource exports the following attributes:
+
+* `name` - See Argument Reference above.
+* `release` - See Argument Reference above.
+* `performance_class` - See Argument Reference above.
+* `username` - Username for PaaS service. It is used to connect to the MS SQL server instance.
+* `password` - Password for PaaS service. It is used to connect to the MS SQL server instance.
+* `listen_port` - The port numbers where this MS SQL server service accepts connections.
+  * `name` - Name of a port.
+  * `listen_port` - Port number.
+* `security_zone_uuid` - See Argument Reference above.
+* `network_uuid` - Network UUID containing security zone.
+* `service_template_uuid` - PaaS service template that MS SQL server service uses.
+* `usage_in_minutes` - Number of minutes that PaaS service is in use.
+* `change_time` - Time of the last change.
+* `create_time` - Date time this service has been created.
+* `status` - Current status of PaaS service.
+* `labels` - See Argument Reference above.

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -100,8 +100,8 @@
             <li<%= sidebar_current("docs-gridscale-resource-postgres") %>>
               <a href="/docs/providers/gridscale/r/postgres.html">gridscale_postgres</a>
             </li>
-            <li<%= sidebar_current("docs-gridscale-resource-sqlserver") %>>
-              <a href="/docs/providers/gridscale/r/sqlserver.html">gridscale_sqlserver</a>
+            <li<%= sidebar_current("docs-gridscale-resource-mssql") %>>
+              <a href="/docs/providers/gridscale/r/mssql.html">gridscale_mssql</a>
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-securityzone") %>>
               <a href="/docs/providers/gridscale/r/securityzone.html">gridscale_paas_securityzone</a>

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -100,6 +100,9 @@
             <li<%= sidebar_current("docs-gridscale-resource-postgres") %>>
               <a href="/docs/providers/gridscale/r/postgres.html">gridscale_postgres</a>
             </li>
+            <li<%= sidebar_current("docs-gridscale-resource-sqlserver") %>>
+              <a href="/docs/providers/gridscale/r/sqlserver.html">gridscale_sqlserver</a>
+            </li>
             <li<%= sidebar_current("docs-gridscale-resource-securityzone") %>>
               <a href="/docs/providers/gridscale/r/securityzone.html">gridscale_paas_securityzone</a>
             </li>


### PR DESCRIPTION
Ref #136 and #160 . Add MS SQL server resource to gs terraform provider.
What changes:
- Add new tf resource "gridscale_mssql".
- Add "gridscale_mssql" resource's docs.
- Add "gridscale_mssql" resource's acceptance test.
- Add "gridscale_mssql" GH Actions workflow.

What it does:
- Manage MS SQL server resources in gridscale.
- Validate MS SQL server parameters.
- Allow user to manage s3 backup of MS SQL server.
- Allow user to input `release` (e.g. "2019") and `performance_class`, instead of inputting `service_template_uuid`.
- **NOTE**: Manage to validate the `release` of MS SQL server UPFRONT.