### PR TITLE
Add MariaDB tf resource

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -1,0 +1,40 @@
+name: Test MariaDB rs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**.go"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "**gridscale_mariadb**"
+      - "gridscale/error-handler/**"
+      - "gridscale/common.go"
+      - "gridscale/config.go"
+      - "gridscale/provider.go"
+      - "gridscale/provider_test.go"
+
+jobs:
+  build:
+    name: GS MariaDB AccTest
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+      GRIDSCALE_UUID: ${{ secrets.CI_USER_UUID }}
+      GRIDSCALE_TOKEN: ${{ secrets.CI_API_TOKEN }}
+      GRIDSCALE_URL: https://api.gridscale.cloud
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run TestAccResourceGridscaleMariaDB_Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMariaDB_Basic'

--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -19,6 +19,7 @@ var firewallRuleProtocols = []string{"udp", "tcp"}
 var marketplaceAppCategories = []string{"CMS", "project management", "Adminpanel", "Collaboration", "Cloud Storage", "Archiving"}
 var postgreSQLPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
 var msSQLServerPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
+var mariaDBPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
 
 const timeLayout = "2006-01-02 15:04:05"
 const (

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -93,6 +93,7 @@ func Provider() *schema.Provider {
 			"gridscale_paas_securityzone":              resourceGridscalePaaSSecurityZone(),
 			"gridscale_postgresql":                     resourceGridscalePostgreSQL(),
 			"gridscale_sqlserver":                      resourceGridscaleMSSQLServer(),
+			"gridscale_mariadb":                        resourceGridscaleMariaDB(),
 			"gridscale_object_storage_accesskey":       resourceGridscaleObjectStorage(),
 			"gridscale_template":                       resourceGridscaleTemplate(),
 			"gridscale_isoimage":                       resourceGridscaleISOImage(),

--- a/gridscale/resource_gridscale_mariadb.go
+++ b/gridscale/resource_gridscale_mariadb.go
@@ -1,0 +1,595 @@
+package gridscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
+
+	"log"
+)
+
+const mariadbTemplateFlavourName = "mariadb"
+
+func resourceGridscaleMariaDB() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGridscaleMariaDBCreate,
+		Read:   resourceGridscaleMariaDBRead,
+		Delete: resourceGridscaleMariaDBDelete,
+		Update: resourceGridscaleMariaDBUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			client := meta.(*gsclient.Client)
+			paasTemplates, err := client.GetPaaSTemplateList(ctx)
+			if err != nil {
+				return err
+			}
+
+			releaseVal := d.Get("release").(string)
+			perfClassVal := d.Get("performance_class").(string)
+			var chosenTemplate gsclient.PaaSTemplate
+			var isReleasePerfClassValid bool
+			releaseWPerfClasess := make(map[string][]string)
+			for _, template := range paasTemplates {
+				if template.Properties.Flavour == mariadbTemplateFlavourName {
+					perfClasses := releaseWPerfClasess[template.Properties.Release]
+					releaseWPerfClasess[template.Properties.Release] = append(perfClasses, template.Properties.PerformanceClass)
+					if template.Properties.Release == releaseVal && template.Properties.PerformanceClass == perfClassVal {
+						isReleasePerfClassValid = true
+						chosenTemplate = template
+					}
+				}
+			}
+			if !isReleasePerfClassValid {
+				errMess := fmt.Sprintf("release %v with performance class %s is not a valid MariaDB release/performance class. Valid releases with corresponding performance classes are:\n\t", releaseVal, perfClassVal)
+				for release, perfClasses := range releaseWPerfClasess {
+					errMess += fmt.Sprintf("release %s has following perfomance classes: %s\n\t", release, strings.Join(perfClasses, ", "))
+				}
+				return errors.New(errMess)
+			}
+			return validateMariaDBParameters(d, chosenTemplate)
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"release": {
+				Type: schema.TypeString,
+				Description: `The MariaDB release of this instance.\n
+				For convenience, please use gscloud https://github.com/gridscale/gscloud to get the list of available MariaDB service releases.`,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"performance_class": {
+				Type:         schema.TypeString,
+				Description:  "Performance class of MariaDB service.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"mariadb_log_bin": {
+				Type:        schema.TypeBool,
+				Description: "Binary Logging.",
+				Optional:    true,
+				Default:     false,
+			},
+			"mariadb_sql_mode": {
+				Type:        schema.TypeString,
+				Description: "SQL Mode.",
+				Optional:    true,
+				Default:     "NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO",
+			},
+			"mariadb_server_id": {
+				Type:        schema.TypeInt,
+				Description: "Server Id.",
+				Optional:    true,
+				Default:     1,
+			},
+			"mariadb_query_cache": {
+				Type:        schema.TypeBool,
+				Description: "Enable query cache.",
+				Optional:    true,
+				Default:     true,
+			},
+			"mariadb_binlog_format": {
+				Type:        schema.TypeString,
+				Description: "Binary Logging Format.",
+				Optional:    true,
+				Default:     "MIXED",
+			},
+			"mariadb_max_connections": {
+				Type:        schema.TypeInt,
+				Description: "Max Connections.",
+				Optional:    true,
+				Default:     4000,
+			},
+			"mariadb_query_cache_size": {
+				Type:        schema.TypeString,
+				Description: "Query Cache Size. Format: xM (where x is an integer, M stands for unit: k(kB), M(MB), G(GB)).",
+				Optional:    true,
+				Default:     "128M",
+			},
+			"mariadb_default_time_zone": {
+				Type:        schema.TypeString,
+				Description: "Server Timezone.",
+				Optional:    true,
+				Default:     "UTC",
+			},
+			"mariadb_query_cache_limit": {
+				Type:        schema.TypeString,
+				Description: "Query Cache Limit. Format: xM (where x is an integer, M stands for unit: k(kB), M(MB), G(GB)).",
+				Optional:    true,
+				Default:     "1M",
+			},
+			"mariadb_max_allowed_packet": {
+				Type:        schema.TypeString,
+				Description: "Max Allowed Packet Size. Format: xM (where x is an integer, M stands for unit: k(kB), M(MB), G(GB)).",
+				Optional:    true,
+				Default:     "64M",
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Description: "Username for MariaDB service. It is used to connect to the MariaDB instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Description: "Password for MariaDB service. It is used to connect to the MariaDB instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"listen_port": {
+				Type:        schema.TypeSet,
+				Description: "The port numbers where this MariaDB service accepts connections.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"security_zone_uuid": {
+				Type:        schema.TypeString,
+				Description: "Security zone UUID linked to MariaDB service.",
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+			},
+			"network_uuid": {
+				Type:        schema.TypeString,
+				Description: "Network UUID containing security zone.",
+				Computed:    true,
+			},
+			"service_template_uuid": {
+				Type:        schema.TypeString,
+				Description: "PaaS service template that MariaDB service uses.",
+				Computed:    true,
+			},
+			"usage_in_minutes": {
+				Type:        schema.TypeInt,
+				Description: "Number of minutes that MariaDB service is in use.",
+				Computed:    true,
+			},
+			"change_time": {
+				Type:        schema.TypeString,
+				Description: "Time of the last change.",
+				Computed:    true,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Description: "Date time this service has been created.",
+				Computed:    true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "Current status of MariaDB service.",
+				Computed:    true,
+			},
+			"max_core_count": {
+				Type:         schema.TypeInt,
+				Description:  "Maximum CPU core count. The MariaDB instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.",
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"labels": {
+				Type:        schema.TypeSet,
+				Description: "List of labels.",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+	}
+}
+
+func resourceGridscaleMariaDBRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	paas, err := client.GetPaaSService(context.Background(), d.Id())
+	if err != nil {
+		if requestError, ok := err.(gsclient.RequestError); ok {
+			if requestError.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	props := paas.Properties
+	creds := props.Credentials
+	if err = d.Set("name", props.Name); err != nil {
+		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
+	}
+	if len(creds) > 0 {
+		if err = d.Set("username", creds[0].Username); err != nil {
+			return fmt.Errorf("%s error setting username: %v", errorPrefix, err)
+		}
+		if err = d.Set("password", creds[0].Password); err != nil {
+			return fmt.Errorf("%s error setting password: %v", errorPrefix, err)
+		}
+	}
+	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
+		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
+		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
+		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
+	}
+	if err = d.Set("change_time", props.ChangeTime.String()); err != nil {
+		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("create_time", props.CreateTime.String()); err != nil {
+		return fmt.Errorf("%s error setting create_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("status", props.Status); err != nil {
+		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
+	}
+
+	// Set MariaDB parameters
+	if err = d.Set("mariadb_log_bin", props.Parameters["mariadb_log_bin"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_log_bin: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_sql_mode", props.Parameters["mariadb_sql_mode"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_sql_mode: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_server_id", props.Parameters["mariadb_server_id"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_server_id: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_query_cache", props.Parameters["mariadb_query_cache"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_query_cache: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_binlog_format", props.Parameters["mariadb_binlog_format"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_binlog_format: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_max_connections", props.Parameters["mariadb_max_connections"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_max_connections: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_query_cache_size", props.Parameters["mariadb_query_cache_size"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_query_cache_size: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_default_time_zone", props.Parameters["mariadb_default_time_zone"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_default_time_zone: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_query_cache_limit", props.Parameters["mariadb_query_cache_limit"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_query_cache_limit: %v", errorPrefix, err)
+	}
+	if err = d.Set("mariadb_max_allowed_packet", props.Parameters["mariadb_max_allowed_packet"]); err != nil {
+		return fmt.Errorf("%s error setting mariadb_max_allowed_packet: %v", errorPrefix, err)
+	}
+	//Get listen ports
+	listenPorts := make([]interface{}, 0)
+	for _, value := range props.ListenPorts {
+		for k, portValue := range value {
+			port := map[string]interface{}{
+				"name": k,
+				"port": portValue,
+			}
+			listenPorts = append(listenPorts, port)
+		}
+	}
+	if err = d.Set("listen_port", listenPorts); err != nil {
+		return fmt.Errorf("%s error setting listen ports: %v", errorPrefix, err)
+	}
+
+	//Get core count's limit
+	for _, value := range props.ResourceLimits {
+		if value.Resource == "cores" {
+			if err = d.Set("max_core_count", value.Limit); err != nil {
+				return fmt.Errorf("%s error setting max_core_count: %v", errorPrefix, err)
+			}
+		}
+	}
+
+	//Set labels
+	if err = d.Set("labels", props.Labels); err != nil {
+		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
+	}
+
+	//Get all available networks
+	networks, err := client.GetNetworkList(context.Background())
+	if err != nil {
+		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
+	}
+	//look for a network that the MariaDB service is in
+	for _, network := range networks {
+		securityZones := network.Properties.Relations.PaaSSecurityZones
+		//Each network can contain only one security zone
+		if len(securityZones) >= 1 {
+			if securityZones[0].ObjectUUID == props.SecurityZoneUUID {
+				if err = d.Set("network_uuid", network.Properties.ObjectUUID); err != nil {
+					return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func resourceGridscaleMariaDBCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+
+	// Get mariadb template UUID
+	release := d.Get("release").(string)
+	performanceClass := d.Get("performance_class").(string)
+	templateUUID, err := getMariaDBTemplateUUID(client, release, performanceClass)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+
+	requestBody := gsclient.PaaSServiceCreateRequest{
+		Name:                    d.Get("name").(string),
+		PaaSServiceTemplateUUID: templateUUID,
+		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
+		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
+	}
+
+	if val, ok := d.GetOk("max_core_count"); ok {
+		limits := []gsclient.ResourceLimit{
+			{
+				Resource: "cores",
+				Limit:    val.(int),
+			},
+		}
+		requestBody.ResourceLimits = limits
+	}
+
+	params := make(map[string]interface{})
+	params["mariadb_log_bin"] = d.Get("mariadb_log_bin")
+	params["mariadb_sql_mode"] = d.Get("mariadb_sql_mode")
+	params["mariadb_server_id"] = d.Get("mariadb_server_id")
+	params["mariadb_query_cache"] = d.Get("mariadb_query_cache")
+	params["mariadb_binlog_format"] = d.Get("mariadb_binlog_format")
+	params["mariadb_max_connections"] = d.Get("mariadb_max_connections")
+	params["mariadb_query_cache_size"] = d.Get("mariadb_query_cache_size")
+	params["mariadb_default_time_zone"] = d.Get("mariadb_default_time_zone")
+	params["mariadb_query_cache_limit"] = d.Get("mariadb_query_cache_limit")
+	params["mariadb_max_allowed_packet"] = d.Get("mariadb_max_allowed_packet")
+	requestBody.Parameters = params
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
+	defer cancel()
+	response, err := client.CreatePaaSService(ctx, requestBody)
+	if err != nil {
+		return err
+	}
+	d.SetId(response.ObjectUUID)
+	log.Printf("The id for MariaDB service %s has been set to %v", requestBody.Name, response.ObjectUUID)
+	return resourceGridscaleMariaDBRead(d, meta)
+}
+
+func resourceGridscaleMariaDBUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+
+	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
+	requestBody := gsclient.PaaSServiceUpdateRequest{
+		Name:   d.Get("name").(string),
+		Labels: &labels,
+	}
+
+	// Only update templateUUID, when `release` or `performance_class` is changed
+	if d.HasChange("release") || d.HasChange("performance_class") {
+		// Get mariadb template UUID
+		release := d.Get("release").(string)
+		performanceClass := d.Get("performance_class").(string)
+		templateUUID, err := getMariaDBTemplateUUID(client, release, performanceClass)
+		if err != nil {
+			return fmt.Errorf("%s error: %v", errorPrefix, err)
+		}
+		requestBody.PaaSServiceTemplateUUID = templateUUID
+	}
+
+	if val, ok := d.GetOk("max_core_count"); ok {
+		limits := []gsclient.ResourceLimit{
+			{
+				Resource: "cores",
+				Limit:    val.(int),
+			},
+		}
+		requestBody.ResourceLimits = limits
+	}
+
+	params := make(map[string]interface{})
+	params["mariadb_log_bin"] = d.Get("mariadb_log_bin")
+	params["mariadb_sql_mode"] = d.Get("mariadb_sql_mode")
+	params["mariadb_server_id"] = d.Get("mariadb_server_id")
+	params["mariadb_query_cache"] = d.Get("mariadb_query_cache")
+	params["mariadb_binlog_format"] = d.Get("mariadb_binlog_format")
+	params["mariadb_max_connections"] = d.Get("mariadb_max_connections")
+	params["mariadb_query_cache_size"] = d.Get("mariadb_query_cache_size")
+	params["mariadb_default_time_zone"] = d.Get("mariadb_default_time_zone")
+	params["mariadb_query_cache_limit"] = d.Get("mariadb_query_cache_limit")
+	params["mariadb_max_allowed_packet"] = d.Get("mariadb_max_allowed_packet")
+	requestBody.Parameters = params
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
+	defer cancel()
+	err := client.UpdatePaaSService(ctx, d.Id(), requestBody)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return resourceGridscaleMariaDBRead(d, meta)
+}
+
+func resourceGridscaleMariaDBDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	defer cancel()
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeletePaaSService(ctx, d.Id()),
+		http.StatusNotFound,
+	)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return nil
+}
+
+// getMariaDBTemplateUUID returns the UUID of the mariadb service template.
+func getMariaDBTemplateUUID(client *gsclient.Client, release, performanceClass string) (string, error) {
+	paasTemplates, err := client.GetPaaSTemplateList(context.Background())
+	if err != nil {
+		return "", err
+	}
+	var isReleaseValid bool
+	var releases []string
+	var uTemplate gsclient.PaaSTemplate
+	for _, template := range paasTemplates {
+		if template.Properties.Flavour == mariadbTemplateFlavourName {
+			releases = append(releases, template.Properties.Release)
+			if template.Properties.Release == release && template.Properties.PerformanceClass == performanceClass {
+				isReleaseValid = true
+				uTemplate = template
+			}
+		}
+	}
+	if !isReleaseValid {
+		return "", fmt.Errorf("%v is not a valid MariaDB release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+	}
+
+	return uTemplate.Properties.ObjectUUID, nil
+}
+
+func validateMariaDBParameters(d *schema.ResourceDiff, template gsclient.PaaSTemplate) error {
+	var errorMessages []string
+	if sqlMode, ok := d.GetOk("mariadb_sql_mode"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_sql_mode"]; ok {
+			validMode := regexp.MustCompile(scheme.Regex)
+			if !validMode.MatchString(sqlMode.(string)) {
+				errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'mariadb_sql_mode' value. Example value: '%s'\n", scheme.Default))
+			}
+		}
+	}
+	if serverID, ok := d.GetOk("mariadb_server_id"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_server_id"]; ok {
+			if scheme.Min > serverID.(int) || serverID.(int) > scheme.Max {
+				errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'mariadb_server_id' value. Value must stays between %d and %d\n", scheme.Min, scheme.Max))
+			}
+		}
+	}
+	if binLogFormat, ok := d.GetOk("mariadb_binlog_format"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_binlog_format"]; ok {
+			var isValidFormat bool
+			for _, allowedValue := range scheme.Allowed {
+				if binLogFormat.(string) == allowedValue {
+					isValidFormat = true
+				}
+			}
+			if !isValidFormat {
+				errorMessages = append(errorMessages,
+					fmt.Sprintf("Invalid 'mariadb_binlog_format' value. Value must be one of these:\n\t%s\n",
+						strings.Join(scheme.Allowed, "\n\t"),
+					),
+				)
+			}
+		}
+	}
+	if maxNConn, ok := d.GetOk("mariadb_max_connections"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_max_connections"]; ok {
+			if scheme.Min > maxNConn.(int) || maxNConn.(int) > scheme.Max {
+				errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'mariadb_max_connections' value. Value must stays between %d and %d\n", scheme.Min, scheme.Max))
+			}
+		}
+	}
+	if cacheSize, ok := d.GetOk("mariadb_query_cache_size"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_query_cache_size"]; ok {
+			validMode := regexp.MustCompile(scheme.Regex)
+			if !validMode.MatchString(cacheSize.(string)) {
+				errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'mariadb_query_cache_size' value. Example value: '%s'\n", scheme.Default))
+			}
+		}
+	}
+	if defaultTimeZone, ok := d.GetOk("mariadb_default_time_zone"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_default_time_zone"]; ok {
+			var isValidFormat bool
+			for _, allowedValue := range scheme.Allowed {
+				if defaultTimeZone.(string) == allowedValue {
+					isValidFormat = true
+				}
+			}
+			if !isValidFormat {
+				errorMessages = append(errorMessages,
+					fmt.Sprintf("Invalid 'mariadb_default_time_zone' value. Value must be one of these:\n\t%s",
+						strings.Join(scheme.Allowed, "\n\t"),
+					),
+				)
+			}
+		}
+	}
+	if cacheLimit, ok := d.GetOk("mariadb_query_cache_limit"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_query_cache_limit"]; ok {
+			validMode := regexp.MustCompile(scheme.Regex)
+			if !validMode.MatchString(cacheLimit.(string)) {
+				errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'mariadb_query_cache_limit' value. Example value: '%s'\n", scheme.Default))
+			}
+		}
+	}
+	if maxAllowedPacket, ok := d.GetOk("mariadb_max_allowed_packet"); ok {
+		if scheme, ok := template.Properties.ParametersSchema["mariadb_max_allowed_packet"]; ok {
+			validMode := regexp.MustCompile(scheme.Regex)
+			if !validMode.MatchString(maxAllowedPacket.(string)) {
+				errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'mariadb_max_allowed_packet' value. Example value: '%s'\n", scheme.Default))
+			}
+		}
+	}
+	if maxNCore, ok := d.GetOk("max_core_count"); ok {
+		autoscalingNCore := template.Properties.Autoscaling.Cores
+		if autoscalingNCore.Min > maxNCore.(int) || maxNCore.(int) > autoscalingNCore.Max {
+			errorMessages = append(errorMessages, fmt.Sprintf("Invalid 'max_core_count' value. Value must stays between %d and %d\n", autoscalingNCore.Min, autoscalingNCore.Max))
+		}
+	}
+	if len(errorMessages) != 0 {
+		return errors.New(strings.Join(errorMessages, ""))
+	}
+	return nil
+}

--- a/gridscale/resource_gridscale_mariadb_test.go
+++ b/gridscale/resource_gridscale_mariadb_test.go
@@ -1,0 +1,67 @@
+package gridscale
+
+import (
+	"fmt"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"testing"
+)
+
+func TestAccResourceGridscaleMariaDB_Basic(t *testing.T) {
+	var object gsclient.PaaSService
+	name := fmt.Sprintf("postgres-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourceGridscaleMariaDBConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_mariadb.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_mariadb.test", "name", name),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleMariaDBConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_mariadb.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_mariadb.test", "name", "newname"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceGridscaleMariaDBConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "gridscale_mariadb" "test" {
+	name = "%s"
+	release = "10.5"
+	performance_class = "standard"
+}
+`, name)
+}
+
+func testAccCheckResourceGridscaleMariaDBConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_mariadb" "test" {
+	name = "newname"
+	release = "10.5"
+	performance_class = "standard"
+	max_core_count = 20
+	labels = ["test"]
+	mariadb_query_cache_limit = "2M"
+	mariadb_default_time_zone = "Europe/Berlin"
+	mariadb_sql_mode = "NO_AUTO_CREATE_USER,ERROR_FOR_DIVISION_BY_ZERO"
+	mariadb_server_id = 2
+	mariadb_binlog_format = "STATEMENT"
+}
+`)
+}

--- a/website/docs/r/mariadb.html.md
+++ b/website/docs/r/mariadb.html.md
@@ -1,0 +1,105 @@
+---
+layout: "gridscale"
+page_title: "gridscale: gridscale_mariadb"
+sidebar_current: "docs-gridscale-resource-mariadb"
+description: |-
+  Manage a MariaDB service in gridscale.
+---
+
+# gridscale_mariadb
+
+Provides a MariaDB resource. This can be used to create, modify, and delete MariaDB instances.
+
+## Example
+
+The following example shows how one might use this resource to add a MariaDB service to gridscale:
+
+```terraform
+resource "gridscale_mariadb" "terra-mariadb-test" {
+    name = "my mariadb"
+	release = "10.5"
+	performance_class = "insane"
+    max_core_count = 20
+    mariadb_query_cache_limit = "2M"
+	mariadb_default_time_zone = "Europe/Berlin"
+	mariadb_server_id = 2
+	mariadb_binlog_format = "STATEMENT"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+
+* `release` - (Required) The MariaDB release of this instance. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available MariaDB service releases.
+
+* `performance_class` - (Required) Performance class of MariaDB service. Available performance classes at the time of writing: `standard`, `high`, `insane`, `ultra`.
+
+* `mariadb_log_bin` - (Optional) MariaDB parameter: Binary Logging. Default: false.
+
+* `mariadb_sql_mode` - (Optional) MariaDB parameter: SQL Mode. Default: "NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO".
+
+* `mariadb_server_id` - (Optional) MariaDB parameter: Server Id. Default: 1.
+
+* `mariadb_query_cache` - (Optional) MariaDB parameter: Enable query cache. Default: true.
+
+* `mariadb_binlog_format` - (Optional) MariaDB parameter: Binary Logging Format. Default: "MIXED".
+
+* `mariadb_max_connections` - (Optional) MariaDB parameter: Max Connections. Default: 4000.
+
+* `mariadb_query_cache_size` - (Optional) MariaDB parameter: Query Cache Size. Format: xM (where x is an integer, M stands for unit: k(kB), M(MB), G(GB)). Default: 128M.
+
+* `mariadb_default_time_zone` - (Optional) MariaDB parameter: Server Timezone. Default: UTC.
+
+* `mariadb_query_cache_limit` - (Optional) MariaDB parameter: Query Cache Limit. Format: xM (where x is an integer, M stands for unit: k(kB), M(MB), G(GB)). Default: 1M.
+
+* `mariadb_max_allowed_packet` - (Optional) MariaDB parameter: Max Allowed Packet Size. Format: xM (where x is an integer, M stands for unit: k(kB), M(MB), G(GB)). Default: 64M.
+
+* `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+
+* `max_core_count` - (Optional) Maximum CPU core count. The MariaDB instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
+
+## Timeouts
+
+Timeouts configuration options (in seconds):
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
+
+* `create` - (Default value is "15m" - 15 minutes) Used for creating a resource.
+* `update` - (Default value is "15m" - 15 minutes) Used for updating a resource.
+* `delete` - (Default value is "15m" - 15 minutes) Used for deleting a resource.
+
+## Attributes
+
+This resource exports the following attributes:
+
+* `name` - See Argument Reference above.
+* `release` - See Argument Reference above.
+* `performance_class` - See Argument Reference above.
+* `mariadb_log_bin` - See Argument Reference above.
+* `mariadb_sql_mode` - See Argument Reference above.
+* `mariadb_server_id` - See Argument Reference above.
+* `mariadb_query_cache` - See Argument Reference above.
+* `mariadb_binlog_format` - See Argument Reference above.
+* `mariadb_max_connections` - See Argument Reference above.
+* `mariadb_query_cache_size` - See Argument Reference above.
+* `mariadb_default_time_zone` - See Argument Reference above.
+* `mariadb_query_cache_limit` - See Argument Reference above.
+* `mariadb_max_allowed_packet` - See Argument Reference above.
+* `username` - Username for PaaS service. It is used to connect to the MariaDB instance.
+* `password` - Password for PaaS service. It is used to connect to the MariaDB instance.
+* `listen_port` - The port numbers where this MariaDB service accepts connections.
+  * `name` - Name of a port.
+  * `listen_port` - Port number.
+* `security_zone_uuid` - See Argument Reference above.
+* `network_uuid` - Network UUID containing security zone.
+* `service_template_uuid` - PaaS service template that MariaDB service uses.
+* `usage_in_minutes` - Number of minutes that PaaS service is in use.
+* `change_time` - Time of the last change.
+* `create_time` - Date time this service has been created.
+* `status` - Current status of PaaS service.
+* `max_core_count` - See Argument Reference above.
+* `labels` - See Argument Reference above.

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -97,6 +97,7 @@
             </li>
             <li<%= sidebar_current("docs-gridscale-resource-k8s") %>>
               <a href="/docs/providers/gridscale/r/k8s.html">gridscale_k8s</a>
+            </li>
             <li<%= sidebar_current("docs-gridscale-resource-postgres") %>>
               <a href="/docs/providers/gridscale/r/postgres.html">gridscale_postgres</a>
             </li>

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -104,6 +104,9 @@
             <li<%= sidebar_current("docs-gridscale-resource-sqlserver") %>>
               <a href="/docs/providers/gridscale/r/sqlserver.html">gridscale_sqlserver</a>
             </li>
+            <li<%= sidebar_current("docs-gridscale-resource-mariadb") %>>
+              <a href="/docs/providers/gridscale/r/mariadb.html">gridscale_mariadb</a>
+            </li>
             <li<%= sidebar_current("docs-gridscale-resource-securityzone") %>>
               <a href="/docs/providers/gridscale/r/securityzone.html">gridscale_paas_securityzone</a>
             </li>


### PR DESCRIPTION
Ref #135. Add MariaDB resource to gs terraform provider.
What changes:
- Add new tf resource "gridscale_mariadb".
- Add "gridscale_mariadb" resource's docs.
- Add "gridscale_mariadb" resource's acceptance test.
- Add "gridscale_mariadb" GH Actions workflow.

What it does:
- Manage MariaDB  resources in gridscale.
- Validate MariaDB  parameters upfront.
- Allow user to input `release` (e.g. "10.5") and `performance_class` (e.g. "insane"), instead of inputting `service_template_uuid`.