### PR TITLE
Add Redis store/cache resources.

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -1,4 +1,4 @@
-name: Test Redis store rs
+name: Test Redis store/cache rs
 
 on:
   push:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    name: GS Redis store AccTest
+    name: GS Redis store/cache AccTest
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/go
@@ -38,3 +38,6 @@ jobs:
 
       - name: Run TestAccResourceGridscaleRedisStore_Basic
         run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisStore_Basic'
+
+      - name: Run TestAccResourceGridscaleRedisCache_Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisCache_Basic'

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - master
     paths:
-      - "**gridscale_redis_store**"
+      - "**gridscale_redis**"
       - "gridscale/error-handler/**"
       - "gridscale/common.go"
       - "gridscale/config.go"

--- a/.github/workflows/redis_store.yml
+++ b/.github/workflows/redis_store.yml
@@ -1,0 +1,40 @@
+name: Test Redis store rs
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "**.go"
+  pull_request:
+    branches:
+      - master
+    paths:
+      - "**gridscale_redis_store**"
+      - "gridscale/error-handler/**"
+      - "gridscale/common.go"
+      - "gridscale/config.go"
+      - "gridscale/provider.go"
+      - "gridscale/provider_test.go"
+
+jobs:
+  build:
+    name: GS PostgreSQLAccTest
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: /home/runner/go
+      GRIDSCALE_UUID: ${{ secrets.CI_USER_UUID }}
+      GRIDSCALE_TOKEN: ${{ secrets.CI_API_TOKEN }}
+      GRIDSCALE_URL: https://api.gridscale.cloud
+    steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.16
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Run TestAccResourceGridscaleRedisStore_Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisStore_Basic'

--- a/.github/workflows/redis_store.yml
+++ b/.github/workflows/redis_store.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    name: GS PostgreSQLAccTest
+    name: GS Redis store AccTest
     runs-on: ubuntu-latest
     env:
       GOPATH: /home/runner/go

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -89,6 +89,7 @@ func Provider() *schema.Provider {
 			"gridscale_snapshotschedule":               resourceGridscaleStorageSnapshotSchedule(),
 			"gridscale_backupschedule":                 resourceGridscaleStorageBackupSchedule(),
 			"gridscale_paas":                           resourceGridscalePaaS(),
+			"gridscale_redis_store":                    resourceGridscaleRedisStore(),
 			"gridscale_k8s":                            resourceGridscaleK8s(),
 			"gridscale_paas_securityzone":              resourceGridscalePaaSSecurityZone(),
 			"gridscale_postgresql":                     resourceGridscalePostgreSQL(),

--- a/gridscale/provider.go
+++ b/gridscale/provider.go
@@ -90,6 +90,7 @@ func Provider() *schema.Provider {
 			"gridscale_backupschedule":                 resourceGridscaleStorageBackupSchedule(),
 			"gridscale_paas":                           resourceGridscalePaaS(),
 			"gridscale_redis_store":                    resourceGridscaleRedisStore(),
+			"gridscale_redis_cache":                    resourceGridscaleRedisCache(),
 			"gridscale_k8s":                            resourceGridscaleK8s(),
 			"gridscale_paas_securityzone":              resourceGridscalePaaSSecurityZone(),
 			"gridscale_postgresql":                     resourceGridscalePostgreSQL(),

--- a/gridscale/resource_gridscale_redis_cache.go
+++ b/gridscale/resource_gridscale_redis_cache.go
@@ -98,6 +98,10 @@ func resourceGridscaleRedisCache() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -204,10 +208,11 @@ func resourceGridscaleRedisCacheRead(d *schema.ResourceData, meta interface{}) e
 
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/gridscale/resource_gridscale_redis_cache.go
+++ b/gridscale/resource_gridscale_redis_cache.go
@@ -1,0 +1,345 @@
+package gridscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
+
+	"log"
+)
+
+const redisCacheTemplateFlavourName = "redis-cache"
+
+func resourceGridscaleRedisCache() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGridscaleRedisCacheCreate,
+		Read:   resourceGridscaleRedisCacheRead,
+		Delete: resourceGridscaleRedisCacheDelete,
+		Update: resourceGridscaleRedisCacheUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			client := meta.(*gsclient.Client)
+			paasTemplates, err := client.GetPaaSTemplateList(ctx)
+			if err != nil {
+				return err
+			}
+
+			releaseVal := d.Get("release").(string)
+			perfClassVal := d.Get("performance_class").(string)
+			var isReleasePerfClassValid bool
+			releaseWPerfClasess := make(map[string][]string)
+			for _, template := range paasTemplates {
+				if template.Properties.Flavour == redisCacheTemplateFlavourName {
+					perfClasses := releaseWPerfClasess[template.Properties.Release]
+					releaseWPerfClasess[template.Properties.Release] = append(perfClasses, template.Properties.PerformanceClass)
+					if template.Properties.Release == releaseVal && template.Properties.PerformanceClass == perfClassVal {
+						isReleasePerfClassValid = true
+					}
+				}
+			}
+			if !isReleasePerfClassValid {
+				errMess := fmt.Sprintf("release %v with performance class %s is not a valid Redis cache release/performance class. Valid releases with corresponding performance classes are:\n\t", releaseVal, perfClassVal)
+				for release, perfClasses := range releaseWPerfClasess {
+					errMess += fmt.Sprintf("release %s has following perfomance classes: %s\n\t", release, strings.Join(perfClasses, ", "))
+				}
+				return errors.New(errMess)
+			}
+			return nil
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"release": {
+				Type: schema.TypeString,
+				Description: `The RedisCache release of this instance.\n
+				For convenience, please use gscloud https://github.com/gridscale/gscloud to get the list of available Redis cache service releases.`,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"performance_class": {
+				Type:         schema.TypeString,
+				Description:  "Performance class of Redis cache service.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Description: "Username for Redis cache service. It is used to connect to the Redis cache instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Description: "Password for Redis cache service. It is used to connect to the Redis cache instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"listen_port": {
+				Type:        schema.TypeSet,
+				Description: "The port numbers where this Redis cache service accepts connections.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"security_zone_uuid": {
+				Type:        schema.TypeString,
+				Description: "Security zone UUID linked to Redis cache service.",
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+			},
+			"network_uuid": {
+				Type:        schema.TypeString,
+				Description: "Network UUID containing security zone.",
+				Computed:    true,
+			},
+			"service_template_uuid": {
+				Type:        schema.TypeString,
+				Description: "PaaS service template that Redis cache service uses.",
+				Computed:    true,
+			},
+			"usage_in_minutes": {
+				Type:        schema.TypeInt,
+				Description: "Number of minutes that Redis cache service is in use.",
+				Computed:    true,
+			},
+			"change_time": {
+				Type:        schema.TypeString,
+				Description: "Time of the last change.",
+				Computed:    true,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Description: "Date time this service has been created.",
+				Computed:    true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "Current status of Redis cache service.",
+				Computed:    true,
+			},
+			"labels": {
+				Type:        schema.TypeSet,
+				Description: "List of labels.",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+	}
+}
+
+func resourceGridscaleRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	paas, err := client.GetPaaSService(context.Background(), d.Id())
+	if err != nil {
+		if requestError, ok := err.(gsclient.RequestError); ok {
+			if requestError.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	props := paas.Properties
+	creds := props.Credentials
+	if err = d.Set("name", props.Name); err != nil {
+		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
+	}
+	if len(creds) > 0 {
+		if err = d.Set("username", creds[0].Username); err != nil {
+			return fmt.Errorf("%s error setting username: %v", errorPrefix, err)
+		}
+		if err = d.Set("password", creds[0].Password); err != nil {
+			return fmt.Errorf("%s error setting password: %v", errorPrefix, err)
+		}
+	}
+	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
+		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
+		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
+		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
+	}
+	if err = d.Set("change_time", props.ChangeTime.String()); err != nil {
+		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("create_time", props.CreateTime.String()); err != nil {
+		return fmt.Errorf("%s error setting create_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("status", props.Status); err != nil {
+		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
+	}
+
+	//Get listen ports
+	listenPorts := make([]interface{}, 0)
+	for _, value := range props.ListenPorts {
+		for k, portValue := range value {
+			port := map[string]interface{}{
+				"name": k,
+				"port": portValue,
+			}
+			listenPorts = append(listenPorts, port)
+		}
+	}
+	if err = d.Set("listen_port", listenPorts); err != nil {
+		return fmt.Errorf("%s error setting listen ports: %v", errorPrefix, err)
+	}
+
+	//Set labels
+	if err = d.Set("labels", props.Labels); err != nil {
+		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
+	}
+
+	//Get all available networks
+	networks, err := client.GetNetworkList(context.Background())
+	if err != nil {
+		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
+	}
+	//look for a network that the Redis cache service is in
+	for _, network := range networks {
+		securityZones := network.Properties.Relations.PaaSSecurityZones
+		//Each network can contain only one security zone
+		if len(securityZones) >= 1 {
+			if securityZones[0].ObjectUUID == props.SecurityZoneUUID {
+				if err = d.Set("network_uuid", network.Properties.ObjectUUID); err != nil {
+					return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func resourceGridscaleRedisCacheCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+
+	// Get redisCache template UUID
+	release := d.Get("release").(string)
+	performanceClass := d.Get("performance_class").(string)
+	templateUUID, err := getRedisCacheTemplateUUID(client, release, performanceClass)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+
+	requestBody := gsclient.PaaSServiceCreateRequest{
+		Name:                    d.Get("name").(string),
+		PaaSServiceTemplateUUID: templateUUID,
+		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
+		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
+	defer cancel()
+	response, err := client.CreatePaaSService(ctx, requestBody)
+	if err != nil {
+		return err
+	}
+	d.SetId(response.ObjectUUID)
+	log.Printf("The id for Redis cache service %s has been set to %v", requestBody.Name, response.ObjectUUID)
+	return resourceGridscaleRedisCacheRead(d, meta)
+}
+
+func resourceGridscaleRedisCacheUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+
+	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
+	requestBody := gsclient.PaaSServiceUpdateRequest{
+		Name:   d.Get("name").(string),
+		Labels: &labels,
+	}
+
+	// Only update templateUUID, when `release` or `performance_class` is changed
+	if d.HasChange("release") || d.HasChange("performance_class") {
+		// Get redisCache template UUID
+		release := d.Get("release").(string)
+		performanceClass := d.Get("performance_class").(string)
+		templateUUID, err := getRedisCacheTemplateUUID(client, release, performanceClass)
+		if err != nil {
+			return fmt.Errorf("%s error: %v", errorPrefix, err)
+		}
+		requestBody.PaaSServiceTemplateUUID = templateUUID
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
+	defer cancel()
+	err := client.UpdatePaaSService(ctx, d.Id(), requestBody)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return resourceGridscaleRedisCacheRead(d, meta)
+}
+
+func resourceGridscaleRedisCacheDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	defer cancel()
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeletePaaSService(ctx, d.Id()),
+		http.StatusNotFound,
+	)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return nil
+}
+
+// getRedisCacheTemplateUUID returns the UUID of the redisCache service template.
+func getRedisCacheTemplateUUID(client *gsclient.Client, release, performanceClass string) (string, error) {
+	paasTemplates, err := client.GetPaaSTemplateList(context.Background())
+	if err != nil {
+		return "", err
+	}
+	var isReleaseValid bool
+	var releases []string
+	var uTemplate gsclient.PaaSTemplate
+	for _, template := range paasTemplates {
+		if template.Properties.Flavour == redisCacheTemplateFlavourName {
+			releases = append(releases, template.Properties.Release)
+			if template.Properties.Release == release && template.Properties.PerformanceClass == performanceClass {
+				isReleaseValid = true
+				uTemplate = template
+			}
+		}
+	}
+	if !isReleaseValid {
+		return "", fmt.Errorf("%v is not a valid RedisCache release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+	}
+
+	return uTemplate.Properties.ObjectUUID, nil
+}

--- a/gridscale/resource_gridscale_redis_cache_test.go
+++ b/gridscale/resource_gridscale_redis_cache_test.go
@@ -1,0 +1,61 @@
+package gridscale
+
+import (
+	"fmt"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"testing"
+)
+
+func TestAccResourceGridscaleRedisCache_Basic(t *testing.T) {
+	var object gsclient.PaaSService
+	name := fmt.Sprintf("redis_cache-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourceGridscaleRedisCacheConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_redis_cache.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_redis_cache.test", "name", name),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleRedisCacheConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_redis_cache.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_redis_cache.test", "name", "newname"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceGridscaleRedisCacheConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "gridscale_redis_cache" "test" {
+	name = "%s"
+	release = "5.0"
+	performance_class = "standard"
+}
+`, name)
+}
+
+func testAccCheckResourceGridscaleRedisCacheConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_redis_cache" "test" {
+	name = "newname"
+	release = "5.0"
+	performance_class = "standard"
+	labels = ["test"]
+}
+`)
+}

--- a/gridscale/resource_gridscale_redis_store.go
+++ b/gridscale/resource_gridscale_redis_store.go
@@ -1,0 +1,345 @@
+package gridscale
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	errHandler "github.com/terraform-providers/terraform-provider-gridscale/gridscale/error-handler"
+
+	"log"
+)
+
+const redisStoreTemplateFlavourName = "redis-store"
+
+func resourceGridscaleRedisStore() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGridscaleRedisStoreCreate,
+		Read:   resourceGridscaleRedisStoreRead,
+		Delete: resourceGridscaleRedisStoreDelete,
+		Update: resourceGridscaleRedisStoreUpdate,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			client := meta.(*gsclient.Client)
+			paasTemplates, err := client.GetPaaSTemplateList(ctx)
+			if err != nil {
+				return err
+			}
+
+			releaseVal := d.Get("release").(string)
+			perfClassVal := d.Get("performance_class").(string)
+			var isReleasePerfClassValid bool
+			releaseWPerfClasess := make(map[string][]string)
+			for _, template := range paasTemplates {
+				if template.Properties.Flavour == redisStoreTemplateFlavourName {
+					perfClasses := releaseWPerfClasess[template.Properties.Release]
+					releaseWPerfClasess[template.Properties.Release] = append(perfClasses, template.Properties.PerformanceClass)
+					if template.Properties.Release == releaseVal && template.Properties.PerformanceClass == perfClassVal {
+						isReleasePerfClassValid = true
+					}
+				}
+			}
+			if !isReleasePerfClassValid {
+				errMess := fmt.Sprintf("release %v with performance class %s is not a valid Redis store release/performance class. Valid releases with corresponding performance classes are:\n\t", releaseVal, perfClassVal)
+				for release, perfClasses := range releaseWPerfClasess {
+					errMess += fmt.Sprintf("release %s has following perfomance classes: %s\n\t", release, strings.Join(perfClasses, ", "))
+				}
+				return errors.New(errMess)
+			}
+			return nil
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Description:  "The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"release": {
+				Type: schema.TypeString,
+				Description: `The RedisStore release of this instance.\n
+				For convenience, please use gscloud https://github.com/gridscale/gscloud to get the list of available Redis store service releases.`,
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"performance_class": {
+				Type:         schema.TypeString,
+				Description:  "Performance class of Redis store service.",
+				Required:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+			"username": {
+				Type:        schema.TypeString,
+				Description: "Username for Redis store service. It is used to connect to the Redis store instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Description: "Password for Redis store service. It is used to connect to the Redis store instance.",
+				Computed:    true,
+				Sensitive:   true,
+			},
+			"listen_port": {
+				Type:        schema.TypeSet,
+				Description: "The port numbers where this Redis store service accepts connections.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"security_zone_uuid": {
+				Type:        schema.TypeString,
+				Description: "Security zone UUID linked to Redis store service.",
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+			},
+			"network_uuid": {
+				Type:        schema.TypeString,
+				Description: "Network UUID containing security zone.",
+				Computed:    true,
+			},
+			"service_template_uuid": {
+				Type:        schema.TypeString,
+				Description: "PaaS service template that Redis store service uses.",
+				Computed:    true,
+			},
+			"usage_in_minutes": {
+				Type:        schema.TypeInt,
+				Description: "Number of minutes that Redis store service is in use.",
+				Computed:    true,
+			},
+			"change_time": {
+				Type:        schema.TypeString,
+				Description: "Time of the last change.",
+				Computed:    true,
+			},
+			"create_time": {
+				Type:        schema.TypeString,
+				Description: "Date time this service has been created.",
+				Computed:    true,
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Description: "Current status of Redis store service.",
+				Computed:    true,
+			},
+			"labels": {
+				Type:        schema.TypeSet,
+				Description: "List of labels.",
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+	}
+}
+
+func resourceGridscaleRedisStoreRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	paas, err := client.GetPaaSService(context.Background(), d.Id())
+	if err != nil {
+		if requestError, ok := err.(gsclient.RequestError); ok {
+			if requestError.StatusCode == 404 {
+				d.SetId("")
+				return nil
+			}
+		}
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	props := paas.Properties
+	creds := props.Credentials
+	if err = d.Set("name", props.Name); err != nil {
+		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
+	}
+	if len(creds) > 0 {
+		if err = d.Set("username", creds[0].Username); err != nil {
+			return fmt.Errorf("%s error setting username: %v", errorPrefix, err)
+		}
+		if err = d.Set("password", creds[0].Password); err != nil {
+			return fmt.Errorf("%s error setting password: %v", errorPrefix, err)
+		}
+	}
+	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
+		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
+		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
+		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
+	}
+	if err = d.Set("change_time", props.ChangeTime.String()); err != nil {
+		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("create_time", props.CreateTime.String()); err != nil {
+		return fmt.Errorf("%s error setting create_time: %v", errorPrefix, err)
+	}
+	if err = d.Set("status", props.Status); err != nil {
+		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
+	}
+
+	//Get listen ports
+	listenPorts := make([]interface{}, 0)
+	for _, value := range props.ListenPorts {
+		for k, portValue := range value {
+			port := map[string]interface{}{
+				"name": k,
+				"port": portValue,
+			}
+			listenPorts = append(listenPorts, port)
+		}
+	}
+	if err = d.Set("listen_port", listenPorts); err != nil {
+		return fmt.Errorf("%s error setting listen ports: %v", errorPrefix, err)
+	}
+
+	//Set labels
+	if err = d.Set("labels", props.Labels); err != nil {
+		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
+	}
+
+	//Get all available networks
+	networks, err := client.GetNetworkList(context.Background())
+	if err != nil {
+		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
+	}
+	//look for a network that the Redis store service is in
+	for _, network := range networks {
+		securityZones := network.Properties.Relations.PaaSSecurityZones
+		//Each network can contain only one security zone
+		if len(securityZones) >= 1 {
+			if securityZones[0].ObjectUUID == props.SecurityZoneUUID {
+				if err = d.Set("network_uuid", network.Properties.ObjectUUID); err != nil {
+					return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func resourceGridscaleRedisStoreCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+
+	// Get redisStore template UUID
+	release := d.Get("release").(string)
+	performanceClass := d.Get("performance_class").(string)
+	templateUUID, err := getRedisStoreTemplateUUID(client, release, performanceClass)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+
+	requestBody := gsclient.PaaSServiceCreateRequest{
+		Name:                    d.Get("name").(string),
+		PaaSServiceTemplateUUID: templateUUID,
+		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
+		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
+	defer cancel()
+	response, err := client.CreatePaaSService(ctx, requestBody)
+	if err != nil {
+		return err
+	}
+	d.SetId(response.ObjectUUID)
+	log.Printf("The id for Redis store service %s has been set to %v", requestBody.Name, response.ObjectUUID)
+	return resourceGridscaleRedisStoreRead(d, meta)
+}
+
+func resourceGridscaleRedisStoreUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+
+	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
+	requestBody := gsclient.PaaSServiceUpdateRequest{
+		Name:   d.Get("name").(string),
+		Labels: &labels,
+	}
+
+	// Only update templateUUID, when `release` or `performance_class` is changed
+	if d.HasChange("release") || d.HasChange("performance_class") {
+		// Get redisStore template UUID
+		release := d.Get("release").(string)
+		performanceClass := d.Get("performance_class").(string)
+		templateUUID, err := getRedisStoreTemplateUUID(client, release, performanceClass)
+		if err != nil {
+			return fmt.Errorf("%s error: %v", errorPrefix, err)
+		}
+		requestBody.PaaSServiceTemplateUUID = templateUUID
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
+	defer cancel()
+	err := client.UpdatePaaSService(ctx, d.Id(), requestBody)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return resourceGridscaleRedisStoreRead(d, meta)
+}
+
+func resourceGridscaleRedisStoreDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gsclient.Client)
+	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
+	defer cancel()
+	err := errHandler.RemoveErrorContainsHTTPCodes(
+		client.DeletePaaSService(ctx, d.Id()),
+		http.StatusNotFound,
+	)
+	if err != nil {
+		return fmt.Errorf("%s error: %v", errorPrefix, err)
+	}
+	return nil
+}
+
+// getRedisStoreTemplateUUID returns the UUID of the redisStore service template.
+func getRedisStoreTemplateUUID(client *gsclient.Client, release, performanceClass string) (string, error) {
+	paasTemplates, err := client.GetPaaSTemplateList(context.Background())
+	if err != nil {
+		return "", err
+	}
+	var isReleaseValid bool
+	var releases []string
+	var uTemplate gsclient.PaaSTemplate
+	for _, template := range paasTemplates {
+		if template.Properties.Flavour == redisStoreTemplateFlavourName {
+			releases = append(releases, template.Properties.Release)
+			if template.Properties.Release == release && template.Properties.PerformanceClass == performanceClass {
+				isReleaseValid = true
+				uTemplate = template
+			}
+		}
+	}
+	if !isReleaseValid {
+		return "", fmt.Errorf("%v is not a valid RedisStore release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+	}
+
+	return uTemplate.Properties.ObjectUUID, nil
+}

--- a/gridscale/resource_gridscale_redis_store.go
+++ b/gridscale/resource_gridscale_redis_store.go
@@ -98,6 +98,10 @@ func resourceGridscaleRedisStore() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -204,10 +208,11 @@ func resourceGridscaleRedisStoreRead(d *schema.ResourceData, meta interface{}) e
 
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/gridscale/resource_gridscale_redis_store_test.go
+++ b/gridscale/resource_gridscale_redis_store_test.go
@@ -1,0 +1,61 @@
+package gridscale
+
+import (
+	"fmt"
+
+	"github.com/gridscale/gsclient-go/v3"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
+	"testing"
+)
+
+func TestAccResourceGridscaleRedisStore_Basic(t *testing.T) {
+	var object gsclient.PaaSService
+	name := fmt.Sprintf("redis_store-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourceGridscaleRedisStoreConfig_basic(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_redis_store.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_redis_store.test", "name", name),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleRedisStoreConfig_basic_update(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_redis_store.test", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_redis_store.test", "name", "newname"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceGridscaleRedisStoreConfig_basic(name string) string {
+	return fmt.Sprintf(`
+resource "gridscale_redis_store" "test" {
+	name = "%s"
+	release = "5.0"
+	performance_class = "standard"
+}
+`, name)
+}
+
+func testAccCheckResourceGridscaleRedisStoreConfig_basic_update() string {
+	return fmt.Sprintf(`
+resource "gridscale_redis_store" "test" {
+	name = "newname"
+	release = "5.0"
+	performance_class = "standard"
+	labels = ["test"]
+}
+`)
+}

--- a/website/docs/r/redis_cache.html.md
+++ b/website/docs/r/redis_cache.html.md
@@ -57,6 +57,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the Redis cache instance.
 * `listen_port` - The port numbers where this Redis cache service accepts connections.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.

--- a/website/docs/r/redis_cache.html.md
+++ b/website/docs/r/redis_cache.html.md
@@ -1,0 +1,68 @@
+---
+layout: "gridscale"
+page_title: "gridscale: gridscale_redis_cache"
+sidebar_current: "docs-gridscale-resource-redis-cache"
+description: |-
+  Manage a Redis cache service in gridscale.
+---
+
+# gridscale_redis_cache
+
+Provides a Redis cache resource. This can be used to create, modify, and delete Redis cache instances.
+
+## Example
+
+The following example shows how one might use this resource to add a Redis cache service to gridscale:
+
+```terraform
+resource "gridscale_redis_cache" "terra-redis-cache-test" {
+  name = "test"
+  release = "5.0"
+  performance_class = "standard"
+  labels = ["test"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+
+* `release` - (Required) The Redis cache release of this instance. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available Redis cache service releases.
+
+* `performance_class` - (Required) Performance class of Redis cache service. Available performance classes at the time of writing: `standard`, `high`, `insane`, `ultra`.
+
+* `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+
+## Timeouts
+
+Timeouts configuration options (in seconds):
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
+
+* `create` - (Default value is "15m" - 15 minutes) Used for creating a resource.
+* `update` - (Default value is "15m" - 15 minutes) Used for updating a resource.
+* `delete` - (Default value is "15m" - 15 minutes) Used for deleting a resource.
+
+## Attributes
+
+This resource exports the following attributes:
+
+* `name` - See Argument Reference above.
+* `release` - See Argument Reference above.
+* `performance_class` - See Argument Reference above.
+* `username` - Username for PaaS service. It is used to connect to the Redis cache instance.
+* `password` - Password for PaaS service. It is used to connect to the Redis cache instance.
+* `listen_port` - The port numbers where this Redis cache service accepts connections.
+  * `name` - Name of a port.
+  * `listen_port` - Port number.
+* `security_zone_uuid` - See Argument Reference above.
+* `network_uuid` - Network UUID containing security zone.
+* `service_template_uuid` - PaaS service template that Redis cache service uses.
+* `usage_in_minutes` - Number of minutes that PaaS service is in use.
+* `change_time` - Time of the last change.
+* `create_time` - Date time this service has been created.
+* `status` - Current status of PaaS service.
+* `labels` - See Argument Reference above.

--- a/website/docs/r/redis_store.html.md
+++ b/website/docs/r/redis_store.html.md
@@ -1,0 +1,68 @@
+---
+layout: "gridscale"
+page_title: "gridscale: gridscale_redis_store"
+sidebar_current: "docs-gridscale-resource-redis-store"
+description: |-
+  Manage a Redis store service in gridscale.
+---
+
+# gridscale_redis_store
+
+Provides a Redis store resource. This can be used to create, modify, and delete Redis store instances.
+
+## Example
+
+The following example shows how one might use this resource to add a Redis store service to gridscale:
+
+```terraform
+resource "gridscale_redis_store" "terra-redis-store-test" {
+  name = "test"
+  release = "5.0"
+  performance_class = "standard"
+  labels = ["test"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
+
+* `release` - (Required) The Redis store release of this instance. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available Redis store service releases.
+
+* `performance_class` - (Required) Performance class of Redis store service. Available performance classes at the time of writing: `standard`, `high`, `insane`, `ultra`.
+
+* `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+
+## Timeouts
+
+Timeouts configuration options (in seconds):
+More info: [terraform.io/docs/configuration/resources.html#operation-timeouts](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)
+
+* `create` - (Default value is "15m" - 15 minutes) Used for creating a resource.
+* `update` - (Default value is "15m" - 15 minutes) Used for updating a resource.
+* `delete` - (Default value is "15m" - 15 minutes) Used for deleting a resource.
+
+## Attributes
+
+This resource exports the following attributes:
+
+* `name` - See Argument Reference above.
+* `release` - See Argument Reference above.
+* `performance_class` - See Argument Reference above.
+* `username` - Username for PaaS service. It is used to connect to the Redis store instance.
+* `password` - Password for PaaS service. It is used to connect to the Redis store instance.
+* `listen_port` - The port numbers where this Redis store service accepts connections.
+  * `name` - Name of a port.
+  * `listen_port` - Port number.
+* `security_zone_uuid` - See Argument Reference above.
+* `network_uuid` - Network UUID containing security zone.
+* `service_template_uuid` - PaaS service template that Redis store service uses.
+* `usage_in_minutes` - Number of minutes that PaaS service is in use.
+* `change_time` - Time of the last change.
+* `create_time` - Date time this service has been created.
+* `status` - Current status of PaaS service.
+* `labels` - See Argument Reference above.

--- a/website/docs/r/redis_store.html.md
+++ b/website/docs/r/redis_store.html.md
@@ -57,6 +57,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the Redis store instance.
 * `listen_port` - The port numbers where this Redis store service accepts connections.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -98,6 +98,9 @@
             <li<%= sidebar_current("docs-gridscale-resource-redis-store") %>>
               <a href="/docs/providers/gridscale/r/redis_store.html">gridscale_redis_store</a>
             </li>
+            <li<%= sidebar_current("docs-gridscale-resource-redis-cache") %>>
+              <a href="/docs/providers/gridscale/r/redis_cache.html">gridscale_redis_cache</a>
+            </li>
             <li<%= sidebar_current("docs-gridscale-resource-k8s") %>>
               <a href="/docs/providers/gridscale/r/k8s.html">gridscale_k8s</a>
             </li>

--- a/website/gridscale.erb
+++ b/website/gridscale.erb
@@ -95,6 +95,9 @@
             <li<%= sidebar_current("docs-gridscale-resource-paas") %>>
               <a href="/docs/providers/gridscale/r/paas.html">gridscale_paas</a>
             </li>
+            <li<%= sidebar_current("docs-gridscale-resource-redis-store") %>>
+              <a href="/docs/providers/gridscale/r/redis_store.html">gridscale_redis_store</a>
+            </li>
             <li<%= sidebar_current("docs-gridscale-resource-k8s") %>>
               <a href="/docs/providers/gridscale/r/k8s.html">gridscale_k8s</a>
             </li>


### PR DESCRIPTION
Ref #138 and #139. Add Redis store/cache resources to gs terraform provider.
What changes:
- Add new tf resources "gridscale_redis_store" and "gridscale_redis_cache".
- Add "gridscale_redis_**" resources' docs.
- Add "gridscale_redis_**" resource's acceptance test.
- Add "gridscale_redis_**" GH Actions workflow.

What it does:
- Manage Redis store/ca resources in gridscale.
- Allow user to input release (e.g. "5.0") and performance_class (e.g. "insane"), instead of `service_template_uuid`.