### PR TITLE
Add field `host` to PaaS resources.

### DIFF
--- a/gridscale/resource_gridscale_mariadb.go
+++ b/gridscale/resource_gridscale_mariadb.go
@@ -161,6 +161,10 @@ func resourceGridscaleMariaDB() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -305,10 +309,11 @@ func resourceGridscaleMariaDBRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/gridscale/resource_gridscale_mysql.go
+++ b/gridscale/resource_gridscale_mysql.go
@@ -161,6 +161,10 @@ func resourceGridscaleMySQL() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -305,10 +309,11 @@ func resourceGridscaleMySQLRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -59,6 +59,10 @@ func resourceGridscalePaaS() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -233,10 +237,11 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/gridscale/resource_gridscale_postgresql.go
+++ b/gridscale/resource_gridscale_postgresql.go
@@ -118,6 +118,10 @@ func resourceGridscalePostgreSQL() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -236,10 +240,11 @@ func resourceGridscalePostgreSQLRead(d *schema.ResourceData, meta interface{}) e
 
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/gridscale/resource_gridscale_sqlserver.go
+++ b/gridscale/resource_gridscale_sqlserver.go
@@ -116,6 +116,10 @@ func resourceGridscaleMSSQLServer() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"host": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"port": {
 							Type:     schema.TypeInt,
 							Computed: true,
@@ -261,10 +265,11 @@ func resourceGridscaleMSSQLServerRead(d *schema.ResourceData, meta interface{}) 
 
 	//Get listen ports
 	listenPorts := make([]interface{}, 0)
-	for _, value := range props.ListenPorts {
+	for host, value := range props.ListenPorts {
 		for k, portValue := range value {
 			port := map[string]interface{}{
 				"name": k,
+				"host": host,
 				"port": portValue,
 			}
 			listenPorts = append(listenPorts, port)

--- a/website/docs/r/mariadb.html.md
+++ b/website/docs/r/mariadb.html.md
@@ -16,11 +16,11 @@ The following example shows how one might use this resource to add a MariaDB ser
 
 ```terraform
 resource "gridscale_mariadb" "terra-mariadb-test" {
-    name = "my mariadb"
+  name = "my mariadb"
 	release = "10.5"
 	performance_class = "insane"
-    max_core_count = 20
-    mariadb_query_cache_limit = "2M"
+  max_core_count = 20
+  mariadb_query_cache_limit = "2M"
 	mariadb_default_time_zone = "Europe/Berlin"
 	mariadb_server_id = 2
 	mariadb_binlog_format = "STATEMENT"
@@ -93,6 +93,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the MariaDB instance.
 * `listen_port` - The port numbers where this MariaDB service accepts connections.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.

--- a/website/docs/r/mysql.html.md
+++ b/website/docs/r/mysql.html.md
@@ -16,11 +16,11 @@ The following example shows how one might use this resource to add a MySQL servi
 
 ```terraform
 resource "gridscale_mysql" "terra-mysql-test" {
-    name = "my mysql"
+  name = "my mysql"
 	release = "5.7"
 	performance_class = "insane"
-    max_core_count = 20
-    mysql_query_cache_limit = "2M"
+  max_core_count = 20
+  mysql_query_cache_limit = "2M"
 	mysql_default_time_zone = "Europe/Berlin"
 	mysql_server_id = 2
 	mysql_binlog_format = "STATEMENT"
@@ -93,6 +93,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the mysql instance.
 * `listen_port` - The port numbers where this mysql service accepts connections.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -68,6 +68,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service.
 * `listen_port` - Ports that PaaS service listens to.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.

--- a/website/docs/r/postgres.html.md
+++ b/website/docs/r/postgres.html.md
@@ -60,6 +60,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the PostgreSQL instance.
 * `listen_port` - The port numbers where this PostgreSQL service accepts connections.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone.

--- a/website/docs/r/sqlserver.html.md
+++ b/website/docs/r/sqlserver.html.md
@@ -67,6 +67,7 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the MS SQL server instance.
 * `listen_port` - The port numbers where this MS SQL server service accepts connections.
   * `name` - Name of a port.
+  * `host` - Host address.
   * `listen_port` - Port number.
 * `s3_backup` - See Argument Reference above.
   * `backup_bucket` - See Argument Reference above.


### PR DESCRIPTION
Changes:
- Add field `host` to PaaS resources: `gridscale_mariadb`, `gridscale_mysql`, `gridscale_postgresql`, `gridscale_sqlserver` and `gridscale_paas`.
- Update docs (add info about the field `host`)

FYI, the field `host` can be used along with the fields `port`, `username`, and `password` to connect to the PaaS within a network.