### PR TITLE
Allow setting storage variant.

### DIFF
--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -11,6 +11,7 @@ import (
 //Arrays can't be constants in Go, but these will be used as constants
 var hardwareProfiles = []string{"default", "legacy", "nested", "cisco_csr", "sophos_utm", "f5_bigip", "q35", "q35_nested"}
 var storageTypes = []string{"storage", "storage_high", "storage_insane"}
+var storageVariants = []string{"distributed", "local"}
 var availabilityZones = []string{"a", "b", "c"}
 var loadbalancerAlgs = []string{"roundrobin", "leastconn"}
 var passwordTypes = []string{"plain", "crypt"}

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -74,6 +74,7 @@ func resourceGridscaleStorage() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Storage variant (one of local or distributed).",
 				Optional:    true,
+				Default:     "distributed",
 				ForceNew:    true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					valid := false

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -74,7 +74,6 @@ func resourceGridscaleStorage() *schema.Resource {
 				Type:        schema.TypeString,
 				Description: "Storage variant (one of local or distributed).",
 				Optional:    true,
-				Default:     "distributed",
 				ForceNew:    true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					valid := false
@@ -290,7 +289,7 @@ func resourceGridscaleStorageUpdate(d *schema.ResourceData, meta interface{}) er
 
 	// Only distributed storage variant allows
 	// to set storage type.
-	storageVariant := d.Get("storage_variant").(string)
+	storageVariant, _ := d.Get("storage_variant").(string)
 	if storageVariant == "" || storageVariant == "distributed" {
 		storageType := d.Get("storage_type").(string)
 		if storageType == "storage" || storageType == "" {
@@ -340,7 +339,7 @@ func resourceGridscaleStorageCreate(d *schema.ResourceData, meta interface{}) er
 
 	// Only distributed storage variant allows
 	// to set storage type.
-	storageVariant := d.Get("storage_variant").(string)
+	storageVariant, _ := d.Get("storage_variant").(string)
 	if storageVariant == "" || storageVariant == "distributed" {
 		storageType := d.Get("storage_type").(string)
 		if storageType == "storage" || storageType == "" {

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -41,6 +41,8 @@ The following arguments are supported:
 
 * `storage_type` - (Optional) (one of storage, storage_high, storage_insane).
 
+* `storage_variant` - (Optional) Storage variant (one of local or distributed).
+
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
 * `rollback_from_backup_uuid` - (Optional) Rollback the storage from a specific storage backup.
@@ -75,6 +77,7 @@ This resource exports the following attributes:
 * `name` - See Argument Reference above.
 * `capacity` - See Argument Reference above.
 * `storage_type` - See Argument Reference above.
+* `storage_variant` - See Argument Reference above.
 * `location_uuid` - The location this storage is placed. The location of a resource is determined by it's project.
 * `labels` - See Argument Reference above.
 * `rollback_from_backup_uuid` - See Argument Reference above.

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `capacity` - (Required) required (integer - minimum: 1 - maximum: 4096).
 
-* `storage_type` - (Optional) (one of storage, storage_high, storage_insane). **Note**: This field will be skipped, if `storage_variant` is set to `local`.
+* `storage_type` - (Optional) (one of storage, storage_high, storage_insane).
 
 * `storage_variant` - (Optional) Storage variant (one of local or distributed).
 

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -39,7 +39,7 @@ The following arguments are supported:
 
 * `capacity` - (Required) required (integer - minimum: 1 - maximum: 4096).
 
-* `storage_type` - (Optional) (one of storage, storage_high, storage_insane).
+* `storage_type` - (Optional) (one of storage, storage_high, storage_insane). **Note**: This field will be skipped, if `storage_variant` is set to `local`.
 
 * `storage_variant` - (Optional) Storage variant (one of local or distributed).
 

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `storage_type` - (Optional) (one of storage, storage_high, storage_insane).
 
-* `storage_variant` - (Optional) Storage variant (one of local or distributed).
+* `storage_variant` - (Optional) Storage variant (one of local or distributed). Default: "distributed".
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 


### PR DESCRIPTION
Changes:
- Add field `storage_variant`, which allows to set storage variant.
- Update storage resource's documentation.
Expected behaviour:
- If `storage_variant` is set to `local`, setting `storage_type` returns an error.
- A change in `storage_variant` causes Force New effect.