### PR TITLE
Remove q35_nested server hardware profile

### DIFF
--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 //Arrays can't be constants in Go, but these will be used as constants
-var hardwareProfiles = []string{"default", "legacy", "nested", "cisco_csr", "sophos_utm", "f5_bigip", "q35", "q35_nested"}
+var hardwareProfiles = []string{"default", "legacy", "nested", "cisco_csr", "sophos_utm", "f5_bigip", "q35"}
 var storageTypes = []string{"storage", "storage_high", "storage_insane"}
 var availabilityZones = []string{"a", "b", "c"}
 var loadbalancerAlgs = []string{"roundrobin", "leastconn"}

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional) If the server should be auto-started in case of a failure (default=true).
 
-* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. Check the
+* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Available options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip, and q35.
 
 * `ipv4` - (Optional) The UUID of the IPv4 address of the server. (***NOTE: The server will NOT automatically be connected to the public network; to give it access to the internet, please add server to the public network.)
 


### PR DESCRIPTION
- Remove q35_nested server hardware profile.
- Update server resource's documentation.