### PR TITLE
Fix "ordering of network in server resource always asks for update"

### DIFF
--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -127,7 +127,7 @@ func (c *ServerRelationManger) LinkNetworks(ctx context.Context) error {
 	d := c.getData()
 	client := c.getGSClient()
 	if attrNetRel, ok := d.GetOk("network"); ok {
-		for _, value := range attrNetRel.([]interface{}) {
+		for _, value := range attrNetRel.(*schema.Set).List() {
 			// customFwRulesPtr is nil initially, that mean the fw is inactive
 			var customFwRulesPtr *gsclient.FirewallRules
 			network := value.(map[string]interface{})
@@ -322,7 +322,7 @@ func (c *ServerRelationManger) UpdateNetworksRel(ctx context.Context) error {
 	if d.HasChange("network") {
 		oldNetworks, _ := d.GetChange("network")
 		//Unlink all old networks if there are any networks linked to the server
-		for _, value := range oldNetworks.([]interface{}) {
+		for _, value := range oldNetworks.(*schema.Set).List() {
 			network := value.(map[string]interface{})
 			if network["object_uuid"].(string) != "" {
 				//If 404 or 409, that means network is already deleted => the relation between network and server is deleted automatically

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -133,7 +133,7 @@ func resourceGridscaleServer() *schema.Resource {
 			},
 
 			"network": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				MaxItems: 7,
 				Elem: &schema.Resource{

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -189,8 +189,7 @@ func resourceGridscaleServer() *schema.Resource {
 						},
 						"ordering": {
 							Type:     schema.TypeInt,
-							Optional: true,
-							Default:  0,
+							Required: true,
 						},
 						"create_time": {
 							Type:     schema.TypeString,

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -129,6 +129,7 @@ resource "gridscale_server" "foo" {
   ipv4 = gridscale_ipv4.foo.id
   network {
 		object_uuid = gridscale_network.foo.id
+		ordering = 0
 		rules_v4_in {
 				order = 0
 				protocol = "tcp"
@@ -178,6 +179,7 @@ resource "gridscale_server" "foo" {
   ipv4 = gridscale_ipv4.foo1.id
   network {
 		object_uuid = gridscale_network.foo.id
+		ordering = 0
 		rules_v4_in {
 				order = 0
 				protocol = "tcp"

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -111,7 +111,7 @@ The following arguments are supported:
 
     * `object_uuid` - (Required) The object UUID or id of the network.
 
-    * `ordering` - (Optional) Defines the ordering of the network interfaces. Lower numbers have lower PCI-IDs.
+    * `ordering` - (Required) Defines the ordering of the network interfaces. Lower numbers have lower PCI-IDs.
 
     * `bootdevice` - (Optional, Computed) Make this network the boot device. This can only be set for one network.
 


### PR DESCRIPTION
Fix #142. Changes:
- "network.k.ordering" is required (**breaking change**).
- "network"'s type is `TypeSet`.