### PR TITLE
Set Q35 as default HW Profile

### DIFF
--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -58,7 +58,7 @@ func resourceGridscaleServer() *schema.Resource {
 				Description: "The number of server cores.",
 				Optional:    true,
 				ForceNew:    true,
-				Default:     "default",
+				Default:     "q35",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					valid := false
 					for _, profile := range hardwareProfiles {

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional) If the server should be auto-started in case of a failure (default=true).
 
-* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. Check the
+* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35. Default: q35.
 
 * `ipv4` - (Optional) The UUID of the IPv4 address of the server. (***NOTE: The server will NOT automatically be connected to the public network; to give it access to the internet, please add server to the public network.)
 


### PR DESCRIPTION
Ref #141. Changes:
- Set Q35 as default HW Profile.
- Update docs.