### PR TITLE
Deprecate `current_price` field.

### DIFF
--- a/gridscale/datasource_gridscale_ipv4.go
+++ b/gridscale/datasource_gridscale_ipv4.go
@@ -93,11 +93,6 @@ func dataSourceGridscaleIpv4() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 	}
 }
@@ -155,9 +150,6 @@ func dataSourceGridscaleIpv4Read(d *schema.ResourceData, meta interface{}) error
 	}
 	if err = d.Set("usage_in_minutes", ip.Properties.UsagesInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", ip.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("labels", ip.Properties.Labels); err != nil {
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_ipv6.go
+++ b/gridscale/datasource_gridscale_ipv6.go
@@ -93,11 +93,6 @@ func dataSourceGridscaleIpv6() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 	}
 }
@@ -155,9 +150,6 @@ func dataSourceGridscaleIpv6Read(d *schema.ResourceData, meta interface{}) error
 	}
 	if err = d.Set("usage_in_minutes", ip.Properties.UsagesInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", ip.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("labels", ip.Properties.Labels); err != nil {
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_isoimage.go
+++ b/gridscale/datasource_gridscale_isoimage.go
@@ -123,11 +123,6 @@ func dataSourceGridscaleISOImage() *schema.Resource {
 				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 	}
 }
@@ -186,9 +181,6 @@ func dataSourceGridscaleISOImageRead(d *schema.ResourceData, meta interface{}) e
 	}
 	if err = d.Set("capacity", props.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 
 	servers := make([]interface{}, 0)

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -74,11 +74,6 @@ func dataSourceGridscalePaaS() *schema.Resource {
 				Description: "Number of minutes that PaaS service is in use",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Current price of PaaS service",
-				Computed:    true,
-			},
 			"change_time": {
 				Type:        schema.TypeString,
 				Description: "Time of the last change",
@@ -174,9 +169,6 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 	}
 	if err = d.Set("usage_in_minute", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minute: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("change_time", props.ChangeTime.String()); err != nil {
 		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_server.go
+++ b/gridscale/datasource_gridscale_server.go
@@ -191,10 +191,6 @@ func dataSourceGridscaleServer() *schema.Resource {
 				Description: "The number of server cores.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
 			"auto_recovery": {
 				Type:        schema.TypeBool,
 				Description: "If the server should be auto-started in case of a failure (default=true).",
@@ -285,9 +281,6 @@ func dataSourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) err
 	}
 	if err = d.Set("change_time", server.Properties.ChangeTime.String()); err != nil {
 		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", server.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("availability_zone", server.Properties.AvailabilityZone); err != nil {
 		return fmt.Errorf("%s error setting availability_zone: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_snapshot.go
+++ b/gridscale/datasource_gridscale_snapshot.go
@@ -76,11 +76,6 @@ func dataSourceGridscaleStorageSnapshot() *schema.Resource {
 				Description: `If a template has been used that requires a license key (e.g. Windows Servers) this shows
 the product_no of the license (see the /prices endpoint for more details)`,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "The price for the current period since the last bill",
-			},
 			"capacity": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -139,9 +134,6 @@ func dataSourceGridscaleSnapshotRead(d *schema.ResourceData, meta interface{}) e
 	}
 	if err = d.Set("license_product_no", props.LicenseProductNo); err != nil {
 		return fmt.Errorf("%s error setting license_product_no: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("capacity", props.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_storage.go
+++ b/gridscale/datasource_gridscale_storage.go
@@ -82,10 +82,6 @@ func dataSourceGridscaleStorage() *schema.Resource {
 				Description: "Uses IATA airport code, which works as a location identifier.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
 			"usage_in_minutes": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -132,9 +128,6 @@ func dataSourceGridscaleStorageRead(d *schema.ResourceData, meta interface{}) er
 	}
 	if err = d.Set("last_used_template", storage.Properties.LastUsedTemplate); err != nil {
 		return fmt.Errorf("%s error setting last_used_template: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", storage.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("capacity", storage.Properties.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_template.go
+++ b/gridscale/datasource_gridscale_template.go
@@ -102,11 +102,6 @@ func dataSourceGridscaleTemplate() *schema.Resource {
 				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 	}
 }
@@ -168,10 +163,6 @@ func dataSourceGridscaleTemplateRead(d *schema.ResourceData, meta interface{}) e
 	if err = d.Set("capacity", template.Properties.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)
 	}
-	if err = d.Set("current_price", template.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
-	}
-
 	if err = d.Set("labels", template.Properties.Labels); err != nil {
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -99,11 +99,6 @@ func resourceGridscaleIpv4() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
@@ -166,10 +161,6 @@ func resourceGridscaleIpRead(d *schema.ResourceData, meta interface{}) error {
 	if err = d.Set("usage_in_minutes", ip.Properties.UsagesInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
 	}
-	if err = d.Set("current_price", ip.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
-	}
-
 	if err = d.Set("labels", ip.Properties.Labels); err != nil {
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_ipv6.go
+++ b/gridscale/resource_gridscale_ipv6.go
@@ -95,11 +95,6 @@ func resourceGridscaleIpv6() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -125,11 +125,6 @@ func resourceGridscaleISOImage() *schema.Resource {
 				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
@@ -194,9 +189,6 @@ func resourceGridscaleISOImageRead(d *schema.ResourceData, meta interface{}) err
 	}
 	if err = d.Set("capacity", props.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 
 	servers := make([]interface{}, 0)

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -98,11 +98,6 @@ func resourceGridscalePaaS() *schema.Resource {
 				Description: "Number of minutes that PaaS service is in use",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Current price of PaaS service",
-				Computed:    true,
-			},
 			"change_time": {
 				Type:        schema.TypeString,
 				Description: "Time of the last change",
@@ -221,9 +216,6 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 	}
 	if err = d.Set("usage_in_minute", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minute: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("change_time", props.ChangeTime.String()); err != nil {
 		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -221,10 +221,6 @@ func resourceGridscaleServer() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
-			"current_price": {
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
 			"auto_recovery": {
 				Type:        schema.TypeBool,
 				Description: "If the server should be auto-started in case of a failure (default=true).",
@@ -422,9 +418,6 @@ func resourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) error
 	}
 	if err = d.Set("change_time", server.Properties.ChangeTime.String()); err != nil {
 		return fmt.Errorf("%s error setting change_time: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", server.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("availability_zone", server.Properties.AvailabilityZone); err != nil {
 		return fmt.Errorf("%s error setting availability_zone: %v", errorPrefix, err)

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -76,11 +76,6 @@ func resourceGridscaleStorageSnapshot() *schema.Resource {
 				Description: `If a template has been used that requires a license key (e.g. Windows Servers) this shows
 the product_no of the license (see the /prices endpoint for more details)`,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Computed:    true,
-				Description: "The price for the current period since the last bill",
-			},
 			"capacity": {
 				Type:        schema.TypeInt,
 				Computed:    true,
@@ -217,9 +212,6 @@ func resourceGridscaleSnapshotRead(d *schema.ResourceData, meta interface{}) err
 	}
 	if err = d.Set("license_product_no", props.LicenseProductNo); err != nil {
 		return fmt.Errorf("%s error setting license_product_no: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("capacity", props.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -132,10 +132,6 @@ func resourceGridscaleStorage() *schema.Resource {
 				Description: "Uses IATA airport code, which works as a location identifier.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
 			"usage_in_minutes": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -244,9 +240,6 @@ func resourceGridscaleStorageRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if err = d.Set("last_used_template", storage.Properties.LastUsedTemplate); err != nil {
 		return fmt.Errorf("%s error setting last_used_template: %v", errorPrefix, err)
-	}
-	if err = d.Set("current_price", storage.Properties.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
 	}
 	if err = d.Set("capacity", storage.Properties.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)

--- a/gridscale/resource_gridscale_storage_clone.go
+++ b/gridscale/resource_gridscale_storage_clone.go
@@ -110,10 +110,6 @@ func resourceGridscaleStorageClone() *schema.Resource {
 				Description: "Uses IATA airport code, which works as a location identifier.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
 			"usage_in_minutes": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/gridscale/resource_gridscale_storage_import.go
+++ b/gridscale/resource_gridscale_storage_import.go
@@ -109,10 +109,6 @@ func resourceGridscaleStorageImport() *schema.Resource {
 				Description: "Uses IATA airport code, which works as a location identifier.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:     schema.TypeFloat,
-				Computed: true,
-			},
 			"usage_in_minutes": {
 				Type:     schema.TypeInt,
 				Computed: true,

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -114,11 +114,6 @@ func resourceGridscaleTemplate() *schema.Resource {
 				Description: "The capacity of a storage/ISO image/template/snapshot in GB.",
 				Computed:    true,
 			},
-			"current_price": {
-				Type:        schema.TypeFloat,
-				Description: "Defines the price for the current period since the last bill.",
-				Computed:    true,
-			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
@@ -190,10 +185,6 @@ func resourceGridscaleTemplateRead(d *schema.ResourceData, meta interface{}) err
 	if err = d.Set("capacity", props.Capacity); err != nil {
 		return fmt.Errorf("%s error setting capacity: %v", errorPrefix, err)
 	}
-	if err = d.Set("current_price", props.CurrentPrice); err != nil {
-		return fmt.Errorf("%s error setting current_price: %v", errorPrefix, err)
-	}
-
 	if err = d.Set("labels", props.Labels); err != nil {
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}

--- a/website/docs/d/ip.html.md
+++ b/website/docs/d/ip.html.md
@@ -56,5 +56,4 @@ The following attributes are exported:
 * `change_time` - The date and time of the last ip change.
 * `delete_block` - Defines if the IP is administratively blocked.
 * `usage_in_minutes` - Total minutes the IP has been running.
-* `current_price` - The price for the current period since the last bill.
 * `labels` - The list of labels.

--- a/website/docs/d/isoimage.html.md
+++ b/website/docs/d/isoimage.html.md
@@ -53,5 +53,4 @@ The following attributes are exported:
 * `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/ISO Image/snapshot in GB.
-* `current_price` - Defines the price for the current period since the last bill.
 * `labels` - List of labels.

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -45,7 +45,6 @@ The following attributes are exported:
 * `network_uuid` - Network UUID containing security zone.
 * `service_template_uuid` - The template used to create the service.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.
-* `current_price` - Current price of PaaS service.
 * `change_time` - Time of the last change.
 * `create_time` - Time of the creation.
 * `status` - Current status of PaaS service.

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -145,4 +145,3 @@ This resource exports the following attributes:
 * `usage_in_minutes_cores` - Total minutes of cores used.
 * `create_time` - Defines the date and time the object was initially created.
 * `change_time` - Defines the date and time of the last object change.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/d/snapshot.html.md
+++ b/website/docs/d/snapshot.html.md
@@ -51,7 +51,6 @@ The following attributes are exported:
 * `create_time` - The date and time the ip was initially created.
 * `change_time` - The date and time of the last snapshot change.
 * `usage_in_minutes` - Total minutes the ip has been running.
-* `current_price` - The price for the current period since the last bill.
 * `capacity` - The capacity of the snapshot in GB.
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `labels` - The list of labels.

--- a/website/docs/d/storage.html.md
+++ b/website/docs/d/storage.html.md
@@ -47,7 +47,6 @@ The following attributes are exported:
 * `location_country` - The human-readable name of the country where the storage locates.
 * `usage_in_minutes` - Total minutes the the storage has been running.
 * `last_used_template` - The UUID of the last used template on the storage.
-* `current_price` - The price for the current period since the last bill.
 * `capacity` - The capacity (GB) of the storage.
 * `location_uuid` - The UUID of the location where the storage locates.
 * `storage_type` - The type of the storage.

--- a/website/docs/d/template.html.md
+++ b/website/docs/d/template.html.md
@@ -62,5 +62,4 @@ The following attributes are exported:
 * `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/template/snapshot in GB.
-* `current_price` - Defines the price for the current period since the last bill.
 * `labels` - List of labels.

--- a/website/docs/r/ipv4.html.md
+++ b/website/docs/r/ipv4.html.md
@@ -63,4 +63,3 @@ This resource exports the following attributes:
 * `location_name` - The location name.
 * `delete_block` - Defines if the object is administratively blocked. If true, it can not be deleted by the user.
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/r/ipv6.html.md
+++ b/website/docs/r/ipv6.html.md
@@ -63,4 +63,3 @@ This resource exports the following attributes:
 * `location_name` - The location name.
 * `delete_block` - Defines if the object is administratively blocked. If true, it can not be deleted by the user.
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/r/isoimage.html.md
+++ b/website/docs/r/isoimage.html.md
@@ -65,5 +65,4 @@ The following attributes are exported:
 * `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/ISO Image/snapshot in GB.
-* `current_price` - Defines the price for the current period since the last bill.
 * `labels` - List of labels.

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -75,7 +75,6 @@ This resource exports the following attributes:
 * `service_template_uuid` - See Argument Reference above.
 * `service_template_uuid_computed` - Template that PaaS service uses. The `service_template_uuid_computed` will be different from `service_template_uuid`, when `service_template_uuid` is updated outside of terraform.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.
-* `current_price` - Current price of PaaS service.
 * `change_time` - Time of the last change.
 * `create_time` - Time of the creation.
 * `status` - Current status of PaaS service.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -280,4 +280,3 @@ This resource exports the following attributes:
 * `usage_in_minutes_cores` - Total minutes of cores used.
 * `create_time` - Defines the date and time the object was initially created.
 * `change_time` - Defines the date and time of the last object change.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -79,7 +79,6 @@ The following attributes are exported:
 * `create_time` - The date and time the ip was initially created.
 * `change_time` - The date and time of the last snapshot change.
 * `usage_in_minutes` - Total minutes the ip has been running.
-* `current_price` - The price for the current period since the last bill.
 * `capacity` - The capacity of the snapshot in GB.
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `object_storage_export` - See Argument Reference above.

--- a/website/docs/r/storage.html.md
+++ b/website/docs/r/storage.html.md
@@ -90,4 +90,3 @@ This resource exports the following attributes:
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `last_used_template` - Indicates the UUID of the last used template on this storage (inherited from snapshots).
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/r/storageclone.html.md
+++ b/website/docs/r/storageclone.html.md
@@ -74,4 +74,3 @@ This resource exports the following attributes:
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `last_used_template` - Indicates the UUID of the last used template on this storage (inherited from snapshots).
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/r/storageimport.html.md
+++ b/website/docs/r/storageimport.html.md
@@ -64,4 +64,3 @@ This resource exports the following attributes:
 * `license_product_no` - If a template has been used that requires a license key (e.g. Windows Servers) this shows the product_no of the license (see the /prices endpoint for more details).
 * `last_used_template` - Indicates the UUID of the last used template on this storage (inherited from snapshots).
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
-* `current_price` - The price for the current period since the last bill.

--- a/website/docs/r/template.html.md
+++ b/website/docs/r/template.html.md
@@ -74,5 +74,4 @@ The following attributes are exported:
 * `description` - Description of the template.
 * `usage_in_minutes` - Total minutes the object has been running.
 * `capacity` - The capacity of a storage/ISO Image/template/snapshot in GB.
-* `current_price` - Defines the price for the current period since the last bill.
 * `labels` - List of labels.


### PR DESCRIPTION
Ref #165 . Changes:
- Remove `current_price` from all resources/datasources.
- Remove `current_price` from docs.