### PR TITLE
Add DHCP options to network resource/data source

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/terraform-providers/terraform-provider-gridscale
 
 require (
-	github.com/gridscale/gsclient-go/v3 v3.6.3
+	github.com/gridscale/gsclient-go/v3 v3.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,8 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
-github.com/gridscale/gsclient-go/v3 v3.6.3 h1:YF3/088C/zLed+BANMOdfh6KKrhsDJOjCsh4iHY+fzk=
-github.com/gridscale/gsclient-go/v3 v3.6.3/go.mod h1:A9+Af0aJL+uei0DwAEnZ3G6gZgdC5oOyw2ZUPxUfvTs=
+github.com/gridscale/gsclient-go/v3 v3.7.0 h1:t3ZzAj9VUW8idmOz1AScYJm+4kd/SP5jYRI2YNROaw8=
+github.com/gridscale/gsclient-go/v3 v3.7.0/go.mod h1:A9+Af0aJL+uei0DwAEnZ3G6gZgdC5oOyw2ZUPxUfvTs=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-checkpoint v0.5.0 h1:MFYpPZCnQqQTE18jFwSII6eUQrD/oxMFp3mlgcqk5mU=

--- a/gridscale/common.go
+++ b/gridscale/common.go
@@ -17,11 +17,11 @@ var supportedPrimTypes = []string{boolInterfaceType, intInterfaceType, floatInte
 
 //convSOStrings converts slice of interfaces to slice of strings
 func convSOStrings(interfaceList []interface{}) []string {
-	labels := make([]string, 0)
-	for _, labelInterface := range interfaceList {
-		labels = append(labels, labelInterface.(string))
+	strList := make([]string, 0)
+	for _, strIntf := range interfaceList {
+		strList = append(strList, strIntf.(string))
 	}
-	return labels
+	return strList
 }
 
 //convStrToTypeInterface converts a string to a primitive type (in the form of interface{})

--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 //Arrays can't be constants in Go, but these will be used as constants
-var hardwareProfiles = []string{"default", "legacy", "nested", "cisco_csr", "sophos_utm", "f5_bigip", "q35", "q35_nested"}
+var hardwareProfiles = []string{"default", "legacy", "nested", "cisco_csr", "sophos_utm", "f5_bigip", "q35"}
 var storageTypes = []string{"storage", "storage_high", "storage_insane"}
 var storageVariants = []string{"distributed", "local"}
 var availabilityZones = []string{"a", "b", "c"}

--- a/gridscale/datasource_gridscale_network.go
+++ b/gridscale/datasource_gridscale_network.go
@@ -58,7 +58,7 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 			},
 			"auto_assigned_servers": {
 				Type:        schema.TypeSet,
-				Description: "Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.",
+				Description: "A list of server UUIDs with the corresponding IPs that are designated by the DHCP server.",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -75,7 +75,7 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 			},
 			"pinned_servers": {
 				Type:        schema.TypeSet,
-				Description: "Contains IP addresses of all servers in the network which got a designated IP by the user.",
+				Description: "A list of server UUIDs with the corresponding IPs that are designated by the user.",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/gridscale/datasource_gridscale_network.go
+++ b/gridscale/datasource_gridscale_network.go
@@ -30,6 +30,66 @@ func dataSourceGridscaleNetwork() *schema.Resource {
 				Description: "MAC spoofing protection - filters layer2 and ARP traffic based on source MAC",
 				Computed:    true,
 			},
+			"dhcp_active": {
+				Type:        schema.TypeBool,
+				Description: "Enable DHCP.",
+				Computed:    true,
+			},
+			"dhcp_range": {
+				Type:        schema.TypeString,
+				Description: "The general IP Range configured for this network (/24 for private networks). If it is not set, gridscale internal default range is used.",
+				Computed:    true,
+			},
+			"dhcp_gateway": {
+				Type:        schema.TypeString,
+				Description: "The IP address reserved and communicated by the dhcp service to be the default gateway.",
+				Computed:    true,
+			},
+			"dhcp_dns": {
+				Type:        schema.TypeString,
+				Description: "DHCP DNS.",
+				Computed:    true,
+			},
+			"dhcp_reserved_subnet": {
+				Type:        schema.TypeSet,
+				Description: "Subrange within the IP range",
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"auto_assigned_servers": {
+				Type:        schema.TypeSet,
+				Description: "Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"pinned_servers": {
+				Type:        schema.TypeSet,
+				Description: "Contains IP addresses of all servers in the network which got a designated IP by the user.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"server_uuid": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"ip": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
 			"status": {
 				Type:        schema.TypeString,
 				Description: "status indicates the status of the object",
@@ -105,6 +165,46 @@ func dataSourceGridscaleNetworkRead(d *schema.ResourceData, meta interface{}) er
 	}
 	if err = d.Set("l2security", network.Properties.L2Security); err != nil {
 		return fmt.Errorf("%s error setting l2security: %v", errorPrefix, err)
+	}
+	if err = d.Set("dhcp_active", network.Properties.DHCPActive); err != nil {
+		return fmt.Errorf("%s error setting dhcp_active: %v", errorPrefix, err)
+	}
+	if err = d.Set("dhcp_range", network.Properties.DHCPRange); err != nil {
+		return fmt.Errorf("%s error setting dhcp_range: %v", errorPrefix, err)
+	}
+	if err = d.Set("dhcp_gateway", network.Properties.DHCPGateway); err != nil {
+		return fmt.Errorf("%s error setting dhcp_gateway: %v", errorPrefix, err)
+	}
+	if err = d.Set("dhcp_dns", network.Properties.DHCPDNS); err != nil {
+		return fmt.Errorf("%s error setting dhcp_dns: %v", errorPrefix, err)
+	}
+	if err = d.Set("dhcp_reserved_subnet", network.Properties.DHCPReservedSubnet); err != nil {
+		return fmt.Errorf("%s error setting dhcp_reserved_subnet: %v", errorPrefix, err)
+	}
+
+	autoAssignedServers := make([]interface{}, 0)
+	for _, value := range network.Properties.AutoAssignedServers {
+		serverWIP := map[string]interface{}{
+			"server_uuid": value.ServerUUID,
+			"ip":          value.IP,
+		}
+		autoAssignedServers = append(autoAssignedServers, serverWIP)
+	}
+	if err = d.Set("auto_assigned_servers", autoAssignedServers); err != nil {
+		return fmt.Errorf("%s error setting auto_assigned_servers: %v", errorPrefix, err)
+	}
+
+	pinnedServers := make([]interface{}, 0)
+	for _, value := range network.Properties.PinnedServers {
+		serverWIP := map[string]interface{}{
+			"server_uuid": value.ServerUUID,
+			"ip":          value.IP,
+		}
+		pinnedServers = append(pinnedServers, serverWIP)
+	}
+
+	if err = d.Set("pinned_servers", pinnedServers); err != nil {
+		return fmt.Errorf("%s error setting pinned_servers: %v", errorPrefix, err)
 	}
 	if err = d.Set("status", network.Properties.Status); err != nil {
 		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)

--- a/gridscale/datasource_gridscale_network_test.go
+++ b/gridscale/datasource_gridscale_network_test.go
@@ -21,6 +21,14 @@ func TestAccdataSourceGridscaleNetwork_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_network.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_network.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"data.gridscale_network.foo", "dhcp_active", "true"),
+					resource.TestCheckResourceAttr(
+						"data.gridscale_network.foo", "dhcp_gateway", "192.168.121.1"),
+					resource.TestCheckResourceAttr(
+						"data.gridscale_network.foo", "dhcp_dns", "192.168.121.2"),
+					resource.TestCheckResourceAttr(
+						"data.gridscale_network.foo", "dhcp_reserved_subnet.#", "1"),
 				),
 			},
 		},
@@ -33,6 +41,11 @@ func testAccCheckDataSourceNetworkConfig_basic(name string) string {
 
 resource "gridscale_network" "foo" {
   name   = "%s"
+  dhcp_active = true
+  dhcp_gateway = "192.168.121.1"
+  dhcp_dns = "192.168.121.2"
+  dhcp_range = "192.168.121.0/27"
+  dhcp_reserved_subnet = ["192.168.121.0/31"]
 }
 
 data "gridscale_network" "foo" {

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -193,6 +193,31 @@ func resourceGridscaleNetworkRead(d *schema.ResourceData, meta interface{}) erro
 	if err = d.Set("dhcp_reserved_subnet", network.Properties.DHCPReservedSubnet); err != nil {
 		return fmt.Errorf("%s error setting dhcp_reserved_subnet: %v", errorPrefix, err)
 	}
+
+	autoAssignedServers := make([]interface{}, 0)
+	for _, value := range network.Properties.AutoAssignedServers {
+		serverWIP := map[string]interface{}{
+			"server_uuid": value.ServerUUID,
+			"ip":          value.IP,
+		}
+		autoAssignedServers = append(autoAssignedServers, serverWIP)
+	}
+	if err = d.Set("auto_assigned_servers", autoAssignedServers); err != nil {
+		return fmt.Errorf("%s error setting auto_assigned_servers: %v", errorPrefix, err)
+	}
+
+	pinnedServers := make([]interface{}, 0)
+	for _, value := range network.Properties.PinnedServers {
+		serverWIP := map[string]interface{}{
+			"server_uuid": value.ServerUUID,
+			"ip":          value.IP,
+		}
+		pinnedServers = append(pinnedServers, serverWIP)
+	}
+	if err = d.Set("pinned_servers", pinnedServers); err != nil {
+		return fmt.Errorf("%s error setting pinned_servers: %v", errorPrefix, err)
+	}
+
 	if err = d.Set("status", network.Properties.Status); err != nil {
 		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
 	}

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -79,7 +79,7 @@ func resourceGridscaleNetwork() *schema.Resource {
 				},
 			},
 			"pinned_servers": {
-				Type:        schema.TypeString,
+				Type:        schema.TypeSet,
 				Description: "Contains IP addresses of all servers in the network which got a designated IP by the user.",
 				Computed:    true,
 				Elem: &schema.Resource{

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -63,7 +63,7 @@ func resourceGridscaleNetwork() *schema.Resource {
 			},
 			"auto_assigned_servers": {
 				Type:        schema.TypeSet,
-				Description: "Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.",
+				Description: "A list of server UUIDs with the corresponding IPs that are designated by the DHCP server.",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -80,7 +80,7 @@ func resourceGridscaleNetwork() *schema.Resource {
 			},
 			"pinned_servers": {
 				Type:        schema.TypeSet,
-				Description: "Contains IP addresses of all servers in the network which got a designated IP by the user.",
+				Description: "A list of server UUIDs with the corresponding IPs that are designated by the user.",
 				Computed:    true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -57,7 +57,7 @@ func resourceGridscaleNetwork() *schema.Resource {
 			},
 			"dhcp_reserved_subnet": {
 				Type:        schema.TypeSet,
-				Description: "Subrange within the IP range",
+				Description: "Subrange within the IP range.",
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},

--- a/gridscale/resource_gridscale_network_test.go
+++ b/gridscale/resource_gridscale_network_test.go
@@ -27,6 +27,14 @@ func TestAccResourceGridscaleNetwork_Basic(t *testing.T) {
 					testAccCheckResourceGridscaleNetworkExists("gridscale_network.foo", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_network.foo", "name", name),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_active", "true"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_gateway", "192.168.121.1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_dns", "192.168.121.2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_reserved_subnet.#", "1"),
 				),
 			},
 			{
@@ -37,6 +45,14 @@ func TestAccResourceGridscaleNetwork_Basic(t *testing.T) {
 						"gridscale_network.foo", "name", "newname"),
 					resource.TestCheckResourceAttr(
 						"gridscale_network.foo", "l2security", "true"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_active", "true"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_gateway", "192.168.122.1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_dns", "192.168.122.2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_network.foo", "dhcp_reserved_subnet.#", "1"),
 				),
 			},
 		},
@@ -103,15 +119,25 @@ func testAccCheckResourceGridscaleNetworkConfig_basic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_network" "foo" {
   name   = "%s"
+  dhcp_active = true
+  dhcp_gateway = "192.168.121.1"
+  dhcp_dns = "192.168.121.2"
+  dhcp_range = "192.168.121.0/27"
+  dhcp_reserved_subnet = ["192.168.121.0/31"]
 }
 `, name)
 }
 
 func testAccCheckResourceGridscaleNetworkConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return fmt.Sprint(`
 resource "gridscale_network" "foo" {
   name   = "newname"
   l2security = true
+  dhcp_active = true
+  dhcp_gateway = "192.168.122.1"
+  dhcp_dns = "192.168.122.2"
+  dhcp_range = "192.168.122.0/27"
+  dhcp_reserved_subnet = ["192.168.122.0/31"]
 }
 `)
 }

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -616,8 +616,6 @@ func resourceGridscaleServerCreate(d *schema.ResourceData, meta interface{}) err
 		requestBody.HardwareProfile = gsclient.F5BigipServerHardware
 	} else if profile == "q35" {
 		requestBody.HardwareProfile = gsclient.Q35ServerHardware
-	} else if profile == "q35_nested" {
-		requestBody.HardwareProfile = gsclient.Q35NestedServerHardware
 	} else {
 		requestBody.HardwareProfile = gsclient.DefaultServerHardware
 	}

--- a/vendor/github.com/gridscale/gsclient-go/v3/CHANGELOG.md
+++ b/vendor/github.com/gridscale/gsclient-go/v3/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.7.0 (Aug 30, 2021)
+
+FEATURES:
+
+* Add DHCP options to network create/update operations ([#206](https://github.com/gridscale/gsclient-go/issues/206)).
+* Add DHCP-relating properties to network's properties ([#206](https://github.com/gridscale/gsclient-go/issues/206)).
+
 ## 3.6.3 (May 11, 2021)
 
 BUG FIXES:

--- a/vendor/github.com/gridscale/gsclient-go/v3/config.go
+++ b/vendor/github.com/gridscale/gsclient-go/v3/config.go
@@ -13,7 +13,7 @@ import (
 const (
 	defaultMaxNumberOfRetries     = 5
 	defaultDelayIntervalMilliSecs = 1000
-	version                       = "3.6.3"
+	version                       = "3.7.0"
 	defaultAPIURL                 = "https://api.gridscale.io"
 	resourceActiveStatus          = "active"
 	requestDoneStatus             = "done"

--- a/vendor/github.com/gridscale/gsclient-go/v3/network.go
+++ b/vendor/github.com/gridscale/gsclient-go/v3/network.go
@@ -71,6 +71,26 @@ type NetworkProperties struct {
 	// It will be true if the network is public, and false if the network is private.
 	L2Security bool `json:"l2security"`
 
+	// Defines the information if dhcp is activated for this network or not.
+	DHCPActive bool `json:"dhcp_active"`
+
+	// The general IP Range configured for this network (/24 for private networks).
+	DHCPRange string `json:"dhcp_range"`
+
+	// The ip reserved and communicated by the dhcp service to be the default gateway.
+	DHCPGateway string `json:"dhcp_gateway"`
+
+	DHCPDNS string `json:"dhcp_dns"`
+
+	// Subrange within the ip range.
+	DHCPReservedSubnet []string `json:"dhcp_reserved_subnet"`
+
+	// Contains ips of all servers in the network which got a designated IP by the DHCP server.
+	AutoAssignedServers []ServerWithIP `json:"auto_assigned_servers"`
+
+	// Contains ips of all servers in the network which got a designated IP by the user.
+	PinnedServers []ServerWithIP `json:"pinned_servers"`
+
 	// Defines the date and time of the last object change.
 	ChangeTime GSTime `json:"change_time"`
 
@@ -88,6 +108,15 @@ type NetworkProperties struct {
 
 	// The information about other object which are related to this network. the object could be servers and/or vlans.
 	Relations NetworkRelations `json:"relations"`
+}
+
+// ServerWithIP holds a server's UUID and a corresponding IP address
+type ServerWithIP struct {
+	// UUID of the server
+	ServerUUID string `json:"server_uuid"`
+
+	// IP which is assigned to the server
+	IP string `json:"ip"`
 }
 
 // NetworkRelations holds a list of a network's relations.
@@ -167,6 +196,20 @@ type NetworkCreateRequest struct {
 	// It can only be (de-)activated on a private network - the public network always has l2security enabled.
 	// It will be true if the network is public, and false if the network is private.
 	L2Security bool `json:"l2security,omitempty"`
+
+	// Defines the information if dhcp is activated for this network or not.
+	DHCPActive bool `json:"dhcp_active,omitempty"`
+
+	// The general IP Range configured for this network (/24 for private networks).
+	DHCPRange string `json:"dhcp_range,omitempty"`
+
+	// The ip reserved and communicated by the dhcp service to be the default gateway.
+	DHCPGateway string `json:"dhcp_gateway,omitempty"`
+
+	DHCPDNS string `json:"dhcp_dns,omitempty"`
+
+	// Subrange within the ip range.
+	DHCPReservedSubnet []string `json:"dhcp_reserved_subnet,omitempty"`
 }
 
 // NetworkCreateResponse represents a response for creating a network.
@@ -188,6 +231,20 @@ type NetworkUpdateRequest struct {
 
 	// List of labels. Can be empty.
 	Labels *[]string `json:"labels,omitempty"`
+
+	// Defines the information if dhcp is activated for this network or not.
+	DHCPActive *bool `json:"dhcp_active,omitempty"`
+
+	// The general IP Range configured for this network (/24 for private networks).
+	DHCPRange *string `json:"dhcp_range,omitempty"`
+
+	// The ip reserved and communicated by the dhcp service to be the default gateway.
+	DHCPGateway *string `json:"dhcp_gateway,omitempty"`
+
+	DHCPDNS *string `json:"dhcp_dns,omitempty"`
+
+	// Subrange within the ip range.
+	DHCPReservedSubnet *[]string `json:"dhcp_reserved_subnet,omitempty"`
 }
 
 // GetNetwork get a specific network based on given id.

--- a/vendor/github.com/gridscale/gsclient-go/v3/server.go
+++ b/vendor/github.com/gridscale/gsclient-go/v3/server.go
@@ -304,7 +304,6 @@ const (
 	SophosUTMServerHardware ServerHardwareProfile = "sophos_utm"
 	F5BigipServerHardware   ServerHardwareProfile = "f5_bigip"
 	Q35ServerHardware       ServerHardwareProfile = "q35"
-	Q35NestedServerHardware ServerHardwareProfile = "q35_nested"
 )
 
 // GetServer gets a specific server based on given list.

--- a/vendor/github.com/gridscale/gsclient-go/v3/storage.go
+++ b/vendor/github.com/gridscale/gsclient-go/v3/storage.go
@@ -73,8 +73,13 @@ type StorageProperties struct {
 	// Helps to identify which data center an object belongs to.
 	LocationUUID string `json:"location_uuid"`
 
-	//(one of storage, storage_high, storage_insane).
+	// Storage type.
+	// (one of storage, storage_high, storage_insane).
 	StorageType string `json:"storage_type"`
+
+	// Storage variant.
+	// (one of local or distributed).
+	StorageVariant string `json:"storage_variant"`
 
 	// The UUID of the Storage used to create this Snapshot.
 	ParentUUID string `json:"parent_uuid"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -76,7 +76,7 @@ github.com/golang/protobuf/ptypes/timestamp
 github.com/google/uuid
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
-# github.com/gridscale/gsclient-go/v3 v3.6.3
+# github.com/gridscale/gsclient-go/v3 v3.7.0
 ## explicit
 github.com/gridscale/gsclient-go/v3
 # github.com/hashicorp/errwrap v1.0.0

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -44,6 +44,17 @@ The following attributes are exported:
 * `name` - The UUID of the network.
 * `location_uuid` - The UUID of the location, that helps to identify which datacenter the network belongs to.
 * `l2security` - Defines information about MAC spoofing protection.
+* `dhcp_active` - Tell if DHCP is enabled.
+* `dhcp_gateway` - The general IP Range configured for this network (/24 for private networks). 
+* `dhcp_dns` - The IP address reserved and communicated by the dhcp service to be the default gateway.
+* `dhcp_range` -  DHCP DNS.
+* `dhcp_reserved_subnet` -  Subrange within the IP range.
+* `auto_assigned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.
+  * `server_uuid` - UUID of the server.
+  * `ip` - IP which is assigned to the server.
+* `pinned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the user.
+  * `server_uuid` - UUID of the server.
+  * `ip` - IP which is assigned to the server.
 * `status` - The status of the network.
 * `network_type` - The type of the network.
 * `location_country` - The human-readable name of the country where the network is located.

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -49,10 +49,10 @@ The following attributes are exported:
 * `dhcp_dns` - The IP address reserved and communicated by the dhcp service to be the default gateway.
 * `dhcp_range` -  DHCP DNS.
 * `dhcp_reserved_subnet` -  Subrange within the IP range.
-* `auto_assigned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.
+* `auto_assigned_servers` - A list of server UUIDs with the corresponding IPs that are designated by the DHCP server.
   * `server_uuid` - UUID of the server.
   * `ip` - IP which is assigned to the server.
-* `pinned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the user.
+* `pinned_servers` - A list of server UUIDs with the corresponding IPs that are designated by the user.
   * `server_uuid` - UUID of the server.
   * `ip` - IP which is assigned to the server.
 * `status` - The status of the network.

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -17,6 +17,11 @@ The following example shows how one might use this resource to add a network to 
 ```terraform
 resource "gridscale_network" "networkname"{
   name = "terraform-network"
+  dhcp_active = true
+  dhcp_gateway = "192.168.121.1"
+  dhcp_dns = "192.168.121.2"
+  dhcp_range = "192.168.121.0/27"
+  dhcp_reserved_subnet = ["192.168.121.0/31"]
   timeouts {
       create="10m"
   }
@@ -32,6 +37,16 @@ The following arguments are supported:
 * `l2security` - (Optional) Defines information about MAC spoofing protection (filters layer2 and ARP traffic based on MAC source). It can only be (de-)activated on a private network - the public network always has l2security enabled. It will be true if the network is public, and false if the network is private.
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
+
+* `dhcp_active` - (Optional) Enable DHCP.
+
+* `dhcp_gateway` - (Optional) The general IP Range configured for this network (/24 for private networks). If it is not set, gridscale internal default range is used.
+
+* `dhcp_dns` - (Optional) The IP address reserved and communicated by the dhcp service to be the default gateway.
+
+* `dhcp_range` - (Optional) DHCP DNS.
+
+* `dhcp_reserved_subnet` - (Optional) Subrange within the IP range.
 
 ## Timeouts
 
@@ -50,6 +65,17 @@ This resource exports the following attributes:
 * `location_uuid` - The location this network is placed. The location of a resource is determined by it's project.
 * `l2security` - See Argument Reference above.
 * `labels` - See Argument Reference above.
+* `dhcp_active` - See Argument Reference above.
+* `dhcp_gateway` - See Argument Reference above.
+* `dhcp_dns` - See Argument Reference above.
+* `dhcp_range` - See Argument Reference above.
+* `dhcp_reserved_subnet` - See Argument Reference above.
+* `auto_assigned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.
+  * `server_uuid` - UUID of the server.
+  * `ip` - IP which is assigned to the server.
+* `pinned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the user.
+  * `server_uuid` - UUID of the server.
+  * `ip` - IP which is assigned to the server.
 * `status` - status indicates the status of the object.
 * `create_time` - The time the object was created.
 * `change_time` - Defines the date and time of the last object change.

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -70,10 +70,10 @@ This resource exports the following attributes:
 * `dhcp_dns` - See Argument Reference above.
 * `dhcp_range` - See Argument Reference above.
 * `dhcp_reserved_subnet` - See Argument Reference above.
-* `auto_assigned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the DHCP server.
+* `auto_assigned_servers` - A list of server UUIDs with the corresponding IPs that are designated by the DHCP server.
   * `server_uuid` - UUID of the server.
   * `ip` - IP which is assigned to the server.
-* `pinned_servers` - Contains IP addresses of all servers in the network which got a designated IP by the user.
+* `pinned_servers` - A list of server UUIDs with the corresponding IPs that are designated by the user.
   * `server_uuid` - UUID of the server.
   * `ip` - IP which is assigned to the server.
 * `status` - status indicates the status of the object.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `auto_recovery` - (Optional) If the server should be auto-started in case of a failure (default=true).
 
-* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. Check the
+* `hardware_profile` - (Optional, ForceNew) The hardware profile of the Server. Options are default, legacy, nested, cisco_csr, sophos_utm, f5_bigip and q35 at the moment of writing. Check [the official docs](https://gridscale.io/en/api-documentation/index.html#operation/createServer).
 
 * `ipv4` - (Optional) The UUID of the IPv4 address of the server. (***NOTE: The server will NOT automatically be connected to the public network; to give it access to the internet, please add server to the public network.)
 


### PR DESCRIPTION
Ref #177. Changes:
- Upgrade `gsclient-go` v3.7.0.
- Remove HW Profile `q35_nested` (as it is no more available in `gsclient-go` v3.7.0).
- Reformat function `convSOStrings` (just rename one of its variables).
- Add DHCP properties/options to the network resource/data source.
- Update the network's acctest.
- Update the network's docs.