### PR TITLE
Allow to set backup location when creating a backup schedule.

### DIFF
--- a/gridscale/datasource_gridscale_backup_schedule.go
+++ b/gridscale/datasource_gridscale_backup_schedule.go
@@ -65,6 +65,16 @@ func dataSourceGridscaleStorageBackupSchedule() *schema.Resource {
 				Computed:    true,
 				Description: "The status of the schedule active or not",
 			},
+			"backup_location_uuid": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "UUID of the location where your backup is stored.",
+			},
+			"backup_location_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+			},
 			"storage_backups": {
 				Type:        schema.TypeSet,
 				Computed:    true,
@@ -109,6 +119,12 @@ func dataSourceGridscaleBackupScheduleRead(d *schema.ResourceData, meta interfac
 	}
 	if err = d.Set("active", props.Active); err != nil {
 		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
+	}
+	if err = d.Set("backup_location_uuid", props.BackupLocationUUID); err != nil {
+		return fmt.Errorf("%s error setting backup_location_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("backup_location_name", props.BackupLocationName); err != nil {
+		return fmt.Errorf("%s error setting backup_location_name: %v", errorPrefix, err)
 	}
 	if err = d.Set("name", props.Name); err != nil {
 		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)

--- a/gridscale/resource_gridscale_backup_schedule.go
+++ b/gridscale/resource_gridscale_backup_schedule.go
@@ -65,6 +65,7 @@ func resourceGridscaleStorageBackupSchedule() *schema.Resource {
 			"backup_location_uuid": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: "UUID of the location where your backup is stored.",
 			},

--- a/gridscale/resource_gridscale_backup_schedule.go
+++ b/gridscale/resource_gridscale_backup_schedule.go
@@ -62,6 +62,17 @@ func resourceGridscaleStorageBackupSchedule() *schema.Resource {
 				Required:    true,
 				Description: "The status of the schedule active or not",
 			},
+			"backup_location_uuid": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: "UUID of the location where your backup is stored.",
+			},
+			"backup_location_name": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.",
+			},
 			"create_time": {
 				Type:        schema.TypeString,
 				Computed:    true,
@@ -128,6 +139,12 @@ func resourceGridscaleBackupScheduleRead(d *schema.ResourceData, meta interface{
 	if err = d.Set("active", props.Active); err != nil {
 		return fmt.Errorf("%s error setting status: %v", errorPrefix, err)
 	}
+	if err = d.Set("backup_location_uuid", props.BackupLocationUUID); err != nil {
+		return fmt.Errorf("%s error setting backup_location_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("backup_location_name", props.BackupLocationName); err != nil {
+		return fmt.Errorf("%s error setting backup_location_name: %v", errorPrefix, err)
+	}
 	if err = d.Set("name", props.Name); err != nil {
 		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
 	}
@@ -168,10 +185,11 @@ func resourceGridscaleBackupScheduleRead(d *schema.ResourceData, meta interface{
 func resourceGridscaleBackupScheduleCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
 	requestBody := gsclient.StorageBackupScheduleCreateRequest{
-		Name:        d.Get("name").(string),
-		RunInterval: d.Get("run_interval").(int),
-		KeepBackups: d.Get("keep_backups").(int),
-		Active:      d.Get("active").(bool),
+		Name:               d.Get("name").(string),
+		RunInterval:        d.Get("run_interval").(int),
+		KeepBackups:        d.Get("keep_backups").(int),
+		Active:             d.Get("active").(bool),
+		BackupLocationUUID: d.Get("backup_location_uuid").(string),
 	}
 	nextRuntime, err := time.Parse(timeLayout, d.Get("next_runtime").(string))
 	if err != nil {

--- a/website/docs/d/backupschedule.html.md
+++ b/website/docs/d/backupschedule.html.md
@@ -47,6 +47,8 @@ The following attributes are exported:
 * `storage_uuid` - UUID of the storage that the backup schedule belongs to.
 * `status` - The status of the backup schedule.
 * `active` - The status of the schedule active or not.
+* `backup_location_uuid` - UUID of the location where your backup is stored.
+* `backup_location_name` - The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `name` - The human-readable name of the backup schedule.
 * `next_runtime` - The date and time that the backup schedule will be run.
 * `keep_backups` - The amount of Snapshots to keep before overwriting the last created Snapshot.

--- a/website/docs/r/backupschedule.html.md
+++ b/website/docs/r/backupschedule.html.md
@@ -46,6 +46,8 @@ The following arguments are supported:
 
 * `run_interval` - (Required) The interval at which the schedule will run (in minutes, >=60).
 
+* `backup_location_uuid` - (Optional, ForceNew) UUID of the location where your backup is stored.
+
 ## Timeouts
 
 Timeouts configuration options (in seconds):
@@ -63,6 +65,8 @@ The following attributes are exported:
 * `storage_uuid` - See Argument Reference above.
 * `status` - The status of the backup schedule.
 * `active` - See Argument Reference above.
+* `backup_location_uuid` - See Argument Reference above.
+* `backup_location_name` - The human-readable name of backup location. It supports the full UTF-8 character set, with a maximum of 64 characters.
 * `name` - See Argument Reference above.
 * `next_runtime` - See Argument Reference above.
 * `next_runtime_computed` - The date and time that the backup schedule will be run. This date and time is computed by gridscale's server.


### PR DESCRIPTION
Ref #188 . Changes:
- Add 2 fields: `backup_location_uuid` and `backup_location_name` in backup schedule datasource/resource.
- Update docs of backup schedule datasource/resource.
- Allow to specify the location of the backup schedule.