### PR TITLE
Suppress server-power-state update's error 400

### DIFF
--- a/gridscale/error-handler/skipHTTPErrCode.go
+++ b/gridscale/error-handler/skipHTTPErrCode.go
@@ -2,9 +2,9 @@ package errorhandler
 
 import "github.com/gridscale/gsclient-go/v3"
 
-//RemoveErrorContainsHTTPCodes returns nil, if the error of HTTP error
-//has status code that is in the given list of http status codes
-func RemoveErrorContainsHTTPCodes(err error, errorCodes ...int) error {
+// SuppressHTTPErrorCodes suppresses the error, if the error
+// is in the list errorCodes.
+func SuppressHTTPErrorCodes(err error, errorCodes ...int) error {
 	if requestError, ok := err.(gsclient.RequestError); ok {
 		if containsInt(errorCodes, requestError.StatusCode) {
 			err = nil

--- a/gridscale/relation-manager/serverRelationManager.go
+++ b/gridscale/relation-manager/serverRelationManager.go
@@ -253,7 +253,7 @@ func (c *ServerRelationManger) UpdateISOImageRel(ctx context.Context) error {
 		//Unlink it
 		if oldIso != "" {
 			//If 404 or 409, that means ISO image is already deleted => the relation between ISO image and server is deleted automatically
-			err = errHandler.RemoveErrorContainsHTTPCodes(
+			err = errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkIsoImage(ctx, d.Id(), oldIso.(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -280,7 +280,7 @@ func (c *ServerRelationManger) UpdateIPv4Rel(ctx context.Context) error {
 		//Unlink it
 		if oldIp != "" {
 			//If 404 or 409, that means IP is already deleted => the relation between IP and server is deleted automatically
-			err = errHandler.RemoveErrorContainsHTTPCodes(
+			err = errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkIP(ctx, d.Id(), oldIp.(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -306,7 +306,7 @@ func (c *ServerRelationManger) UpdateIPv6Rel(ctx context.Context) error {
 		//Unlink it
 		if oldIp != "" {
 			//If 404 or 409, that means IP is already deleted => the relation between IP and server is deleted automatically
-			err = errHandler.RemoveErrorContainsHTTPCodes(
+			err = errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkIP(ctx, d.Id(), oldIp.(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -337,7 +337,7 @@ func (c *ServerRelationManger) RelinkAllNetworks(ctx context.Context) error {
 		network := value.(map[string]interface{})
 		if network["object_uuid"].(string) != "" {
 			//If 404 or 409, that means network is already deleted => the relation between network and server is deleted automatically
-			err := errHandler.RemoveErrorContainsHTTPCodes(
+			err := errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkNetwork(ctx, d.Id(), network["object_uuid"].(string)),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -406,7 +406,7 @@ func (c *ServerRelationManger) UpdateNetRelsProperties(ctx context.Context) erro
 					)
 				}
 			} else {
-				if err := errHandler.RemoveErrorContainsHTTPCodes(
+				if err := errHandler.SuppressHTTPErrorCodes(
 					client.DeleteNetworkPinnedServer(
 						ctx,
 						network["object_uuid"].(string),
@@ -439,7 +439,7 @@ func (c *ServerRelationManger) UpdateStoragesRel(ctx context.Context) error {
 			storage := value.(map[string]interface{})
 			if storage["object_uuid"].(string) != "" {
 				//If 404 or 409, that means storage is already deleted => the relation between storage and server is deleted automatically
-				err = errHandler.RemoveErrorContainsHTTPCodes(
+				err = errHandler.SuppressHTTPErrorCodes(
 					client.UnlinkStorage(ctx, d.Id(), storage["object_uuid"].(string)),
 					http.StatusConflict,
 					http.StatusNotFound,

--- a/gridscale/resource_gridscale_backup_schedule.go
+++ b/gridscale/resource_gridscale_backup_schedule.go
@@ -250,7 +250,7 @@ func resourceGridscaleBackupScheduleDelete(d *schema.ResourceData, meta interfac
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteStorageBackupSchedule(ctx, storageUUID, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_filesystem.go
+++ b/gridscale/resource_gridscale_filesystem.go
@@ -371,7 +371,7 @@ func resourceGridscaleFilesystemDelete(d *schema.ResourceData, meta interface{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_firewall.go
+++ b/gridscale/resource_gridscale_firewall.go
@@ -315,7 +315,7 @@ func resourceGridscaleFirewallDelete(d *schema.ResourceData, meta interface{}) e
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteFirewall(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -233,7 +233,7 @@ func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
 
 	ip, err := client.GetIP(ctx, d.Id())
 	//In case of 404, don't catch the error
-	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
+	if errHandler.SuppressHTTPErrorCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 	//Stop the server relating to this IP address if there is one
@@ -242,7 +242,7 @@ func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
 		server := ip.Properties.Relations.Servers[0]
 		unlinkIPAction := func(ctx context.Context) error {
 			//No need to unlink when server returns 409 or 404
-			err := errHandler.RemoveErrorContainsHTTPCodes(
+			err := errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkIP(ctx, server.ServerUUID, d.Id()),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -256,7 +256,7 @@ func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	err = errHandler.RemoveErrorContainsHTTPCodes(
+	err = errHandler.SuppressHTTPErrorCodes(
 		client.DeleteIP(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_isoimage.go
+++ b/gridscale/resource_gridscale_isoimage.go
@@ -272,13 +272,13 @@ func resourceGridscaleISOImageDelete(d *schema.ResourceData, meta interface{}) e
 
 	isoimage, err := client.GetISOImage(ctx, d.Id())
 	//In case of 404, don't catch the error
-	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
+	if errHandler.SuppressHTTPErrorCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 	//Remove all links between this ISO-Image and all servers.
 	for _, server := range isoimage.Properties.Relations.Servers {
 		//No need to unlink when server returns 409 or 404
-		err = errHandler.RemoveErrorContainsHTTPCodes(
+		err = errHandler.SuppressHTTPErrorCodes(
 			client.UnlinkIsoImage(ctx, server.ObjectUUID, d.Id()),
 			http.StatusConflict,
 			http.StatusNotFound,
@@ -287,7 +287,7 @@ func resourceGridscaleISOImageDelete(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 	}
-	err = errHandler.RemoveErrorContainsHTTPCodes(
+	err = errHandler.SuppressHTTPErrorCodes(
 		client.DeleteISOImage(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -410,7 +410,7 @@ func resourceGridscaleK8sDelete(d *schema.ResourceData, meta interface{}) error 
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -268,7 +268,7 @@ func resourceGridscaleLoadBalancerDelete(d *schema.ResourceData, meta interface{
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteLoadBalancer(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_mariadb.go
+++ b/gridscale/resource_gridscale_mariadb.go
@@ -470,7 +470,7 @@ func resourceGridscaleMariaDBDelete(d *schema.ResourceData, meta interface{}) er
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_marketplace_app.go
+++ b/gridscale/resource_gridscale_marketplace_app.go
@@ -427,7 +427,7 @@ func resourceGridscaleMarketplaceApplicationDelete(d *schema.ResourceData, meta 
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteMarketplaceApplication(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_memcached.go
+++ b/gridscale/resource_gridscale_memcached.go
@@ -352,7 +352,7 @@ func resourceGridscaleMemcachedDelete(d *schema.ResourceData, meta interface{}) 
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_mysql.go
+++ b/gridscale/resource_gridscale_mysql.go
@@ -470,7 +470,7 @@ func resourceGridscaleMySQLDelete(d *schema.ResourceData, meta interface{}) erro
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -340,7 +340,7 @@ func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) er
 	defer cancel()
 	net, err := client.GetNetwork(ctx, d.Id())
 	//In case of 404, don't catch the error
-	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
+	if errHandler.SuppressHTTPErrorCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 
@@ -348,7 +348,7 @@ func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) er
 	for _, server := range net.Properties.Relations.Servers {
 		unlinkNetAction := func(ctx context.Context) error {
 			//No need to unlink when server returns 409 or 404
-			err := errHandler.RemoveErrorContainsHTTPCodes(
+			err := errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkNetwork(ctx, server.ObjectUUID, d.Id()),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -362,7 +362,7 @@ func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	err = errHandler.RemoveErrorContainsHTTPCodes(
+	err = errHandler.SuppressHTTPErrorCodes(
 		client.DeleteNetwork(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_objectstorage.go
+++ b/gridscale/resource_gridscale_objectstorage.go
@@ -86,7 +86,7 @@ func resourceGridscaleObjectStorageDelete(d *schema.ResourceData, meta interface
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteObjectStorageAccessKey(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -415,7 +415,7 @@ func resourceGridscalePaaSServiceDelete(d *schema.ResourceData, meta interface{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_postgresql.go
+++ b/gridscale/resource_gridscale_postgresql.go
@@ -375,7 +375,7 @@ func resourceGridscalePostgreSQLDelete(d *schema.ResourceData, meta interface{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_redis_cache.go
+++ b/gridscale/resource_gridscale_redis_cache.go
@@ -314,7 +314,7 @@ func resourceGridscaleRedisCacheDelete(d *schema.ResourceData, meta interface{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_redis_store.go
+++ b/gridscale/resource_gridscale_redis_store.go
@@ -314,7 +314,7 @@ func resourceGridscaleRedisStoreDelete(d *schema.ResourceData, meta interface{})
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_securityzone.go
+++ b/gridscale/resource_gridscale_securityzone.go
@@ -180,7 +180,7 @@ func resourceGridscalePaaSSecurityZoneDelete(d *schema.ResourceData, meta interf
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSSecurityZone(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -723,7 +723,7 @@ func resourceGridscaleServerDelete(d *schema.ResourceData, meta interface{}) err
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
 	//remove the server
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		globalServerStatusList.removeServerSynchronously(ctx, client, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_snapshot.go
+++ b/gridscale/resource_gridscale_snapshot.go
@@ -418,7 +418,7 @@ func resourceGridscaleSnapshotDelete(d *schema.ResourceData, meta interface{}) e
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteStorageSnapshot(ctx, storageUUID, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_snapshotschedule.go
+++ b/gridscale/resource_gridscale_snapshotschedule.go
@@ -239,7 +239,7 @@ func resourceGridscaleSnapshotScheduleDelete(d *schema.ResourceData, meta interf
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteStorageSnapshotSchedule(ctx, storageUUID, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_sqlserver.go
+++ b/gridscale/resource_gridscale_sqlserver.go
@@ -412,7 +412,7 @@ func resourceGridscaleMSSQLServerDelete(d *schema.ResourceData, meta interface{}
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeletePaaSService(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_sshkey.go
+++ b/gridscale/resource_gridscale_sshkey.go
@@ -155,7 +155,7 @@ func resourceGridscaleSshkeyDelete(d *schema.ResourceData, meta interface{}) err
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteSshkey(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_sslcert.go
+++ b/gridscale/resource_gridscale_sslcert.go
@@ -205,7 +205,7 @@ func resourceGridscaleSSLCertDelete(d *schema.ResourceData, meta interface{}) er
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteSSLCertificate(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -411,7 +411,7 @@ func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) er
 	defer cancel()
 	storage, err := client.GetStorage(ctx, d.Id())
 	//In case of 404, don't catch the error
-	if errHandler.RemoveErrorContainsHTTPCodes(err, http.StatusNotFound) != nil {
+	if errHandler.SuppressHTTPErrorCodes(err, http.StatusNotFound) != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 
@@ -419,7 +419,7 @@ func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) er
 	for _, server := range storage.Properties.Relations.Servers {
 		unlinkStorageAction := func(ctx context.Context) error {
 			//No need to unlink when server returns 409 or 404
-			err := errHandler.RemoveErrorContainsHTTPCodes(
+			err := errHandler.SuppressHTTPErrorCodes(
 				client.UnlinkStorage(ctx, server.ObjectUUID, d.Id()),
 				http.StatusConflict,
 				http.StatusNotFound,
@@ -433,7 +433,7 @@ func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-	err = errHandler.RemoveErrorContainsHTTPCodes(
+	err = errHandler.SuppressHTTPErrorCodes(
 		client.DeleteStorage(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/resource_gridscale_template.go
+++ b/gridscale/resource_gridscale_template.go
@@ -250,7 +250,7 @@ func resourceGridscaleTemplateDelete(d *schema.ResourceData, meta interface{}) e
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()
-	err := errHandler.RemoveErrorContainsHTTPCodes(
+	err := errHandler.SuppressHTTPErrorCodes(
 		client.DeleteTemplate(ctx, d.Id()),
 		http.StatusNotFound,
 	)

--- a/gridscale/server_concurrency_handler.go
+++ b/gridscale/server_concurrency_handler.go
@@ -122,7 +122,7 @@ func (l *serverStatusList) startServerSynchronously(ctx context.Context, c *gscl
 			log.Printf("[DEBUG] LOCK RELEASED! Starting server (%v) is done", id)
 		}()
 		if !s.deleted {
-			err := errHandler.RemoveErrorContainsHTTPCodes(
+			err := errHandler.SuppressHTTPErrorCodes(
 				c.StartServer(ctx, id),
 				http.StatusBadRequest,
 			)
@@ -153,7 +153,7 @@ func (l *serverStatusList) shutdownServerSynchronously(ctx context.Context, c *g
 			//set the shutdown timeout specifically
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), serverShutdownTimeoutSecs*time.Second)
 			defer cancel()
-			err := errHandler.RemoveErrorContainsHTTPCodes(
+			err := errHandler.SuppressHTTPErrorCodes(
 				c.ShutdownServer(shutdownCtx, id),
 				http.StatusBadRequest,
 			)
@@ -171,7 +171,7 @@ func (l *serverStatusList) shutdownServerSynchronously(ctx context.Context, c *g
 				default:
 				}
 				//force the sever to stop
-				return errHandler.RemoveErrorContainsHTTPCodes(
+				return errHandler.SuppressHTTPErrorCodes(
 					c.StopServer(ctx, id),
 					http.StatusBadRequest,
 				)


### PR DESCRIPTION
Error 400 is returned when the server power state update request has the same state as the current server's power state. TF doesn't need to handle this error, instead, it could suppress the error.