### PR TITLE
Remove `MaxItems` in server-storage/net relations

### DIFF
--- a/gridscale/resource_gridscale_server.go
+++ b/gridscale/resource_gridscale_server.go
@@ -76,7 +76,6 @@ func resourceGridscaleServer() *schema.Resource {
 			"storage": {
 				Type:        schema.TypeList,
 				Optional:    true,
-				MaxItems:    8,
 				Description: `A list of storages attached to the server. The first storage in the list is always set as the boot storage of the server.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -135,7 +134,6 @@ func resourceGridscaleServer() *schema.Resource {
 			"network": {
 				Type:     schema.TypeList,
 				Optional: true,
-				MaxItems: 7,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"object_uuid": {


### PR DESCRIPTION
Ref #195 . Let API backend decide the maximum items. If the maximum number is reached, tf will return API error. This approach is also future-proof.