### PR TITLE
Add private network support for paas resources

### DIFF
--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -59,6 +59,11 @@ func dataSourceGridscalePaaS() *schema.Resource {
 				Description: "Security zone UUID linked to PaaS service",
 				Computed:    true,
 			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
+			},
 			"network_uuid": {
 				Type:        schema.TypeString,
 				Description: "Network UUID containing security zone",

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -169,8 +169,14 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minute", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minute: %v", errorPrefix, err)
@@ -240,7 +246,11 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)

--- a/gridscale/mssql.html.md
+++ b/gridscale/mssql.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is running in.
 
 * `s3_backup` - (Optional) Allow backup/restore MS SQL server to/from a S3 bucket.
 

--- a/gridscale/resource_gridscale_filesystem.go
+++ b/gridscale/resource_gridscale_filesystem.go
@@ -115,6 +115,7 @@ func resourceGridscaleFilesystem() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to Filesystem service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
@@ -142,13 +143,19 @@ func resourceGridscaleFilesystem() *schema.Resource {
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that Filesystem service uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -205,8 +212,14 @@ func resourceGridscaleFilesystemRead(d *schema.ResourceData, meta interface{}) e
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
@@ -256,7 +269,11 @@ func resourceGridscaleFilesystemRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -292,7 +309,14 @@ func resourceGridscaleFilesystemCreate(d *schema.ResourceData, meta interface{})
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
+	}
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
 	}
 	params := make(map[string]interface{})
 	if rootSquash, ok := d.GetOk("root_squash"); ok {
@@ -328,6 +352,9 @@ func resourceGridscaleFilesystemUpdate(d *schema.ResourceData, meta interface{})
 	requestBody := gsclient.PaaSServiceUpdateRequest{
 		Name:   d.Get("name").(string),
 		Labels: &labels,
+	}
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
 	}
 	params := make(map[string]interface{})
 	if rootSquash, ok := d.GetOk("root_squash"); ok {

--- a/gridscale/resource_gridscale_filesystem.go
+++ b/gridscale/resource_gridscale_filesystem.go
@@ -194,7 +194,7 @@ func resourceGridscaleFilesystem() *schema.Resource {
 
 func resourceGridscaleFilesystemRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read gridFs (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -295,7 +295,7 @@ func resourceGridscaleFilesystemRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceGridscaleFilesystemCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create gridFs (%s) resource -", d.Id())
 
 	release := d.Get("release").(string)
 	performanceClass := d.Get("performance_class").(string)
@@ -346,7 +346,7 @@ func resourceGridscaleFilesystemCreate(d *schema.ResourceData, meta interface{})
 
 func resourceGridscaleFilesystemUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update gridFs (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -96,6 +96,7 @@ func resourceGridscaleK8s() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to PaaS service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,

--- a/gridscale/resource_gridscale_mariadb.go
+++ b/gridscale/resource_gridscale_mariadb.go
@@ -240,7 +240,7 @@ func resourceGridscaleMariaDB() *schema.Resource {
 
 func resourceGridscaleMariaDBRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read mariadb (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -376,7 +376,7 @@ func resourceGridscaleMariaDBRead(d *schema.ResourceData, meta interface{}) erro
 
 func resourceGridscaleMariaDBCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create mariadb (%s) resource -", d.Id())
 
 	// Get mariadb template UUID
 	release := d.Get("release").(string)
@@ -435,7 +435,7 @@ func resourceGridscaleMariaDBCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceGridscaleMariaDBUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update mariadb (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
@@ -491,7 +491,7 @@ func resourceGridscaleMariaDBUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceGridscaleMariaDBDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("delete mariadb (%s) resource -", d.Id())
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()

--- a/gridscale/resource_gridscale_mariadb.go
+++ b/gridscale/resource_gridscale_mariadb.go
@@ -175,19 +175,26 @@ func resourceGridscaleMariaDB() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to MariaDB service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that MariaDB service uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -260,8 +267,14 @@ func resourceGridscaleMariaDBRead(d *schema.ResourceData, meta interface{}) erro
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
@@ -337,7 +350,11 @@ func resourceGridscaleMariaDBRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -373,9 +390,15 @@ func resourceGridscaleMariaDBCreate(d *schema.ResourceData, meta interface{}) er
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
 	}
-
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
+	}
 	if val, ok := d.GetOk("max_core_count"); ok {
 		limits := []gsclient.ResourceLimit{
 			{
@@ -419,7 +442,9 @@ func resourceGridscaleMariaDBUpdate(d *schema.ResourceData, meta interface{}) er
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update templateUUID, when `release` or `performance_class` is changed
 	if d.HasChange("release") || d.HasChange("performance_class") {
 		// Get mariadb template UUID

--- a/gridscale/resource_gridscale_memcached.go
+++ b/gridscale/resource_gridscale_memcached.go
@@ -179,7 +179,7 @@ func resourceGridscaleMemcached() *schema.Resource {
 
 func resourceGridscaleMemcachedRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read memcached (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -284,7 +284,7 @@ func resourceGridscaleMemcachedRead(d *schema.ResourceData, meta interface{}) er
 
 func resourceGridscaleMemcachedCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create memcached (%s) resource -", d.Id())
 
 	// Get memcached template UUID
 	release := d.Get("release").(string)
@@ -330,7 +330,7 @@ func resourceGridscaleMemcachedCreate(d *schema.ResourceData, meta interface{}) 
 
 func resourceGridscaleMemcachedUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update memcached (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
@@ -373,7 +373,7 @@ func resourceGridscaleMemcachedUpdate(d *schema.ResourceData, meta interface{}) 
 
 func resourceGridscaleMemcachedDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("delete memcached (%s) resource -", d.Id())
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()

--- a/gridscale/resource_gridscale_memcached.go
+++ b/gridscale/resource_gridscale_memcached.go
@@ -114,19 +114,26 @@ func resourceGridscaleMemcached() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to Memcached service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that Memcached service uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -199,8 +206,14 @@ func resourceGridscaleMemcachedRead(d *schema.ResourceData, meta interface{}) er
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
@@ -245,7 +258,11 @@ func resourceGridscaleMemcachedRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -281,9 +298,15 @@ func resourceGridscaleMemcachedCreate(d *schema.ResourceData, meta interface{}) 
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
 	}
-
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
+	}
 	if val, ok := d.GetOk("max_core_count"); ok {
 		limits := []gsclient.ResourceLimit{
 			{
@@ -314,7 +337,9 @@ func resourceGridscaleMemcachedUpdate(d *schema.ResourceData, meta interface{}) 
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update templateUUID, when `release` or `performance_class` is changed
 	if d.HasChange("release") || d.HasChange("performance_class") {
 		// Get memcached template UUID

--- a/gridscale/resource_gridscale_mysql.go
+++ b/gridscale/resource_gridscale_mysql.go
@@ -240,7 +240,7 @@ func resourceGridscaleMySQL() *schema.Resource {
 
 func resourceGridscaleMySQLRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read mysql (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -376,7 +376,7 @@ func resourceGridscaleMySQLRead(d *schema.ResourceData, meta interface{}) error 
 
 func resourceGridscaleMySQLCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create mysql (%s) resource -", d.Id())
 
 	// Get mysql template UUID
 	release := d.Get("release").(string)
@@ -435,7 +435,7 @@ func resourceGridscaleMySQLCreate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceGridscaleMySQLUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update mysql (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
@@ -491,7 +491,7 @@ func resourceGridscaleMySQLUpdate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceGridscaleMySQLDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("delete mysql (%s) resource -", d.Id())
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()

--- a/gridscale/resource_gridscale_mysql.go
+++ b/gridscale/resource_gridscale_mysql.go
@@ -175,19 +175,26 @@ func resourceGridscaleMySQL() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to MySQL service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that MySQL service uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -257,8 +264,14 @@ func resourceGridscaleMySQLRead(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf("%s error setting password: %v", errorPrefix, err)
 		}
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
@@ -337,7 +350,11 @@ func resourceGridscaleMySQLRead(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -373,9 +390,15 @@ func resourceGridscaleMySQLCreate(d *schema.ResourceData, meta interface{}) erro
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
 	}
-
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
+	}
 	if val, ok := d.GetOk("max_core_count"); ok {
 		limits := []gsclient.ResourceLimit{
 			{
@@ -419,7 +442,9 @@ func resourceGridscaleMySQLUpdate(d *schema.ResourceData, meta interface{}) erro
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update templateUUID, when `release` or `performance_class` is changed
 	if d.HasChange("release") || d.HasChange("performance_class") {
 		// Get mysql template UUID

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -80,7 +80,7 @@ func resourceGridscalePaaS() *schema.Resource {
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone",
+				Description: "The UUID of the network that the service is attached to.",
 				Optional:    true,
 				Computed:    true,
 			},

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -73,6 +73,7 @@ func resourceGridscalePaaS() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to PaaS service",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
@@ -80,6 +81,7 @@ func resourceGridscalePaaS() *schema.Resource {
 			"network_uuid": {
 				Type:        schema.TypeString,
 				Description: "Network UUID containing security zone",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
@@ -92,6 +94,11 @@ func resourceGridscalePaaS() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 				Description: "Template that PaaS service uses. The `service_template_uuid_computed` will be different from `service_template_uuid`, when `service_template_uuid` is updated outside of terraform.",
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minute": {
 				Type:        schema.TypeInt,
@@ -216,8 +223,14 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid_computed", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid_computed: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minute", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minute: %v", errorPrefix, err)
@@ -288,12 +301,15 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
 	}
-	//look for a network that the PaaS service is in
 	for _, network := range networks {
 		securityZones := network.Properties.Relations.PaaSSecurityZones
 		//Each network can contain only one security zone
@@ -314,7 +330,14 @@ func resourceGridscalePaaSServiceCreate(d *schema.ResourceData, meta interface{}
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: d.Get("service_template_uuid").(string),
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
+	}
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
 	}
 
 	params := make(map[string]interface{}, 0)
@@ -363,7 +386,9 @@ func resourceGridscalePaaSServiceUpdate(d *schema.ResourceData, meta interface{}
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update service_template_uuid, when it is changed
 	// NOTE: remember to check if service_template_uuid is changed,
 	// otherwise tf will force to update service_template_uuid every time Update is executed.

--- a/gridscale/resource_gridscale_postgresql.go
+++ b/gridscale/resource_gridscale_postgresql.go
@@ -132,19 +132,26 @@ func resourceGridscalePostgreSQL() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to PostgreSQL service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that PostgreSQL service uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -222,8 +229,14 @@ func resourceGridscalePostgreSQLRead(d *schema.ResourceData, meta interface{}) e
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
@@ -268,7 +281,11 @@ func resourceGridscalePostgreSQLRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -304,9 +321,15 @@ func resourceGridscalePostgreSQLCreate(d *schema.ResourceData, meta interface{})
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
 	}
-
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
+	}
 	if val, ok := d.GetOk("max_core_count"); ok {
 		limits := []gsclient.ResourceLimit{
 			{
@@ -337,7 +360,9 @@ func resourceGridscalePostgreSQLUpdate(d *schema.ResourceData, meta interface{})
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update templateUUID, when `release` or `performance_class` is changed
 	if d.HasChange("release") || d.HasChange("performance_class") {
 		// Get postgres template UUID

--- a/gridscale/resource_gridscale_redis_cache.go
+++ b/gridscale/resource_gridscale_redis_cache.go
@@ -112,19 +112,26 @@ func resourceGridscaleRedisCache() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to Redis cache service.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that Redis cache service uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -190,8 +197,14 @@ func resourceGridscaleRedisCacheRead(d *schema.ResourceData, meta interface{}) e
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
@@ -227,7 +240,11 @@ func resourceGridscaleRedisCacheRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -263,9 +280,15 @@ func resourceGridscaleRedisCacheCreate(d *schema.ResourceData, meta interface{})
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
 	}
-
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
 	defer cancel()
 	response, err := client.CreatePaaSService(ctx, requestBody)
@@ -286,7 +309,9 @@ func resourceGridscaleRedisCacheUpdate(d *schema.ResourceData, meta interface{})
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update templateUUID, when `release` or `performance_class` is changed
 	if d.HasChange("release") || d.HasChange("performance_class") {
 		// Get redisCache template UUID

--- a/gridscale/resource_gridscale_redis_cache.go
+++ b/gridscale/resource_gridscale_redis_cache.go
@@ -170,7 +170,7 @@ func resourceGridscaleRedisCache() *schema.Resource {
 
 func resourceGridscaleRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read redis cache (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -266,7 +266,7 @@ func resourceGridscaleRedisCacheRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceGridscaleRedisCacheCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create redis cache (%s) resource -", d.Id())
 
 	// Get redisCache template UUID
 	release := d.Get("release").(string)
@@ -302,7 +302,7 @@ func resourceGridscaleRedisCacheCreate(d *schema.ResourceData, meta interface{})
 
 func resourceGridscaleRedisCacheUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update redis cache (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
@@ -335,7 +335,7 @@ func resourceGridscaleRedisCacheUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceGridscaleRedisCacheDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("delete redis cache (%s) resource -", d.Id())
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()

--- a/gridscale/resource_gridscale_redis_store.go
+++ b/gridscale/resource_gridscale_redis_store.go
@@ -170,7 +170,7 @@ func resourceGridscaleRedisStore() *schema.Resource {
 
 func resourceGridscaleRedisStoreRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read redis store (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -266,7 +266,7 @@ func resourceGridscaleRedisStoreRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceGridscaleRedisStoreCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create redis store (%s) resource -", d.Id())
 
 	// Get redisStore template UUID
 	release := d.Get("release").(string)
@@ -302,7 +302,7 @@ func resourceGridscaleRedisStoreCreate(d *schema.ResourceData, meta interface{})
 
 func resourceGridscaleRedisStoreUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update redis store (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
@@ -335,7 +335,7 @@ func resourceGridscaleRedisStoreUpdate(d *schema.ResourceData, meta interface{})
 
 func resourceGridscaleRedisStoreDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("delete redis store (%s) resource -", d.Id())
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()

--- a/gridscale/resource_gridscale_sqlserver.go
+++ b/gridscale/resource_gridscale_sqlserver.go
@@ -233,7 +233,7 @@ func resourceGridscaleMSSQLServer() *schema.Resource {
 
 func resourceGridscaleMSSQLServerRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("read paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("read mssql (%s) resource -", d.Id())
 	paas, err := client.GetPaaSService(context.Background(), d.Id())
 	if err != nil {
 		if requestError, ok := err.(gsclient.RequestError); ok {
@@ -343,7 +343,7 @@ func resourceGridscaleMSSQLServerRead(d *schema.ResourceData, meta interface{}) 
 
 func resourceGridscaleMSSQLServerCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("create k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("create mssql (%s) resource -", d.Id())
 
 	// get ms sql template UUID
 	release := d.Get("release").(string)
@@ -390,7 +390,7 @@ func resourceGridscaleMSSQLServerCreate(d *schema.ResourceData, meta interface{}
 
 func resourceGridscaleMSSQLServerUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("update k8s (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("update mssql (%s) resource -", d.Id())
 
 	labels := convSOStrings(d.Get("labels").(*schema.Set).List())
 	requestBody := gsclient.PaaSServiceUpdateRequest{
@@ -433,7 +433,7 @@ func resourceGridscaleMSSQLServerUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceGridscaleMSSQLServerDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	errorPrefix := fmt.Sprintf("delete paas (%s) resource -", d.Id())
+	errorPrefix := fmt.Sprintf("delete mssql (%s) resource -", d.Id())
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutDelete))
 	defer cancel()

--- a/gridscale/resource_gridscale_sqlserver.go
+++ b/gridscale/resource_gridscale_sqlserver.go
@@ -175,19 +175,26 @@ func resourceGridscaleMSSQLServer() *schema.Resource {
 			"security_zone_uuid": {
 				Type:        schema.TypeString,
 				Description: "Security zone UUID linked to MS SQL Server.",
+				Deprecated:  "Security zone is deprecated for gridSQL, gridStore, and gridFs. Please consider to use private network instead.",
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
 			},
 			"network_uuid": {
 				Type:        schema.TypeString,
-				Description: "Network UUID containing security zone.",
+				Description: "The UUID of the network that the service is attached to.",
+				Optional:    true,
 				Computed:    true,
 			},
 			"service_template_uuid": {
 				Type:        schema.TypeString,
 				Description: "PaaS service template that MS SQL Server uses.",
 				Computed:    true,
+			},
+			"service_template_category": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "The template service's category used to create the service.",
 			},
 			"usage_in_minutes": {
 				Type:        schema.TypeInt,
@@ -253,8 +260,14 @@ func resourceGridscaleMSSQLServerRead(d *schema.ResourceData, meta interface{}) 
 	if err = d.Set("security_zone_uuid", props.SecurityZoneUUID); err != nil {
 		return fmt.Errorf("%s error setting security_zone_uuid: %v", errorPrefix, err)
 	}
+	if err = d.Set("network_uuid", props.NetworkUUID); err != nil {
+		return fmt.Errorf("%s error setting network_uuid: %v", errorPrefix, err)
+	}
 	if err = d.Set("service_template_uuid", props.ServiceTemplateUUID); err != nil {
 		return fmt.Errorf("%s error setting service_template_uuid: %v", errorPrefix, err)
+	}
+	if err = d.Set("service_template_category", props.ServiceTemplateCategory); err != nil {
+		return fmt.Errorf("%s error setting service_template_category: %v", errorPrefix, err)
 	}
 	if err = d.Set("usage_in_minutes", props.UsageInMinutes); err != nil {
 		return fmt.Errorf("%s error setting usage_in_minutes: %v", errorPrefix, err)
@@ -304,7 +317,11 @@ func resourceGridscaleMSSQLServerRead(d *schema.ResourceData, meta interface{}) 
 		return fmt.Errorf("%s error setting labels: %v", errorPrefix, err)
 	}
 
-	//Get all available networks
+	// Look for security zone's network that the PaaS service is connected to
+	// (if the paas is connected to security zone. O.w skip)
+	if props.SecurityZoneUUID == "" {
+		return nil
+	}
 	networks, err := client.GetNetworkList(context.Background())
 	if err != nil {
 		return fmt.Errorf("%s error getting networks: %v", errorPrefix, err)
@@ -340,9 +357,15 @@ func resourceGridscaleMSSQLServerCreate(d *schema.ResourceData, meta interface{}
 		Name:                    d.Get("name").(string),
 		PaaSServiceTemplateUUID: templateUUID,
 		Labels:                  convSOStrings(d.Get("labels").(*schema.Set).List()),
-		PaaSSecurityZoneUUID:    d.Get("security_zone_uuid").(string),
 	}
-
+	networkUUIDInf, isNetworkSet := d.GetOk("network_uuid")
+	if isNetworkSet {
+		requestBody.NetworkUUID = networkUUIDInf.(string)
+	}
+	// If network_uuid is set, skip setting security_zone_uuid.
+	if secZoneUUIDInf, ok := d.GetOk("security_zone_uuid"); ok && !isNetworkSet {
+		requestBody.PaaSSecurityZoneUUID = secZoneUUIDInf.(string)
+	}
 	// If s3_backup is set, attach the backup parameters to the create request.
 	if _, ok := d.GetOk("s3_backup"); ok {
 		params := make(map[string]interface{})
@@ -374,7 +397,9 @@ func resourceGridscaleMSSQLServerUpdate(d *schema.ResourceData, meta interface{}
 		Name:   d.Get("name").(string),
 		Labels: &labels,
 	}
-
+	if d.HasChange("network_uuid") {
+		requestBody.NetworkUUID = d.Get("network_uuid").(string)
+	}
 	// Only update templateUUID, when `release` or `performance_class` is changed.
 	if d.HasChange("performance_class") || d.HasChange("release") {
 		// get ms sql template UUID

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -44,6 +44,7 @@ The following attributes are exported:
 * `security_zone_uuid` - The UUID of the security zone that the service is attached to.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - The template used to create the service.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.
 * `current_price` - Current price of PaaS service.
 * `change_time` - Time of the last change.

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -42,7 +42,7 @@ The following attributes are exported:
   * `name` - Name of a port.
   * `listen_port` - Port number.
 * `security_zone_uuid` - The UUID of the security zone that the service is attached to.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - The template used to create the service.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.
 * `current_price` - Current price of PaaS service.

--- a/website/docs/d/paas.html.md
+++ b/website/docs/d/paas.html.md
@@ -41,7 +41,7 @@ The following attributes are exported:
 * `listen_port` - Ports that PaaS service listens to.
   * `name` - Name of a port.
   * `listen_port` - Port number.
-* `security_zone_uuid` - The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - The UUID of the security zone that the service is attached to.
 * `network_uuid` - Network UUID containing security zone.
 * `service_template_uuid` - The template used to create the service.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.

--- a/website/docs/r/filesystem.html.md
+++ b/website/docs/r/filesystem.html.md
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `root_squash` - (Optional) Map root user/group ownership to anon_uid/anon_gid.
@@ -71,7 +73,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that filesystem service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/filesystem.html.md
+++ b/website/docs/r/filesystem.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `root_squash` - (Optional) Map root user/group ownership to anon_uid/anon_gid.
 

--- a/website/docs/r/filesystem.html.md
+++ b/website/docs/r/filesystem.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 * `root_squash` - (Optional) Map root user/group ownership to anon_uid/anon_gid.
 

--- a/website/docs/r/filesystem.html.md
+++ b/website/docs/r/filesystem.html.md
@@ -75,6 +75,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that filesystem service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/k8s.html.md
+++ b/website/docs/r/k8s.html.md
@@ -68,6 +68,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `release` - See Argument Reference above.
 * `service_template_uuid` - PaaS service template that k8s service uses. The `service_template_uuid` may not relate to `release`, if `service_template_uuid`/`release` is updated outside of terraform (e.g. the k8s service is upgraded by gridscale staffs).
+* `service_template_category` - The template service's category used to create the service.
 * `labels` - See Argument Reference above.
 * `network_uuid` - Network UUID containing security zone, which is linked to the k8s cluster.
 * `node_pool` - See Argument Reference above.

--- a/website/docs/r/k8s.html.md
+++ b/website/docs/r/k8s.html.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 * `name` - (Required) The human-readable name of the object. It supports the full UTF-8 character set, with a maximum of 64 characters.
 
-* `security_zone_uuid` - (Optional) Security zone UUID linked to the Kubernetes resource. If `security_zone_uuid` is not set, the default security zone will be created (if it doesn't exist) and linked. A change of this argument necessitates the re-creation of the resource.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) Security zone UUID linked to the Kubernetes resource. If `security_zone_uuid` is not set, the default security zone will be created (if it doesn't exist) and linked. A change of this argument necessitates the re-creation of the resource.
 
 * `release` - (Required) The Kubernetes release of this instance. Define which release will be used to create the cluster. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available release numbers.
 

--- a/website/docs/r/mariadb.html.md
+++ b/website/docs/r/mariadb.html.md
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The MariaDB instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/mariadb.html.md
+++ b/website/docs/r/mariadb.html.md
@@ -100,6 +100,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that MariaDB service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/mariadb.html.md
+++ b/website/docs/r/mariadb.html.md
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The MariaDB instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
@@ -96,7 +98,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that MariaDB service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/mariadb.html.md
+++ b/website/docs/r/mariadb.html.md
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The MariaDB instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/memcached.html.md
+++ b/website/docs/r/memcached.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The Memcached instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/memcached.html.md
+++ b/website/docs/r/memcached.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The Memcached instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/memcached.html.md
+++ b/website/docs/r/memcached.html.md
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The Memcached instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
@@ -63,7 +65,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that Memcached service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/memcached.html.md
+++ b/website/docs/r/memcached.html.md
@@ -67,6 +67,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that Memcached service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/mssql.html.md
+++ b/website/docs/r/mssql.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is running in.
 
 * `s3_backup` - (Optional) Allow backup/restore MS SQL server to/from a S3 bucket.
 

--- a/website/docs/r/mssql.html.md
+++ b/website/docs/r/mssql.html.md
@@ -1,12 +1,12 @@
 ---
 layout: "gridscale"
-page_title: "gridscale: gridscale_sqlserver"
+page_title: "gridscale: gridscale_mssql"
 sidebar_current: "docs-gridscale-resource-sqlserver"
 description: |-
   Manage a MS SQL server service in gridscale.
 ---
 
-# gridscale_sqlserver
+# gridscale_mssql
 
 Provides a MS SQL server resource. This can be used to create, modify, and delete MS SQL server instances.
 
@@ -15,7 +15,7 @@ Provides a MS SQL server resource. This can be used to create, modify, and delet
 The following example shows how one might use this resource to add a MS SQL server service to gridscale:
 
 ```terraform
-resource "gridscale_sqlserver" "terra-sqlserver-test" {
+resource "gridscale_mssql" "terra-sqlserver-test" {
   name = "test"
   release = "2019"
   performance_class = "standard"
@@ -35,19 +35,17 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
 
 * `s3_backup` - (Optional) Allow backup/restore MS SQL server to/from a S3 bucket.
 
   * `backup_bucket` - (Required) Object Storage bucket to upload backups to and restore backups from.
 
-  * `backup_retention` - (Optional) Retention (in seconds) for local originals of backups. (0 for immediate removal once uploaded to Object Storage (default), higher values for delayed removal after the given time and once uploaded to Object Storage).
-
   * `backup_access_key` - (Required) Access key used to authenticate against Object Storage server.
 
   * `backup_secret_key` - (Required) Secret key used to authenticate against Object Storage server.
 
-  * `backup_server_url` - (Optional, Default: "https://gos3.io/") Object Storage server URL the bucket is located on. **Note**: Currently, only object storage host "https://gos3.io/" is supported.
+  * `backup_server_url` - (Required) Object Storage server URL the bucket is located on.
 
 ## Timeouts
 
@@ -69,7 +67,6 @@ This resource exports the following attributes:
 * `password` - Password for PaaS service. It is used to connect to the MS SQL server instance.
 * `listen_port` - The port numbers where this MS SQL server service accepts connections.
   * `name` - Name of a port.
-  * `host` - Host address.
   * `listen_port` - Port number.
 * `s3_backup` - See Argument Reference above.
   * `backup_bucket` - See Argument Reference above.

--- a/website/docs/r/mysql.html.md
+++ b/website/docs/r/mysql.html.md
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The mysql instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/mysql.html.md
+++ b/website/docs/r/mysql.html.md
@@ -100,6 +100,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that mysql service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/mysql.html.md
+++ b/website/docs/r/mysql.html.md
@@ -59,6 +59,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The mysql instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
@@ -96,7 +98,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that mysql service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/mysql.html.md
+++ b/website/docs/r/mysql.html.md
@@ -59,7 +59,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The mysql instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -76,6 +76,7 @@ This resource exports the following attributes:
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - See Argument Reference above.
 * `service_template_uuid_computed` - Template that PaaS service uses. The `service_template_uuid_computed` will be different from `service_template_uuid`, when `service_template_uuid` is updated outside of terraform.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.
 * `current_price` - Current price of PaaS service.
 * `change_time` - Time of the last change.

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `parameters` - (Optional) Contains the service parameters for the service.
 

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -34,6 +34,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `parameters` - (Optional) Contains the service parameters for the service.
@@ -71,7 +73,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - See Argument Reference above.
 * `service_template_uuid_computed` - Template that PaaS service uses. The `service_template_uuid_computed` will be different from `service_template_uuid`, when `service_template_uuid` is updated outside of terraform.
 * `usage_in_minute` - Number of minutes that PaaS service is in use.

--- a/website/docs/r/paas.html.md
+++ b/website/docs/r/paas.html.md
@@ -34,7 +34,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 * `parameters` - (Optional) Contains the service parameters for the service.
 

--- a/website/docs/r/postgres.html.md
+++ b/website/docs/r/postgres.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The PostgreSQL instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/postgres.html.md
+++ b/website/docs/r/postgres.html.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The PostgreSQL instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
 

--- a/website/docs/r/postgres.html.md
+++ b/website/docs/r/postgres.html.md
@@ -36,6 +36,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `max_core_count` - (Optional) Maximum CPU core count. The PostgreSQL instance's CPU core count will be autoscaled based on the workload. The number of cores stays between 1 and `max_core_count`.
@@ -63,7 +65,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that PostgreSQL service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/redis_cache.html.md
+++ b/website/docs/r/redis_cache.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 ## Timeouts
 

--- a/website/docs/r/redis_cache.html.md
+++ b/website/docs/r/redis_cache.html.md
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 ## Timeouts
@@ -60,7 +62,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that Redis cache service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/redis_cache.html.md
+++ b/website/docs/r/redis_cache.html.md
@@ -64,6 +64,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that Redis cache service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/redis_cache.html.md
+++ b/website/docs/r/redis_cache.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 ## Timeouts
 

--- a/website/docs/r/redis_store.html.md
+++ b/website/docs/r/redis_store.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is running in.
+* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
 
 ## Timeouts
 

--- a/website/docs/r/redis_store.html.md
+++ b/website/docs/r/redis_store.html.md
@@ -64,6 +64,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that Redis store service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/redis_store.html.md
+++ b/website/docs/r/redis_store.html.md
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 ## Timeouts
@@ -60,7 +62,7 @@ This resource exports the following attributes:
   * `host` - Host address.
   * `listen_port` - Port number.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that Redis store service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.

--- a/website/docs/r/redis_store.html.md
+++ b/website/docs/r/redis_store.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 ## Timeouts
 

--- a/website/docs/r/sqlserver.html.md
+++ b/website/docs/r/sqlserver.html.md
@@ -35,7 +35,7 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
-* `security_zone_uuid` - (Optional) The UUID of the security zone that the service is attached to.
+* `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `s3_backup` - (Optional) Allow backup/restore MS SQL server to/from a S3 bucket.
 

--- a/website/docs/r/sqlserver.html.md
+++ b/website/docs/r/sqlserver.html.md
@@ -81,6 +81,7 @@ This resource exports the following attributes:
 * `security_zone_uuid` - See Argument Reference above.
 * `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that MS SQL server service uses.
+* `service_template_category` - The template service's category used to create the service.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.
 * `create_time` - Date time this service has been created.

--- a/website/docs/r/sqlserver.html.md
+++ b/website/docs/r/sqlserver.html.md
@@ -35,6 +35,8 @@ The following arguments are supported:
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
+* `network_uuid` - (Optional) The UUID of the network that the service is attached to.
+
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) The UUID of the security zone that the service is attached to.
 
 * `s3_backup` - (Optional) Allow backup/restore MS SQL server to/from a S3 bucket.
@@ -77,7 +79,7 @@ This resource exports the following attributes:
   * `backup_secret_key` - See Argument Reference above.
   * `backup_server_url` - See Argument Reference above.
 * `security_zone_uuid` - See Argument Reference above.
-* `network_uuid` - Network UUID containing security zone.
+* `network_uuid` -  The UUID of the network that the service is attached to or network UUID containing security zone.
 * `service_template_uuid` - PaaS service template that MS SQL server service uses.
 * `usage_in_minutes` - Number of minutes that PaaS service is in use.
 * `change_time` - Time of the last change.


### PR DESCRIPTION
Changes:
- Allow to set field `network_uuid` in paas resources.
- Deprecate field `security_zone_uuid` in paas resources.
- Add a new computed field `service_template_category` to paas resources.
- Update docs of paas.

Tested paas created with current version of gs tf provider, then upgrading to gs tf provider with those changes above :heavy_check_mark: 