### PR TITLE
Do not shutdown server when removing server-related resources (i.e IP addr, network, storage)

### DIFF
--- a/gridscale/resource_gridscale_ipv4.go
+++ b/gridscale/resource_gridscale_ipv4.go
@@ -240,18 +240,12 @@ func resourceGridscaleIpDelete(d *schema.ResourceData, meta interface{}) error {
 	//ip server relation is 1-1 relation
 	if len(ip.Properties.Relations.Servers) == 1 {
 		server := ip.Properties.Relations.Servers[0]
-		unlinkIPAction := func(ctx context.Context) error {
-			//No need to unlink when server returns 409 or 404
-			err := errHandler.SuppressHTTPErrorCodes(
-				client.UnlinkIP(ctx, server.ServerUUID, d.Id()),
-				http.StatusConflict,
-				http.StatusNotFound,
-			)
-			return err
-		}
-		//DeleteIP requires the server to be off
-		err = globalServerStatusList.runActionRequireServerOff(ctx, client, server.ServerUUID, false, unlinkIPAction)
-		if err != nil {
+		//No need to unlink when server returns 409 or 404
+		if err := errHandler.SuppressHTTPErrorCodes(
+			client.UnlinkIP(ctx, server.ServerUUID, d.Id()),
+			http.StatusConflict,
+			http.StatusNotFound,
+		); err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 	}

--- a/gridscale/resource_gridscale_network.go
+++ b/gridscale/resource_gridscale_network.go
@@ -346,18 +346,12 @@ func resourceGridscaleNetworkDelete(d *schema.ResourceData, meta interface{}) er
 
 	//Stop all servers relating to this network address if there is one
 	for _, server := range net.Properties.Relations.Servers {
-		unlinkNetAction := func(ctx context.Context) error {
-			//No need to unlink when server returns 409 or 404
-			err := errHandler.SuppressHTTPErrorCodes(
-				client.UnlinkNetwork(ctx, server.ObjectUUID, d.Id()),
-				http.StatusConflict,
-				http.StatusNotFound,
-			)
-			return err
-		}
-		//UnlinkNetwork requires the server to be off
-		err = globalServerStatusList.runActionRequireServerOff(ctx, client, server.ObjectUUID, false, unlinkNetAction)
-		if err != nil {
+		//No need to unlink when server returns 409 or 404
+		if err := errHandler.SuppressHTTPErrorCodes(
+			client.UnlinkNetwork(ctx, server.ObjectUUID, d.Id()),
+			http.StatusConflict,
+			http.StatusNotFound,
+		); err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 	}

--- a/gridscale/resource_gridscale_storage.go
+++ b/gridscale/resource_gridscale_storage.go
@@ -417,18 +417,12 @@ func resourceGridscaleStorageDelete(d *schema.ResourceData, meta interface{}) er
 
 	//Stop all server relating to this IP address if there is one
 	for _, server := range storage.Properties.Relations.Servers {
-		unlinkStorageAction := func(ctx context.Context) error {
-			//No need to unlink when server returns 409 or 404
-			err := errHandler.SuppressHTTPErrorCodes(
-				client.UnlinkStorage(ctx, server.ObjectUUID, d.Id()),
-				http.StatusConflict,
-				http.StatusNotFound,
-			)
-			return err
-		}
-		//UnlinkStorage requires the server to be off
-		err = globalServerStatusList.runActionRequireServerOff(ctx, client, server.ObjectUUID, false, unlinkStorageAction)
-		if err != nil {
+		//No need to unlink when server returns 409 or 404
+		if err := errHandler.SuppressHTTPErrorCodes(
+			client.UnlinkStorage(ctx, server.ObjectUUID, d.Id()),
+			http.StatusConflict,
+			http.StatusNotFound,
+		); err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 	}


### PR DESCRIPTION
Changes:
- Do not shutdown server when removing server-related resources (i.e IP addr, network, storage).
- Return errors when cannot unlink.