### PR TITLE
allow to set `gsk_version` & add surge node feature  in k8s resource

### DIFF
--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -181,6 +181,11 @@ func resourceGridscaleK8s() *schema.Resource {
 							Description: "Storage type.",
 							Required:    true,
 						},
+						"surge_node_count": {
+							Type:        schema.TypeInt,
+							Description: "Number of surge nodes. Surge nodes are used to avoid resources shortage during the cluster upgrade.",
+							Optional:    true,
+						},
 					},
 				},
 			},
@@ -281,12 +286,13 @@ func resourceGridscaleK8sRead(d *schema.ResourceData, meta interface{}) error {
 	nodePoolList := make([]interface{}, 0)
 	// TODO: The API scheme will be CHANGED in the future. There will be multiple node pools.
 	nodePool := map[string]interface{}{
-		"name":         d.Get("node_pool.0.name"),
-		"node_count":   props.Parameters["k8s_worker_node_count"],
-		"cores":        props.Parameters["k8s_worker_node_cores"],
-		"memory":       props.Parameters["k8s_worker_node_ram"],
-		"storage":      props.Parameters["k8s_worker_node_storage"],
-		"storage_type": props.Parameters["k8s_worker_node_storage_type"],
+		"name":             d.Get("node_pool.0.name"),
+		"node_count":       props.Parameters["k8s_worker_node_count"],
+		"cores":            props.Parameters["k8s_worker_node_cores"],
+		"memory":           props.Parameters["k8s_worker_node_ram"],
+		"storage":          props.Parameters["k8s_worker_node_storage"],
+		"storage_type":     props.Parameters["k8s_worker_node_storage_type"],
+		"surge_node_count": props.Parameters["k8s_surge_node_count"],
 	}
 	nodePoolList = append(nodePoolList, nodePool)
 	if err = d.Set("node_pool", nodePoolList); err != nil {
@@ -355,6 +361,7 @@ func resourceGridscaleK8sCreate(d *schema.ResourceData, meta interface{}) error 
 	params["k8s_worker_node_count"] = d.Get("node_pool.0.node_count")
 	params["k8s_worker_node_storage"] = d.Get("node_pool.0.storage")
 	params["k8s_worker_node_storage_type"] = d.Get("node_pool.0.storage_type")
+	params["k8s_surge_node_count"] = d.Get("node_pool.0.surge_node_count")
 	requestBody.Parameters = params
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutCreate))
@@ -404,6 +411,7 @@ func resourceGridscaleK8sUpdate(d *schema.ResourceData, meta interface{}) error 
 	params["k8s_worker_node_count"] = d.Get("node_pool.0.node_count")
 	params["k8s_worker_node_storage"] = d.Get("node_pool.0.storage")
 	params["k8s_worker_node_storage_type"] = d.Get("node_pool.0.storage_type")
+	params["k8s_surge_node_count"] = d.Get("node_pool.0.surge_node_count")
 	requestBody.Parameters = params
 
 	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -77,10 +77,10 @@ func resourceGridscaleK8s() *schema.Resource {
 				}
 			}
 			if !isReleaseValid && isReleaseSet {
-				return fmt.Errorf("%v is not a valid Kubernetes release. Valid releases are: %v\n", newReleaseVal, strings.Join(releaseList, ", "))
+				return fmt.Errorf("%v is an INVALID Kubernetes minor release. Valid releases are: %v\n", newReleaseVal, strings.Join(releaseList, ", "))
 			}
 			if !isVersionValid && isVersionSet {
-				return fmt.Errorf("%v is not a valid gridscale Kubernetes (GSK) version. Valid GSK versions are: %v\n", newVersionVal, strings.Join(versionList, ", "))
+				return fmt.Errorf("%v is an INVALID gridscale Kubernetes (GSK) version. Valid GSK versions are: %v\n", newVersionVal, strings.Join(versionList, ", "))
 			}
 			return validateK8sParameters(d, chosenTemplate)
 		},
@@ -458,11 +458,12 @@ func getK8sTemplateUUIDFromRelease(client *gsclient.Client, release string) (str
 			if template.Properties.Release == release {
 				isReleaseValid = true
 				uTemplate = template
+				break
 			}
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid Kubernetes release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is an INVALID Kubernetes minor release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil
@@ -483,11 +484,12 @@ func getK8sTemplateUUIDFromGSKVersion(client *gsclient.Client, version string) (
 			if template.Properties.Version == version {
 				isVersionValid = true
 				uTemplate = template
+				break
 			}
 		}
 	}
 	if !isVersionValid {
-		return "", fmt.Errorf("%v is not a valid gridscale Kubernetes (GSK) version. Valid GSK versions are: %v\n", version, strings.Join(versions, ", "))
+		return "", fmt.Errorf("%v is an INVALID gridscale Kubernetes (GSK) version. Valid GSK versions are: %v\n", version, strings.Join(versions, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/website/docs/r/k8s.html.md
+++ b/website/docs/r/k8s.html.md
@@ -18,7 +18,7 @@ The following example shows how one might use this resource to add a k8s cluster
 ```terraform
 resource "gridscale_k8s" "k8s-test" {
   name   = "test"
-  release = "1.19"
+  release = "1.21" # instead, gsk_version can be set.
   node_pool {
   name = "my_node_pool"
     node_count = 2
@@ -39,7 +39,9 @@ The following arguments are supported:
 
 * `security_zone_uuid` -  *DEPRECATED* (Optional, Forcenew) Security zone UUID linked to the Kubernetes resource. If `security_zone_uuid` is not set, the default security zone will be created (if it doesn't exist) and linked. A change of this argument necessitates the re-creation of the resource.
 
-* `release` - (Required) The Kubernetes release of this instance. Define which release will be used to create the cluster. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available release numbers.
+* `gsk_version` - (Optional) The gridscale's Kubernetes version of this instance (e.g. "1.21.14-gs1"). Define which gridscale k8s version will be used to create the cluster. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available gridscale k8s version. **NOTE**: Either `gsk_version` or `release` is set at a time.
+
+* `release` - (Optional) The Kubernetes release of this instance. Define which release will be used to create the cluster. For convenience, please use [gscloud](https://github.com/gridscale/gscloud) to get the list of available releases. **NOTE**: Either `gsk_version` or `release` is set at a time.
 
 * `labels` - (Optional) List of labels in the format [ "label1", "label2" ].
 
@@ -50,6 +52,7 @@ The following arguments are supported:
     * `memory` - (Immutable) Memory per worker node (in GiB).
     * `storage` - (Immutable) Storage per worker node (in GiB).
     * `storage_type` - (Immutable) Storage type (one of storage, storage_high, storage_insane).
+    * `surge_node_count` - Number of surge nodes. Surge nodes are used to avoid resources shortage during the cluster upgrade..
 
 ## Timeouts
 
@@ -67,6 +70,7 @@ This resource exports the following attributes:
 * `name` - See Argument Reference above.
 * `security_zone_uuid` - See Argument Reference above.
 * `release` - See Argument Reference above.
+* `gsk_version` - See Argument Reference above.
 * `service_template_uuid` - PaaS service template that k8s service uses. The `service_template_uuid` may not relate to `release`, if `service_template_uuid`/`release` is updated outside of terraform (e.g. the k8s service is upgraded by gridscale staffs).
 * `service_template_category` - The template service's category used to create the service.
 * `labels` - See Argument Reference above.
@@ -77,6 +81,7 @@ This resource exports the following attributes:
     * `cores` - See Argument Reference above.
     * `memory` - See Argument Reference above.
     * `storage` - See Argument Reference above.
+    * `storage_type` - See Argument Reference above.
     * `storage_type` - See Argument Reference above.
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
 * `create_time` - The time the object was created.

--- a/website/docs/r/k8s.html.md
+++ b/website/docs/r/k8s.html.md
@@ -52,7 +52,7 @@ The following arguments are supported:
     * `memory` - (Immutable) Memory per worker node (in GiB).
     * `storage` - (Immutable) Storage per worker node (in GiB).
     * `storage_type` - (Immutable) Storage type (one of storage, storage_high, storage_insane).
-    * `surge_node_count` - Number of surge nodes. Surge nodes are used to avoid resources shortage during the cluster upgrade..
+    * `surge_node` - Enable surge node to avoid resources shortage during the cluster upgrade (Default: true).
 
 ## Timeouts
 
@@ -82,7 +82,7 @@ This resource exports the following attributes:
     * `memory` - See Argument Reference above.
     * `storage` - See Argument Reference above.
     * `storage_type` - See Argument Reference above.
-    * `surge_node_count` - See Argument Reference above.
+    * `surge_node` - See Argument Reference above.
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
 * `create_time` - The time the object was created.
 * `change_time` - Defines the date and time of the last object change.

--- a/website/docs/r/k8s.html.md
+++ b/website/docs/r/k8s.html.md
@@ -82,7 +82,7 @@ This resource exports the following attributes:
     * `memory` - See Argument Reference above.
     * `storage` - See Argument Reference above.
     * `storage_type` - See Argument Reference above.
-    * `storage_type` - See Argument Reference above.
+    * `surge_node_count` - See Argument Reference above.
 * `usage_in_minutes` - The amount of minutes the IP address has been in use.
 * `create_time` - The time the object was created.
 * `change_time` - Defines the date and time of the last object change.


### PR DESCRIPTION
Changes:
- Allow to set `gsk_version` in k8s resource.
- Allow switching between `release` and `gsk_version` in k8s resource.
- Add surge node feature to k8s resource.