### PR TITLE
Update description of power property

### DIFF
--- a/gridscale/datasource_gridscale_server.go
+++ b/gridscale/datasource_gridscale_server.go
@@ -197,7 +197,7 @@ func dataSourceGridscaleServer() *schema.Resource {
 			},
 			"power": {
 				Type:        schema.TypeBool,
-				Description: "The number of server cores.",
+				Description: "The power state of the server. Set this to true to will boot the server, false will shut it down.",
 				Computed:    true,
 			},
 			"current_price": {


### PR DESCRIPTION
When using the `IntelliCode` feature from Visual Studio Code the description for the `power` property diffs with the description in the [official documentation](https://registry.terraform.io/providers/gridscale/gridscale/latest/docs/resources/server#power).

![image](https://user-images.githubusercontent.com/35262568/204222923-fe814e85-6bc6-4c8c-96aa-23371f39152a.png)

```[power](https://registry.terraform.io/providers/gridscale/gridscale/latest/docs/resources/server#power) - (Optional, Computed) The power state of the server. Set this to true to will boot the server, false will shut it down.```

I've provided a simple change to fix that.