### PR TITLE
Make name in datasource template case-insensitive and trim leading&trailing white spaces

### DIFF
--- a/website/docs/d/template.html.md
+++ b/website/docs/d/template.html.md
@@ -39,7 +39,7 @@ resource "gridscale_storage" "storage-test"{
 
 The following arguments are supported:
 
-* `name` - (Required) The exact name of the template as show in [the page Template](https://my.gridscale.io/Template).
+* `name` - (Required) The name of the template as show in [the page Template](https://my.gridscale.io/Template). **Note**: any leading and trailing white spaces will be trimmed. The name is case-insensitive.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Changes:
- Allow the name of datasource `template` case-insensitive.
- Trim all leading and trailing white spaces in the template name.