### PR TITLE
feature/expand-feature-release-compatibility-validation

### DIFF
--- a/gridscale/common.go
+++ b/gridscale/common.go
@@ -15,6 +15,9 @@ const (
 
 var supportedPrimTypes = []string{boolInterfaceType, intInterfaceType, floatInterfaceType, stringInterfaceType}
 
+// Truth type
+type Truth bool
+
 // convSOStrings converts slice of interfaces to slice of strings
 func convSOStrings(interfaceList []interface{}) []string {
 	strList := make([]string, 0)

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -608,7 +608,7 @@ func validateK8sParameters(d *schema.ResourceDiff, template gsclient.PaaSTemplat
 	if rocket_storage, ok := d.GetOk("node_pool.0.rocket_storage"); ok && rocket_storage_ok {
 		rocketStorageValidation := true
 		featureReleaseCompabilityValidation := true
-		supportedRelease, err := NewRelease(k8sRocketStorageSupportRelease)
+		supportedReleaseSpan, err := NewReleaseSpan(k8sRocketStorageSupportRelease, nil)
 		if err != nil {
 			panic("Something went wrong at backend side parsing of version string expected for support of rocket storage at k8s.")
 		}
@@ -618,7 +618,7 @@ func validateK8sParameters(d *schema.ResourceDiff, template gsclient.PaaSTemplat
 			featureReleaseCompabilityValidation = false
 		}
 		if featureReleaseCompabilityValidation {
-			err := requestedRelease.CheckIfFeatureIsKnown(&Feature{Description: "rocket storage", Release: *supportedRelease})
+			err := requestedRelease.CheckIfFeatureRequestIsApplicable(&Feature{Description: "rocket storage", ReleaseSpans: []ReleaseSpan{*supportedReleaseSpan}})
 			if err != nil {
 				errorMessages = append(errorMessages, err.Error())
 				rocketStorageValidation = false


### PR DESCRIPTION
Basically the implementations this merge request holds are used to expand the already existing validation of compatibility between requested feature and release in a meaning that additionally it gets considered that a requested feature can ...
   - not just has a reference/relation to a release from which on it gets
     supported, but as well might get supported just till specific
     release.
     So instead considering just a start point of support at validation
     of a feature's applicability, a span with optional end needs to be considered.
   - can be part of various release spans.