### PR TITLE
feature/fix-linter-issues

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleBackup_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleBackup_basic'
+      - name: Run TestAccdataSourceGridscaleBackupBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleBackupBasic'
 
-      - name: Run TestAccdataSourceGridscaleBackupSchedule_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleBackupSchedule_basic'
+      - name: Run TestAccdataSourceGridscaleBackupScheduleBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleBackupScheduleBasic'
 
-      - name: Run TestAccResourceGridscaleBackupSchedule_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleBackupSchedule_Basic'
+      - name: Run TestAccResourceGridscaleBackupScheduleBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleBackupScheduleBasic'

--- a/.github/workflows/filesystem.yml
+++ b/.github/workflows/filesystem.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleFilesystem_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleFilesystem_Basic'
+      - name: Run TestAccResourceGridscaleFilesystemBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleFilesystemBasic'

--- a/.github/workflows/firewall.yml
+++ b/.github/workflows/firewall.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleFirewall_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleFirewall_basic'
+      - name: Run TestAccdataSourceGridscaleFirewallBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleFirewallBasic'
 
-      - name: Run TestAccResourceGridscaleFirewall_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleFirewall_Basic'
+      - name: Run TestAccResourceGridscaleFirewallBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleFirewallBasic'

--- a/.github/workflows/ipv4_ipv6.yml
+++ b/.github/workflows/ipv4_ipv6.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleIPv4_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleIPv4_basic'
+      - name: Run TestAccdataSourceGridscaleIPv4Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleIPv4Basic'
 
-      - name: Run TestAccdataSourceGridscaleIPv6_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleIPv6_basic'
+      - name: Run TestAccdataSourceGridscaleIPv6Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleIPv6Basic'
 
-      - name: Run TestAccResourceGridscaleIpv4_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleIpv4_Basic'
+      - name: Run TestAccResourceGridscaleIpv4Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleIpv4Basic'
 
-      - name: Run TestAccResourceGridscaleIpv6_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleIpv6_Basic'
+      - name: Run TestAccResourceGridscaleIpv6Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleIpv6Basic'

--- a/.github/workflows/isoimage.yml
+++ b/.github/workflows/isoimage.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccDataSourceISOImage_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccDataSourceISOImage_basic'
+      - name: Run TestAccDataSourceISOImageBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccDataSourceISOImageBasic'
 
-      - name: Run TestAccResourceGridscaleISOImage_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleISOImage_Basic'
+      - name: Run TestAccResourceGridscaleISOImageBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleISOImageBasic'

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleK8s_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleK8s_Basic'
+      - name: Run TestAccResourceGridscaleK8sBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleK8sBasic'

--- a/.github/workflows/loadbalancer.yml
+++ b/.github/workflows/loadbalancer.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleLoadBalancer_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleLoadBalancer_basic'
+      - name: Run TestAccdataSourceGridscaleLoadBalancerBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleLoadBalancerBasic'
 
       - name: Run TestAccResourceGridscaleLoadBalancerBasic
         run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleLoadBalancerBasic'

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleMariaDB_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMariaDB_Basic'
+      - name: Run TestAccResourceGridscaleMariaDBBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMariaDBBasic'

--- a/.github/workflows/marketplace_app.yml
+++ b/.github/workflows/marketplace_app.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleMarketplaceApplication_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleMarketplaceApplication_basic'
+      - name: Run TestAccdataSourceGridscaleMarketplaceApplicationBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleMarketplaceApplicationBasic'
 
-      - name: Run TestAccResourceGridscaleMarketplaceApplication_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMarketplaceApplication_Basic'
+      - name: Run TestAccResourceGridscaleMarketplaceApplicationBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMarketplaceApplicationBasic'
 
-      - name: Run TestAccResourceGridscaleMarketplaceApplicationImport_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMarketplaceApplicationImport_Basic'
+      - name: Run TestAccResourceGridscaleMarketplaceApplicationImportBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMarketplaceApplicationImportBasic'

--- a/.github/workflows/memcached.yml
+++ b/.github/workflows/memcached.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleMemcached_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMemcached_Basic'
+      - name: Run TestAccResourceGridscaleMemcachedBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMemcachedBasic'

--- a/.github/workflows/mssql.yml
+++ b/.github/workflows/mssql.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleMSSQLServer_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMSSQLServer_Basic'
+      - name: Run TestAccResourceGridscaleMSSQLServerBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMSSQLServerBasic'

--- a/.github/workflows/mysql8_0.yml
+++ b/.github/workflows/mysql8_0.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleMySQL8_0_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMySQL8_0_Basic'
+      - name: Run TestAccResourceGridscaleMySQL8_0Basic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleMySQL8_0Basic'

--- a/.github/workflows/network.yml
+++ b/.github/workflows/network.yml
@@ -42,11 +42,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleNetwork_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleNetwork_basic'
+      - name: Run TestAccdataSourceGridscaleNetworkBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleNetworkBasic'
 
-      - name: Run TestAccdataSourceGridscalePublicNetwork_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscalePublicNetwork_basic'
+      - name: Run TestAccdataSourceGridscalePublicNetworkBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscalePublicNetworkBasic'
 
-      - name: Run TestAccResourceGridscaleNetwork_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleNetwork_Basic'
+      - name: Run TestAccResourceGridscaleNetworkBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleNetworkBasic'

--- a/.github/workflows/object_storage.yml
+++ b/.github/workflows/object_storage.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleObjectStorage_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleObjectStorage_basic'
+      - name: Run TestAccdataSourceGridscaleObjectStorageBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleObjectStorageBasic'
 
-      - name: Run TestAccResourceGridscaleObjectStorage_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleObjectStorage_Basic'
+      - name: Run TestAccResourceGridscaleObjectStorageBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleObjectStorageBasic'

--- a/.github/workflows/paas.yml
+++ b/.github/workflows/paas.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscalePaaS_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscalePaaS_basic'
+      - name: Run TestAccdataSourceGridscalePaaSBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscalePaaSBasic'
 
-      - name: Run TestAccResourceGridscalePaaS_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscalePaaS_Basic'
+      - name: Run TestAccResourceGridscalePaaSBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscalePaaSBasic'

--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -41,5 +41,5 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscalePostgres_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscalePostgres_Basic'
+      - name: Run TestAccResourceGridscalePostgresBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscalePostgresBasic'

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccResourceGridscaleRedisStore_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisStore_Basic'
+      - name: Run TestAccResourceGridscaleRedisStoreBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisStoreBasic'
 
-      - name: Run TestAccResourceGridscaleRedisCache_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisCache_Basic'
+      - name: Run TestAccResourceGridscaleRedisCacheBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleRedisCacheBasic'

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleServer_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleServer_basic'
+      - name: Run TestAccdataSourceGridscaleServerBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleServerBasic'
 
-      - name: Run TestAccResourceGridscaleServer_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleServer_Basic'
+      - name: Run TestAccResourceGridscaleServerBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleServerBasic'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleSnapshot_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSnapshot_basic'
+      - name: Run TestAccdataSourceGridscaleSnapshotBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSnapshotBasic'
 
-      - name: Run TestAccdataSourceGridscaleSnapshotSchedule_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSnapshotSchedule_basic'
+      - name: Run TestAccdataSourceGridscaleSnapshotScheduleBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSnapshotScheduleBasic'
 
-      - name: Run TestAccResourceGridscaleSnapshot_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSnapshot_Basic'
+      - name: Run TestAccResourceGridscaleSnapshotBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSnapshotBasic'
 
-      - name: Run TestAccResourceGridscaleSnapshotSchedule_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSnapshotSchedule_Basic'
+      - name: Run TestAccResourceGridscaleSnapshotScheduleBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSnapshotScheduleBasic'

--- a/.github/workflows/sshkey.yml
+++ b/.github/workflows/sshkey.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleSSHKey_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSSHKey_basic'
+      - name: Run TestAccdataSourceGridscaleSSHKeyBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSSHKeyBasic'
 
-      - name: Run TestAccResourceGridscaleSshkey_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSshkey_Basic'
+      - name: Run TestAccResourceGridscaleSshkeyBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSshkeyBasic'

--- a/.github/workflows/sslcert.yml
+++ b/.github/workflows/sslcert.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleSSLCert_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSSLCert_basic'
+      - name: Run TestAccdataSourceGridscaleSSLCertBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleSSLCertBasic'
 
-      - name: Run TestAccResourceGridscaleSSLCert_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSSLCert_Basic'
+      - name: Run TestAccResourceGridscaleSSLCertBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleSSLCertBasic'

--- a/.github/workflows/storage.yml
+++ b/.github/workflows/storage.yml
@@ -41,11 +41,11 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccdataSourceGridscaleStorage_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleStorage_basic'
+      - name: Run TestAccdataSourceGridscaleStorageBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccdataSourceGridscaleStorageBasic'
 
-      - name: Run TestAccResourceGridscaleStorage_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleStorage_Basic'
+      - name: Run TestAccResourceGridscaleStorageBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleStorageBasic'
 
-      - name: Run TestAccResourceGridscaleStorageClone_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleStorageClone_Basic'
+      - name: Run TestAccResourceGridscaleStorageCloneBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleStorageCloneBasic'

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
 
-      - name: Run TestAccDataSourceTemplate_basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccDataSourceTemplate_basic'
+      - name: Run TestAccDataSourceTemplateBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccDataSourceTemplateBasic'
 
-      - name: Run TestAccResourceGridscaleTemplate_Basic
-        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleTemplate_Basic'
+      - name: Run TestAccResourceGridscaleTemplateBasic
+        run: make testacc TEST=./gridscale TESTARGS='-run=TestAccResourceGridscaleTemplateBasic'

--- a/gridscale/config.go
+++ b/gridscale/config.go
@@ -21,7 +21,6 @@ var marketplaceAppCategories = []string{"CMS", "project management", "Adminpanel
 var postgreSQLPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
 var filesystemPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
 var msSQLServerPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
-var mariaDBPerformanceClasses = []string{"standard", "high", "insane", "ultra"}
 var machineTypes = []string{"i440fx", "q35_bios", "q35_uefi"}
 var storageDevices = []string{"ide", "sata", "virtio_scsi", "virtio_block"}
 var usbControllers = []string{"nec_xhci", "piix3_uhci"}

--- a/gridscale/datasource_gridscale_backup_schedule_test.go
+++ b/gridscale/datasource_gridscale_backup_schedule_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleBackupSchedule_basic(t *testing.T) {
+func TestAccdataSourceGridscaleBackupScheduleBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccdataSourceGridscaleBackupSchedule_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceBackupScheduleConfig_basic(name),
+				Config: testAccCheckDataSourceBackupScheduleConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_backupschedule.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_backupschedule.foo", "name", name),
@@ -29,7 +29,7 @@ func TestAccdataSourceGridscaleBackupSchedule_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceBackupScheduleConfig_basic(name string) string {
+func testAccCheckDataSourceBackupScheduleConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_storage" "foo" {

--- a/gridscale/datasource_gridscale_backup_test.go
+++ b/gridscale/datasource_gridscale_backup_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleBackup_basic(t *testing.T) {
+func TestAccdataSourceGridscaleBackupBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceBackupConfig_basic(),
+				Config: testAccCheckDataSourceBackupConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_backup_list.foo", "id"),
 				),
@@ -22,7 +22,7 @@ func TestAccdataSourceGridscaleBackup_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceBackupConfig_basic() string {
+func testAccCheckDataSourceBackupConfigBasic() string {
 	return `
 resource "gridscale_storage" "foo" {
 	name   = "storage"

--- a/gridscale/datasource_gridscale_backup_test.go
+++ b/gridscale/datasource_gridscale_backup_test.go
@@ -1,7 +1,6 @@
 package gridscale
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -24,12 +23,12 @@ func TestAccdataSourceGridscaleBackup_basic(t *testing.T) {
 }
 
 func testAccCheckDataSourceBackupConfig_basic() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "foo" {
 	name   = "storage"
 	capacity = 1
 }
 data "gridscale_backup_list" "foo" {
   	storage_uuid = gridscale_storage.foo.id
-}`)
+}`
 }

--- a/gridscale/datasource_gridscale_firewall_test.go
+++ b/gridscale/datasource_gridscale_firewall_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleFirewall_basic(t *testing.T) {
+func TestAccdataSourceGridscaleFirewallBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccdataSourceGridscaleFirewall_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceFirewallConfig_basic(name),
+				Config: testAccCheckDataSourceFirewallConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_firewall.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_firewall.foo", "name", name),
@@ -29,7 +29,7 @@ func TestAccdataSourceGridscaleFirewall_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceFirewallConfig_basic(name string) string {
+func testAccCheckDataSourceFirewallConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_firewall" "foo" {
   name   = "%s"

--- a/gridscale/datasource_gridscale_ipv4_test.go
+++ b/gridscale/datasource_gridscale_ipv4_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleIPv4_basic(t *testing.T) {
+func TestAccdataSourceGridscaleIPv4Basic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccdataSourceGridscaleIPv4_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceIPv4Config_basic(name),
+				Config: testAccCheckDataSourceIPv4ConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_ipv4.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_ipv4.foo", "name", name),
@@ -29,7 +29,7 @@ func TestAccdataSourceGridscaleIPv4_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceIPv4Config_basic(name string) string {
+func testAccCheckDataSourceIPv4ConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ipv4" "foo" {

--- a/gridscale/datasource_gridscale_ipv6_test.go
+++ b/gridscale/datasource_gridscale_ipv6_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleIPv6_basic(t *testing.T) {
+func TestAccdataSourceGridscaleIPv6Basic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleIPv6_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceIPv6Config_basic(name),
+				Config: testAccCheckDataSourceIPv6ConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_ipv6.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_ipv6.foo", "name", name),
@@ -28,7 +28,7 @@ func TestAccdataSourceGridscaleIPv6_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceIPv6Config_basic(name string) string {
+func testAccCheckDataSourceIPv6ConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ipv6" "foo" {

--- a/gridscale/datasource_gridscale_isoimage_test.go
+++ b/gridscale/datasource_gridscale_isoimage_test.go
@@ -2,13 +2,14 @@ package gridscale
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceISOImage_basic(t *testing.T) {
+func TestAccDataSourceISOImageBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -18,7 +19,7 @@ func TestAccDataSourceISOImage_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceGridscaleISOImageConfig_basic(name),
+				Config: testAccCheckDataSourceGridscaleISOImageConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_isoimage.foo", "id"),
 				),
@@ -28,7 +29,7 @@ func TestAccDataSourceISOImage_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceGridscaleISOImageConfig_basic(name string) string {
+func testAccCheckDataSourceGridscaleISOImageConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_isoimage" "foo" {
   name   = "%s"

--- a/gridscale/datasource_gridscale_loadbalancer_test.go
+++ b/gridscale/datasource_gridscale_loadbalancer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleLoadBalancer_basic(t *testing.T) {
+func TestAccdataSourceGridscaleLoadBalancerBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleLoadBalancer_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceLoadBalancerConfig_basic(name),
+				Config: testAccCheckDataSourceLoadBalancerConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_loadbalancer.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_loadbalancer.foo", "name", name),
@@ -35,7 +35,7 @@ func TestAccdataSourceGridscaleLoadBalancer_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceLoadBalancerConfig_basic(name string) string {
+func testAccCheckDataSourceLoadBalancerConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ipv4" "lb" {

--- a/gridscale/datasource_gridscale_marketplace_app_test.go
+++ b/gridscale/datasource_gridscale_marketplace_app_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleMarketplaceApplication_basic(t *testing.T) {
+func TestAccdataSourceGridscaleMarketplaceApplicationBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccdataSourceGridscaleMarketplaceApplication_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceMarketplaceApplicationConfig_basic(name),
+				Config: testAccCheckDataSourceMarketplaceApplicationConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_marketplace_application.foo", "id"),
 					resource.TestCheckResourceAttrSet("data.gridscale_marketplace_application.foo", "category"),
@@ -33,7 +33,7 @@ func TestAccdataSourceGridscaleMarketplaceApplication_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceMarketplaceApplicationConfig_basic(name string) string {
+func testAccCheckDataSourceMarketplaceApplicationConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_marketplace_application" "foo" {
 	name = "%s"

--- a/gridscale/datasource_gridscale_network_test.go
+++ b/gridscale/datasource_gridscale_network_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleNetwork_basic(t *testing.T) {
+func TestAccdataSourceGridscaleNetworkBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleNetwork_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceNetworkConfig_basic(name),
+				Config: testAccCheckDataSourceNetworkConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_network.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_network.foo", "name", name),
@@ -36,7 +36,7 @@ func TestAccdataSourceGridscaleNetwork_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceNetworkConfig_basic(name string) string {
+func testAccCheckDataSourceNetworkConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_network" "foo" {

--- a/gridscale/datasource_gridscale_objectstorage_test.go
+++ b/gridscale/datasource_gridscale_objectstorage_test.go
@@ -1,7 +1,6 @@
 package gridscale
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -29,12 +28,12 @@ func TestAccdataSourceGridscaleObjectStorage_basic(t *testing.T) {
 }
 
 func testAccCheckDataSourceObjectStorageConfig_basic() string {
-	return fmt.Sprint(`
+	return `
 resource "gridscale_object_storage_accesskey" "foo" {
 }
 
 data "gridscale_object_storage_accesskey" "foo" {
 	resource_id   = "${gridscale_object_storage_accesskey.foo.id}"
 }
-`)
+`
 }

--- a/gridscale/datasource_gridscale_objectstorage_test.go
+++ b/gridscale/datasource_gridscale_objectstorage_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleObjectStorage_basic(t *testing.T) {
+func TestAccdataSourceGridscaleObjectStorageBasic(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +15,7 @@ func TestAccdataSourceGridscaleObjectStorage_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceObjectStorageConfig_basic(),
+				Config: testAccCheckDataSourceObjectStorageConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_object_storage_accesskey.foo", "id"),
 					resource.TestCheckResourceAttrSet("data.gridscale_object_storage_accesskey.foo", "access_key"),
@@ -27,7 +27,7 @@ func TestAccdataSourceGridscaleObjectStorage_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceObjectStorageConfig_basic() string {
+func testAccCheckDataSourceObjectStorageConfigBasic() string {
 	return `
 resource "gridscale_object_storage_accesskey" "foo" {
 }

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -163,7 +163,7 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 	if err = d.Set("name", props.Name); err != nil {
 		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
 	}
-	if creds != nil && len(creds) > 0 {
+	if len(creds) > 0 {
 		if err = d.Set("username", creds[0].Username); err != nil {
 			return fmt.Errorf("%s error setting username: %v", errorPrefix, err)
 		}
@@ -222,6 +222,10 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 		valueInString, err := convInterfaceToString(paramValType, value)
+
+		if err != nil {
+			return err
+		}
 		param := map[string]interface{}{
 			"param": k,
 			"value": valueInString,

--- a/gridscale/datasource_gridscale_paas_test.go
+++ b/gridscale/datasource_gridscale_paas_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscalePaaS_basic(t *testing.T) {
+func TestAccdataSourceGridscalePaaSBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -16,7 +16,7 @@ func TestAccdataSourceGridscalePaaS_basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourcePaaSConfig_basic(name),
+				Config: testAccCheckDataSourcePaaSConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.gridscale_paas.foo", "name", name),
 					resource.TestCheckResourceAttr("data.gridscale_paas.foo", "service_template_uuid", "d7a5e8ec-fa78-4d1b-86f9-febe3e16e398"),
@@ -27,7 +27,7 @@ func TestAccdataSourceGridscalePaaS_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourcePaaSConfig_basic(name string) string {
+func testAccCheckDataSourcePaaSConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas" "foo" {
   name = "%s"

--- a/gridscale/datasource_gridscale_publicnetwork_test.go
+++ b/gridscale/datasource_gridscale_publicnetwork_test.go
@@ -1,7 +1,6 @@
 package gridscale
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -26,7 +25,7 @@ func TestAccdataSourceGridscalePublicNetwork_basic(t *testing.T) {
 }
 
 func testAccCheckDataSourcePublicNetworkConfig_basic() string {
-	return fmt.Sprint(`
+	return `
 data "gridscale_public_network" "foo" {
-}`)
+}`
 }

--- a/gridscale/datasource_gridscale_publicnetwork_test.go
+++ b/gridscale/datasource_gridscale_publicnetwork_test.go
@@ -6,14 +6,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscalePublicNetwork_basic(t *testing.T) {
+func TestAccdataSourceGridscalePublicNetworkBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourcePublicNetworkConfig_basic(),
+				Config: testAccCheckDataSourcePublicNetworkConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_public_network.foo", "id"),
 					resource.TestCheckResourceAttrSet("data.gridscale_public_network.foo", "name"),
@@ -24,7 +24,7 @@ func TestAccdataSourceGridscalePublicNetwork_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourcePublicNetworkConfig_basic() string {
+func testAccCheckDataSourcePublicNetworkConfigBasic() string {
 	return `
 data "gridscale_public_network" "foo" {
 }`

--- a/gridscale/datasource_gridscale_securityzone_test.go
+++ b/gridscale/datasource_gridscale_securityzone_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleSecurityZone_basic(t *testing.T) {
+func TestAccdataSourceGridscaleSecurityZoneBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleSecurityZone_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceSecurityZoneConfig_basic(name),
+				Config: testAccCheckDataSourceSecurityZoneConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_paas_securityzone.foo", "location_uuid"),
 					resource.TestCheckResourceAttr("data.gridscale_paas_securityzone.foo", "name", name),
@@ -28,7 +28,7 @@ func TestAccdataSourceGridscaleSecurityZone_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceSecurityZoneConfig_basic(name string) string {
+func testAccCheckDataSourceSecurityZoneConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas_securityzone" "foo" {
   name = "%s"

--- a/gridscale/datasource_gridscale_server.go
+++ b/gridscale/datasource_gridscale_server.go
@@ -372,7 +372,7 @@ func dataSourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	//Get storages
-	storages := make([]interface{}, 0)
+	/*storages := make([]interface{}, 0)
 	for _, value := range server.Properties.Relations.Storages {
 		storage := map[string]interface{}{
 			"object_uuid":        value.ObjectUUID,
@@ -389,7 +389,7 @@ func dataSourceGridscaleServerRead(d *schema.ResourceData, meta interface{}) err
 			"capacity":           value.Capacity,
 		}
 		storages = append(storages, storage)
-	}
+	}*/
 
 	// Get hardware_profile_config
 	hardwareProfileConfigList := make([]interface{}, 0)

--- a/gridscale/datasource_gridscale_server_test.go
+++ b/gridscale/datasource_gridscale_server_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleServer_basic(t *testing.T) {
+func TestAccdataSourceGridscaleServerBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccdataSourceGridscaleServer_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceServerConfig_basic(name),
+				Config: testAccCheckDataSourceServerConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_server.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_server.foo", "name", name),
@@ -29,7 +29,7 @@ func TestAccdataSourceGridscaleServer_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceServerConfig_basic(name string) string {
+func testAccCheckDataSourceServerConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_server" "foo" {
   name   = "%s"

--- a/gridscale/datasource_gridscale_snapshot_test.go
+++ b/gridscale/datasource_gridscale_snapshot_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleSnapshot_basic(t *testing.T) {
+func TestAccdataSourceGridscaleSnapshotBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleSnapshot_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceSnapshotConfig_basic(name),
+				Config: testAccCheckDataSourceSnapshotConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_snapshot.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_snapshot.foo", "name", name),
@@ -28,7 +28,7 @@ func TestAccdataSourceGridscaleSnapshot_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceSnapshotConfig_basic(name string) string {
+func testAccCheckDataSourceSnapshotConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "storage"

--- a/gridscale/datasource_gridscale_snapshotschedule_test.go
+++ b/gridscale/datasource_gridscale_snapshotschedule_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleSnapshotSchedule_basic(t *testing.T) {
+func TestAccdataSourceGridscaleSnapshotScheduleBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -18,7 +18,7 @@ func TestAccdataSourceGridscaleSnapshotSchedule_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceSnapshotScheduleConfig_basic(name),
+				Config: testAccCheckDataSourceSnapshotScheduleConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_snapshotschedule.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_snapshotschedule.foo", "name", name),
@@ -29,7 +29,7 @@ func TestAccdataSourceGridscaleSnapshotSchedule_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceSnapshotScheduleConfig_basic(name string) string {
+func testAccCheckDataSourceSnapshotScheduleConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_storage" "foo" {

--- a/gridscale/datasource_gridscale_sshkey_test.go
+++ b/gridscale/datasource_gridscale_sshkey_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleSSHKey_basic(t *testing.T) {
+func TestAccdataSourceGridscaleSSHKeyBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleSSHKey_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceSSHKeyConfig_basic(name),
+				Config: testAccCheckDataSourceSSHKeyConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_sshkey.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_sshkey.foo", "name", name),
@@ -28,7 +28,7 @@ func TestAccdataSourceGridscaleSSHKey_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceSSHKeyConfig_basic(name string) string {
+func testAccCheckDataSourceSSHKeyConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_sshkey" "foo" {

--- a/gridscale/datasource_gridscale_sslcert_test.go
+++ b/gridscale/datasource_gridscale_sslcert_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleSSLCert_basic(t *testing.T) {
+func TestAccdataSourceGridscaleSSLCertBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleSSLCert_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceSSLCertConfig_basic(name),
+				Config: testAccCheckDataSourceSSLCertConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_ssl_certificate.foo", "id"),
 					resource.TestCheckResourceAttrSet("data.gridscale_ssl_certificate.foo", "common_name"),
@@ -36,7 +36,7 @@ func TestAccdataSourceGridscaleSSLCert_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceSSLCertConfig_basic(name string) string {
+func testAccCheckDataSourceSSLCertConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_ssl_certificate" "foo" {

--- a/gridscale/datasource_gridscale_storage_test.go
+++ b/gridscale/datasource_gridscale_storage_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccdataSourceGridscaleStorage_basic(t *testing.T) {
+func TestAccdataSourceGridscaleStorageBasic(t *testing.T) {
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -17,7 +17,7 @@ func TestAccdataSourceGridscaleStorage_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceStorageConfig_basic(name),
+				Config: testAccCheckDataSourceStorageConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_storage.foo", "id"),
 					resource.TestCheckResourceAttr("data.gridscale_storage.foo", "name", name),
@@ -29,7 +29,7 @@ func TestAccdataSourceGridscaleStorage_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceStorageConfig_basic(name string) string {
+func testAccCheckDataSourceStorageConfigBasic(name string) string {
 	return fmt.Sprintf(`
 
 resource "gridscale_storage" "foo" {

--- a/gridscale/datasource_gridscale_template_test.go
+++ b/gridscale/datasource_gridscale_template_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccDataSourceTemplate_basic(t *testing.T) {
+func TestAccDataSourceTemplateBasic(t *testing.T) {
 	name := "Ubuntu 22.04 LTS (Jammy Jellyfish) "
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -17,7 +17,7 @@ func TestAccDataSourceTemplate_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 
-				Config: testAccCheckDataSourceGridscaleTemplateConfig_basic(name),
+				Config: testAccCheckDataSourceGridscaleTemplateConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.gridscale_template.foo", "id"),
 				),
@@ -27,7 +27,7 @@ func TestAccDataSourceTemplate_basic(t *testing.T) {
 
 }
 
-func testAccCheckDataSourceGridscaleTemplateConfig_basic(name string) string {
+func testAccCheckDataSourceGridscaleTemplateConfigBasic(name string) string {
 	return fmt.Sprintf(`
 data "gridscale_template" "foo" {
 	name   = "%s"

--- a/gridscale/provider_test.go
+++ b/gridscale/provider_test.go
@@ -24,7 +24,7 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-func TestProvider_impl(t *testing.T) {
+func TestProviderInitialization(t *testing.T) {
 	var _ *schema.Provider = Provider()
 }
 
@@ -38,7 +38,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
-func Test_convertStrToHeaderMap(t *testing.T) {
+func TestConvertStrToHeaderMap(t *testing.T) {
 	type testCase struct {
 		InputStr       string
 		ExpectedOutput map[string]string

--- a/gridscale/resource_gridscale_backup_schedule_test.go
+++ b/gridscale/resource_gridscale_backup_schedule_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleBackupSchedule_Basic(t *testing.T) {
+func TestAccResourceGridscaleBackupScheduleBasic(t *testing.T) {
 	var object gsclient.StorageBackupSchedule
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleBackupSchedule_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDataSourceGridscaleBackupScheduleDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleBackupScheduleConfig_basic(name),
+				Config: testAccCheckDataSourceGridscaleBackupScheduleConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleBackupScheduleExists("gridscale_backupschedule.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleBackupSchedule_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleBackupScheduleConfig_basic_update(),
+				Config: testAccCheckDataSourceGridscaleBackupScheduleConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleBackupScheduleExists("gridscale_backupschedule.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -38,7 +38,7 @@ func TestAccResourceGridscaleBackupSchedule_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleBackupScheduleConfig_forcenew_update(),
+				Config: testAccCheckDataSourceGridscaleBackupScheduleConfigForceNewUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleBackupScheduleExists("gridscale_backupschedule.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -96,7 +96,7 @@ func testAccCheckDataSourceGridscaleBackupScheduleDestroyCheck(s *terraform.Stat
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleBackupScheduleConfig_basic(name string) string {
+func testAccCheckDataSourceGridscaleBackupScheduleConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "storage"
@@ -113,7 +113,7 @@ resource "gridscale_backupschedule" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleBackupScheduleConfig_basic_update() string {
+func testAccCheckDataSourceGridscaleBackupScheduleConfigBasicUpdate() string {
 	return `
 resource "gridscale_storage" "foo" {
   name   = "storage"
@@ -130,7 +130,7 @@ resource "gridscale_backupschedule" "foo" {
 `
 }
 
-func testAccCheckDataSourceGridscaleBackupScheduleConfig_forcenew_update() string {
+func testAccCheckDataSourceGridscaleBackupScheduleConfigForceNewUpdate() string {
 	return `
 resource "gridscale_storage" "new" {
   name   = "storage"

--- a/gridscale/resource_gridscale_backup_schedule_test.go
+++ b/gridscale/resource_gridscale_backup_schedule_test.go
@@ -114,7 +114,7 @@ resource "gridscale_backupschedule" "foo" {
 }
 
 func testAccCheckDataSourceGridscaleBackupScheduleConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "foo" {
   name   = "storage"
   capacity = 1
@@ -127,11 +127,11 @@ resource "gridscale_backupschedule" "foo" {
   next_runtime = "2030-12-30 15:04:05"
   active = true
 }
-`)
+`
 }
 
 func testAccCheckDataSourceGridscaleBackupScheduleConfig_forcenew_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "new" {
   name   = "storage"
   capacity = 1
@@ -144,5 +144,5 @@ resource "gridscale_backupschedule" "foo" {
   next_runtime = "2030-12-30 15:04:05"
   active = true
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_bucket_test.go
+++ b/gridscale/resource_gridscale_bucket_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccResourceGridscaleBucket_Basic(t *testing.T) {
+func TestAccResourceGridscaleBucketBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleBucketConfig_basic(),
+				Config: testAccCheckResourceGridscaleBucketConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(
 						"gridscale_object_storage_bucket.foo", "access_key"),
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleBucket_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleBucketConfig_basic() string {
+func testAccCheckResourceGridscaleBucketConfigBasic() string {
 	return `
 resource "gridscale_object_storage_accesskey" "test" {
    timeouts {

--- a/gridscale/resource_gridscale_bucket_test.go
+++ b/gridscale/resource_gridscale_bucket_test.go
@@ -1,7 +1,6 @@
 package gridscale
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -32,7 +31,7 @@ func TestAccResourceGridscaleBucket_Basic(t *testing.T) {
 }
 
 func testAccCheckResourceGridscaleBucketConfig_basic() string {
-	return fmt.Sprint(`
+	return `
 resource "gridscale_object_storage_accesskey" "test" {
    timeouts {
       create="10m"
@@ -44,5 +43,5 @@ resource "gridscale_object_storage_bucket" "foo" {
    secret_key = gridscale_object_storage_accesskey.test.secret_key
    bucket_name = "myterraformbucket"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_filesystem.go
+++ b/gridscale/resource_gridscale_filesystem.go
@@ -54,7 +54,7 @@ func resourceGridscaleFilesystem() *schema.Resource {
 					}
 				}
 				if !isReleaseValid {
-					return fmt.Errorf("%v is not a valid Filesystem service release. Valid releases are: %v\n", newReleaseVal, strings.Join(releaseList, ", "))
+					return fmt.Errorf("%v is not a valid Filesystem service release. Valid releases are: %v", newReleaseVal, strings.Join(releaseList, ", "))
 				}
 				return nil
 			}),
@@ -427,7 +427,7 @@ func getFilesystemTemplateUUID(client *gsclient.Client, release, performanceClas
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid Filesystem service release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid Filesystem service release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_filesystem_test.go
+++ b/gridscale/resource_gridscale_filesystem_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleFilesystem_Basic(t *testing.T) {
+func TestAccResourceGridscaleFilesystemBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("TEST-Filesystem-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
@@ -19,7 +19,7 @@ func TestAccResourceGridscaleFilesystem_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleFilesystemConfig_basic(name),
+				Config: testAccCheckResourceGridscaleFilesystemConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_filesystem.test", &object),
 					resource.TestCheckResourceAttr(
@@ -33,7 +33,7 @@ func TestAccResourceGridscaleFilesystem_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleFilesystemConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleFilesystemConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_filesystem.test", &object),
 					resource.TestCheckResourceAttr(
@@ -46,7 +46,7 @@ func TestAccResourceGridscaleFilesystem_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleFilesystemConfig_basic(name string) string {
+func testAccCheckResourceGridscaleFilesystemConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_filesystem" "test" {
 	name = "%s"
@@ -58,7 +58,7 @@ resource "gridscale_filesystem" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleFilesystemConfig_basic_update() string {
+func testAccCheckResourceGridscaleFilesystemConfigBasicUpdate() string {
 	return `
 resource "gridscale_filesystem" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_filesystem_test.go
+++ b/gridscale/resource_gridscale_filesystem_test.go
@@ -59,7 +59,7 @@ resource "gridscale_filesystem" "test" {
 }
 
 func testAccCheckResourceGridscaleFilesystemConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_filesystem" "test" {
 	name = "newname"
 	root_squash = false
@@ -68,5 +68,5 @@ resource "gridscale_filesystem" "test" {
 	allowed_ip_ranges = ["192.14.15.15"]
 	labels = ["test"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_firewall_test.go
+++ b/gridscale/resource_gridscale_firewall_test.go
@@ -121,7 +121,7 @@ resource "gridscale_firewall" "foo" {
 }
 
 func testAccCheckResourceGridscaleFirewallConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_firewall" "foo" {
   name   = "newname"
   rules_v4_out {
@@ -139,5 +139,5 @@ resource "gridscale_firewall" "foo" {
 	comment = "testv6"
   }
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_firewall_test.go
+++ b/gridscale/resource_gridscale_firewall_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleFirewall_Basic(t *testing.T) {
+func TestAccResourceGridscaleFirewallBasic(t *testing.T) {
 	var object gsclient.Firewall
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleFirewall_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleFirewallDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleFirewallConfig_basic(name),
+				Config: testAccCheckResourceGridscaleFirewallConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleFirewallExists("gridscale_firewall.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleFirewall_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleFirewallConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleFirewallConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleFirewallExists("gridscale_firewall.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -97,7 +97,7 @@ func testAccCheckGridscaleFirewallDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleFirewallConfig_basic(name string) string {
+func testAccCheckResourceGridscaleFirewallConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_firewall" "foo" {
   name   = "%s"
@@ -120,7 +120,7 @@ resource "gridscale_firewall" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleFirewallConfig_basic_update() string {
+func testAccCheckResourceGridscaleFirewallConfigBasicUpdate() string {
 	return `
 resource "gridscale_firewall" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_ipv4_test.go
+++ b/gridscale/resource_gridscale_ipv4_test.go
@@ -110,11 +110,11 @@ resource "gridscale_ipv4" "foo" {
 }
 
 func testAccCheckResourceGridscaleIpv4Config_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_ipv4" "foo" {
   name   = "newname"
   failover = true
   reverse_dns = "test.test"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_ipv4_test.go
+++ b/gridscale/resource_gridscale_ipv4_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleIpv4_Basic(t *testing.T) {
+func TestAccResourceGridscaleIpv4Basic(t *testing.T) {
 	var object gsclient.IP
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleIpv4_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleIpv4DestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleIpv4Config_basic(name),
+				Config: testAccCheckResourceGridscaleIpv4ConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleIpv4Exists("gridscale_ipv4.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleIpv4_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleIpv4Config_basic_update(),
+				Config: testAccCheckResourceGridscaleIpv4ConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleIpv4Exists("gridscale_ipv4.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -101,7 +101,7 @@ func testAccCheckGridscaleIpv4DestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleIpv4Config_basic(name string) string {
+func testAccCheckResourceGridscaleIpv4ConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
   name   = "%s"
@@ -109,7 +109,7 @@ resource "gridscale_ipv4" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleIpv4Config_basic_update() string {
+func testAccCheckResourceGridscaleIpv4ConfigBasicUpdate() string {
 	return `
 resource "gridscale_ipv4" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_ipv6_test.go
+++ b/gridscale/resource_gridscale_ipv6_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleIpv6_Basic(t *testing.T) {
+func TestAccResourceGridscaleIpv6Basic(t *testing.T) {
 	var object gsclient.IP
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleIpv6_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleIpv6DestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleIpv6Config_basic(name),
+				Config: testAccCheckResourceGridscaleIpv6ConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleIpv6Exists("gridscale_ipv6.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleIpv6_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleIpv6Config_basic_update(),
+				Config: testAccCheckResourceGridscaleIpv6ConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleIpv6Exists("gridscale_ipv6.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -101,7 +101,7 @@ func testAccCheckGridscaleIpv6DestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleIpv6Config_basic(name string) string {
+func testAccCheckResourceGridscaleIpv6ConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv6" "foo" {
   name   = "%s"
@@ -109,7 +109,7 @@ resource "gridscale_ipv6" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleIpv6Config_basic_update() string {
+func testAccCheckResourceGridscaleIpv6ConfigBasicUpdate() string {
 	return `
 resource "gridscale_ipv6" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_ipv6_test.go
+++ b/gridscale/resource_gridscale_ipv6_test.go
@@ -110,11 +110,11 @@ resource "gridscale_ipv6" "foo" {
 }
 
 func testAccCheckResourceGridscaleIpv6Config_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_ipv6" "foo" {
   name   = "newname"
   failover = true
   reverse_dns = "test.test"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_isoimage_test.go
+++ b/gridscale/resource_gridscale_isoimage_test.go
@@ -114,10 +114,10 @@ resource "gridscale_server" "foo" {
 }
 
 func testAccCheckResourceGridscaleISOImageConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_isoimage" "foo" {
   name   = "newname"
   source_url = "http://tinycorelinux.net/10.x/x86/release/TinyCore-current.iso"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_isoimage_test.go
+++ b/gridscale/resource_gridscale_isoimage_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleISOImage_Basic(t *testing.T) {
+func TestAccResourceGridscaleISOImageBasic(t *testing.T) {
 	var object gsclient.ISOImage
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleISOImage_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleISOImageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleISOImageConfig_basic(name),
+				Config: testAccCheckResourceGridscaleISOImageConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleISOImageExists("gridscale_isoimage.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleISOImage_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleISOImageConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleISOImageConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleISOImageExists("gridscale_isoimage.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -97,7 +97,7 @@ func testAccCheckGridscaleISOImageDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleISOImageConfig_basic(name string) string {
+func testAccCheckResourceGridscaleISOImageConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_isoimage" "foo" {
   name   = "%s"
@@ -113,7 +113,7 @@ resource "gridscale_server" "foo" {
 `, name, name)
 }
 
-func testAccCheckResourceGridscaleISOImageConfig_basic_update() string {
+func testAccCheckResourceGridscaleISOImageConfigBasicUpdate() string {
 	return `
 resource "gridscale_isoimage" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -39,10 +39,10 @@ func resourceGridscaleK8s() *schema.Resource {
 			newVersionValInf, isVersionSet := d.GetOk("gsk_version")
 			newVersionVal := newVersionValInf.(string)
 			if !isReleaseSet && !isVersionSet {
-				return errors.New("either \"release\" or \"gsk_version\" has to be defined.")
+				return errors.New("either \"release\" or \"gsk_version\" has to be defined")
 			}
 			if isReleaseSet && isVersionSet {
-				return errors.New("\"release\" and \"gsk_version\" cannot be set at the same time. Only one of them is set at a time.")
+				return errors.New("\"release\" and \"gsk_version\" cannot be set at the same time. Only one of them is set at a time")
 			}
 
 			paasTemplates, err := client.GetPaaSTemplateList(ctx)
@@ -78,10 +78,10 @@ func resourceGridscaleK8s() *schema.Resource {
 				}
 			}
 			if !isReleaseValid && isReleaseSet {
-				return fmt.Errorf("%v is an INVALID Kubernetes minor release. Valid releases are: %v\n", newReleaseVal, strings.Join(releaseList, ", "))
+				return fmt.Errorf("%v is an INVALID Kubernetes minor release. Valid releases are: %v", newReleaseVal, strings.Join(releaseList, ", "))
 			}
 			if !isVersionValid && isVersionSet {
-				return fmt.Errorf("%v is an INVALID gridscale Kubernetes (GSK) version. Valid GSK versions are: %v\n", newVersionVal, strings.Join(versionList, ", "))
+				return fmt.Errorf("%v is an INVALID gridscale Kubernetes (GSK) version. Valid GSK versions are: %v", newVersionVal, strings.Join(versionList, ", "))
 			}
 			return validateK8sParameters(d, chosenTemplate)
 		},
@@ -551,7 +551,7 @@ func getK8sTemplateUUIDFromRelease(client *gsclient.Client, release string) (str
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is an INVALID Kubernetes minor release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is an INVALID Kubernetes minor release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil
@@ -577,7 +577,7 @@ func getK8sTemplateUUIDFromGSKVersion(client *gsclient.Client, version string) (
 		}
 	}
 	if !isVersionValid {
-		return "", fmt.Errorf("%v is an INVALID gridscale Kubernetes (GSK) version. Valid GSK versions are: %v\n", version, strings.Join(versions, ", "))
+		return "", fmt.Errorf("%v is an INVALID gridscale Kubernetes (GSK) version. Valid GSK versions are: %v", version, strings.Join(versions, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil
@@ -671,7 +671,7 @@ func validateK8sParameters(d *schema.ResourceDiff, template gsclient.PaaSTemplat
 			if cluster_cidr.(string) != "" {
 				_, _, err := net.ParseCIDR(cluster_cidr.(string))
 				if err != nil {
-					errorMessages = append(errorMessages, fmt.Sprintf("Invalid value for PaaS template release. Value must be a valid CIDR.\n"))
+					errorMessages = append(errorMessages, "Invalid value for PaaS template release. Value must be a valid CIDR.\n")
 				}
 			}
 			// if cluster_cidr_template is immutable, return error if it is set during k8s creation

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleK8s_Basic(t *testing.T) {
+func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("k8s-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleK8s_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleK8sConfig_basic(name),
+				Config: testAccCheckResourceGridscaleK8sConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleK8s_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleK8sConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleK8sConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleK8s_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleK8sConfig_basic(name string) string {
+func testAccCheckResourceGridscaleK8sConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_k8s" "foopaas" {
 	name   = "%s"
@@ -57,7 +57,7 @@ resource "gridscale_k8s" "foopaas" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleK8sConfig_basic_update() string {
+func testAccCheckResourceGridscaleK8sConfigBasicUpdate() string {
 	return `
 resource "gridscale_k8s" "foopaas" {
 	name   = "newname"

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -58,7 +58,7 @@ resource "gridscale_k8s" "foopaas" {
 }
 
 func testAccCheckResourceGridscaleK8sConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_k8s" "foopaas" {
 	name   = "newname"
 	release = "1.26"
@@ -72,5 +72,5 @@ resource "gridscale_k8s" "foopaas" {
 		rocket_storage = 90
 	}
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_loadbalancer.go
+++ b/gridscale/resource_gridscale_loadbalancer.go
@@ -321,32 +321,34 @@ func expandLoadbalancerForwardingRules(forwardingRules interface{}) []gsclient.F
 func flattenLoadbalancerForwardingRules(forwardingRules []gsclient.ForwardingRule) []interface{} {
 	tempForwardingRules := make([]interface{}, 0)
 
-	if forwardingRules != nil {
-		for _, value := range forwardingRules {
-			forwardingRule := map[string]interface{}{
-				"letsencrypt_ssl":  value.LetsencryptSSL,
-				"certificate_uuid": value.CertificateUUID,
-				"listen_port":      value.ListenPort,
-				"mode":             value.Mode,
-				"target_port":      value.TargetPort,
-			}
-			tempForwardingRules = append(tempForwardingRules, forwardingRule)
+	if forwardingRules == nil {
+		return tempForwardingRules
+	}
+	for _, value := range forwardingRules {
+		forwardingRule := map[string]interface{}{
+			"letsencrypt_ssl":  value.LetsencryptSSL,
+			"certificate_uuid": value.CertificateUUID,
+			"listen_port":      value.ListenPort,
+			"mode":             value.Mode,
+			"target_port":      value.TargetPort,
 		}
+		tempForwardingRules = append(tempForwardingRules, forwardingRule)
 	}
 	return tempForwardingRules
 }
 
 func flattenLoadbalancerBackendServers(backendServers []gsclient.BackendServer) []interface{} {
 	tempBackendServers := make([]interface{}, 0)
-	if backendServers != nil {
-		for _, value := range backendServers {
-			backendServer := map[string]interface{}{
-				"weight":         value.Weight,
-				"host":           value.Host,
-				"proxy_protocol": value.ProxyProtocol,
-			}
-			tempBackendServers = append(tempBackendServers, backendServer)
+	if backendServers == nil {
+		return tempBackendServers
+	}
+	for _, value := range backendServers {
+		backendServer := map[string]interface{}{
+			"weight":         value.Weight,
+			"host":           value.Host,
+			"proxy_protocol": value.ProxyProtocol,
 		}
+		tempBackendServers = append(tempBackendServers, backendServer)
 	}
 	return tempBackendServers
 }

--- a/gridscale/resource_gridscale_loadbalancer_test.go
+++ b/gridscale/resource_gridscale_loadbalancer_test.go
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleLoadBalancerBasic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleLoadBalancerDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleLoadBalancerConfig_basic(name, "leastconn"),
+				Config: testAccCheckResourceGridscaleLoadBalancerConfigBasic(name, "leastconn"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleLoadBalancerExists("gridscale_loadbalancer.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -34,7 +34,7 @@ func TestAccResourceGridscaleLoadBalancerBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleLoadBalancerConfig_update("newname", "roundrobin"),
+				Config: testAccCheckResourceGridscaleLoadBalancerConfigUpdate("newname", "roundrobin"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleLoadBalancerExists("gridscale_loadbalancer.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -79,7 +79,7 @@ func testAccCheckResourceGridscaleLoadBalancerExists(n string, object *gsclient.
 	}
 }
 
-func testAccCheckResourceGridscaleLoadBalancerConfig_basic(name string, algorithm string) string {
+func testAccCheckResourceGridscaleLoadBalancerConfigBasic(name string, algorithm string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "lb" {
 	name   = "ipv4-%s"
@@ -111,7 +111,7 @@ resource "gridscale_loadbalancer" "foo" {
 }`, name, name, name, name, algorithm)
 }
 
-func testAccCheckResourceGridscaleLoadBalancerConfig_update(name string, algorithm string) string {
+func testAccCheckResourceGridscaleLoadBalancerConfigUpdate(name string, algorithm string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "lb" {
 	name   = "ipv4-%s"

--- a/gridscale/resource_gridscale_mariadb.go
+++ b/gridscale/resource_gridscale_mariadb.go
@@ -524,7 +524,7 @@ func getMariaDBTemplateUUID(client *gsclient.Client, release, performanceClass s
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid MariaDB release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid MariaDB release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_mariadb_test.go
+++ b/gridscale/resource_gridscale_mariadb_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleMariaDB_Basic(t *testing.T) {
+func TestAccResourceGridscaleMariaDBBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("postgres-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleMariaDB_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleMariaDBConfig_basic(name),
+				Config: testAccCheckResourceGridscaleMariaDBConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_mariadb.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleMariaDB_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleMariaDBConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleMariaDBConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_mariadb.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleMariaDB_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleMariaDBConfig_basic(name string) string {
+func testAccCheckResourceGridscaleMariaDBConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_mariadb" "test" {
 	name = "%s"
@@ -49,7 +49,7 @@ resource "gridscale_mariadb" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleMariaDBConfig_basic_update() string {
+func testAccCheckResourceGridscaleMariaDBConfigBasicUpdate() string {
 	return `
 resource "gridscale_mariadb" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_mariadb_test.go
+++ b/gridscale/resource_gridscale_mariadb_test.go
@@ -50,7 +50,7 @@ resource "gridscale_mariadb" "test" {
 }
 
 func testAccCheckResourceGridscaleMariaDBConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_mariadb" "test" {
 	name = "newname"
 	release = "10.5"
@@ -63,5 +63,5 @@ resource "gridscale_mariadb" "test" {
 	mariadb_server_id = 2
 	mariadb_binlog_format = "STATEMENT"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_marketplace_app.go
+++ b/gridscale/resource_gridscale_marketplace_app.go
@@ -314,8 +314,7 @@ func resourceGridscaleMarketplaceApplicationRead(d *schema.ResourceData, meta in
 
 func resourceGridscaleMarketplaceApplicationCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
-	var publish bool
-	publish = d.Get("publish").(bool)
+	publish := d.Get("publish").(bool)
 	requestBody := gsclient.MarketplaceApplicationCreateRequest{
 		Name:              d.Get("name").(string),
 		ObjectStoragePath: d.Get("object_storage_path").(string),
@@ -370,9 +369,7 @@ func resourceGridscaleMarketplaceApplicationCreate(d *schema.ResourceData, meta 
 func resourceGridscaleMarketplaceApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gsclient.Client)
 	errorPrefix := fmt.Sprintf("update marketplace application (%s) resource -", d.Id())
-
-	var publish bool
-	publish = d.Get("publish").(bool)
+	publish := d.Get("publish").(bool)
 	requestBody := gsclient.MarketplaceApplicationUpdateRequest{
 		Name:              d.Get("name").(string),
 		ObjectStoragePath: d.Get("object_storage_path").(string),

--- a/gridscale/resource_gridscale_marketplace_app_import_test.go
+++ b/gridscale/resource_gridscale_marketplace_app_import_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleMarketplaceApplicationImport_Basic(t *testing.T) {
+func TestAccResourceGridscaleMarketplaceApplicationImportBasic(t *testing.T) {
 	var object gsclient.MarketplaceApplication
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleMarketplaceApplicationImport_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleMarketplaceApplicationImportDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleMarketplaceApplicationImportConfig_basic(name),
+				Config: testAccCheckResourceGridscaleMarketplaceApplicationImportConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleMarketplaceApplicationImportExists("gridscale_marketplace_application_import.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleMarketplaceApplicationImport_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleMarketplaceApplicationImportConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleMarketplaceApplicationImportConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleMarketplaceApplicationImportExists("gridscale_marketplace_application_import.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -97,7 +97,7 @@ func testAccCheckGridscaleMarketplaceApplicationImportDestroyCheck(s *terraform.
 	return nil
 }
 
-func testAccCheckResourceGridscaleMarketplaceApplicationImportConfig_basic(name string) string {
+func testAccCheckResourceGridscaleMarketplaceApplicationImportConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_marketplace_application" "foo" {
 	name = "%s"
@@ -114,7 +114,7 @@ resource "gridscale_marketplace_application_import" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleMarketplaceApplicationImportConfig_basic_update() string {
+func testAccCheckResourceGridscaleMarketplaceApplicationImportConfigBasicUpdate() string {
 	return `
 resource "gridscale_marketplace_application" "foonew" {
   	name   = "newname"

--- a/gridscale/resource_gridscale_marketplace_app_import_test.go
+++ b/gridscale/resource_gridscale_marketplace_app_import_test.go
@@ -115,7 +115,7 @@ resource "gridscale_marketplace_application_import" "foo" {
 }
 
 func testAccCheckResourceGridscaleMarketplaceApplicationImportConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_marketplace_application" "foonew" {
   	name   = "newname"
 	object_storage_path = "s3://testsnapshot/test.gz"
@@ -127,5 +127,5 @@ resource "gridscale_marketplace_application" "foonew" {
 resource "gridscale_marketplace_application_import" "foo" {
 	import_unique_hash = gridscale_marketplace_application.foonew.unique_hash
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_marketplace_app_test.go
+++ b/gridscale/resource_gridscale_marketplace_app_test.go
@@ -112,7 +112,7 @@ resource "gridscale_marketplace_application" "foo" {
 }
 
 func testAccCheckResourceGridscaleMarketplaceApplicationConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_marketplace_application" "foo" {
   	name   = "newname"
 	object_storage_path = "s3://testsnapshot/test.gz"
@@ -122,5 +122,5 @@ resource "gridscale_marketplace_application" "foo" {
 	setup_storage_capacity = 5
 	meta_components = ["test_component", "test_component1"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_marketplace_app_test.go
+++ b/gridscale/resource_gridscale_marketplace_app_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleMarketplaceApplication_Basic(t *testing.T) {
+func TestAccResourceGridscaleMarketplaceApplicationBasic(t *testing.T) {
 	var object gsclient.MarketplaceApplication
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleMarketplaceApplication_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleMarketplaceApplicationDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleMarketplaceApplicationConfig_basic(name),
+				Config: testAccCheckResourceGridscaleMarketplaceApplicationConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleMarketplaceApplicationExists("gridscale_marketplace_application.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleMarketplaceApplication_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleMarketplaceApplicationConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleMarketplaceApplicationConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleMarketplaceApplicationExists("gridscale_marketplace_application.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -97,7 +97,7 @@ func testAccCheckGridscaleMarketplaceApplicationDestroyCheck(s *terraform.State)
 	return nil
 }
 
-func testAccCheckResourceGridscaleMarketplaceApplicationConfig_basic(name string) string {
+func testAccCheckResourceGridscaleMarketplaceApplicationConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_marketplace_application" "foo" {
 	name = "%s"
@@ -111,7 +111,7 @@ resource "gridscale_marketplace_application" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleMarketplaceApplicationConfig_basic_update() string {
+func testAccCheckResourceGridscaleMarketplaceApplicationConfigBasicUpdate() string {
 	return `
 resource "gridscale_marketplace_application" "foo" {
   	name   = "newname"

--- a/gridscale/resource_gridscale_memcached.go
+++ b/gridscale/resource_gridscale_memcached.go
@@ -407,7 +407,7 @@ func getMemcachedTemplateUUID(client *gsclient.Client, release, performanceClass
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid Memcached release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid Memcached release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_mysql.go
+++ b/gridscale/resource_gridscale_mysql.go
@@ -524,7 +524,7 @@ func getMySQLTemplateUUID(client *gsclient.Client, release, performanceClass str
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid MySQL release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid MySQL release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_mysql8_0.go
+++ b/gridscale/resource_gridscale_mysql8_0.go
@@ -458,7 +458,7 @@ func getMySQL8_0TemplateUUID(client *gsclient.Client, release, performanceClass 
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid MySQL release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid MySQL release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_mysql8_0_test.go
+++ b/gridscale/resource_gridscale_mysql8_0_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleMySQL8_0_Basic(t *testing.T) {
+func TestAccResourceGridscaleMySQL8_0Basic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("MySQL-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleMySQL8_0_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleMySQL8_0Config_basic(name),
+				Config: testAccCheckResourceGridscaleMySQL8_0ConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_mysql8_0.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleMySQL8_0_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleMySQL8_0Config_basic_update(),
+				Config: testAccCheckResourceGridscaleMySQL8_0ConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_mysql8_0.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleMySQL8_0_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleMySQL8_0Config_basic(name string) string {
+func testAccCheckResourceGridscaleMySQL8_0ConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_mysql8_0" "test" {
 	name = "%s"
@@ -49,7 +49,7 @@ resource "gridscale_mysql8_0" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleMySQL8_0Config_basic_update() string {
+func testAccCheckResourceGridscaleMySQL8_0ConfigBasicUpdate() string {
 	return `
 resource "gridscale_mysql8_0" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_mysql8_0_test.go
+++ b/gridscale/resource_gridscale_mysql8_0_test.go
@@ -50,7 +50,7 @@ resource "gridscale_mysql8_0" "test" {
 }
 
 func testAccCheckResourceGridscaleMySQL8_0Config_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_mysql8_0" "test" {
 	name = "newname"
 	release = "8.0"
@@ -59,5 +59,5 @@ resource "gridscale_mysql8_0" "test" {
 	mysql_max_connections = 2000
 	labels = ["test"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_mysql_test.go
+++ b/gridscale/resource_gridscale_mysql_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleMySQL_Basic(t *testing.T) {
+func TestAccResourceGridscaleMySQLBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("MySQL-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleMySQL_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleMySQLConfig_basic(name),
+				Config: testAccCheckResourceGridscaleMySQLConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_mysql.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleMySQL_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleMySQLConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleMySQLConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_mysql.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleMySQL_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleMySQLConfig_basic(name string) string {
+func testAccCheckResourceGridscaleMySQLConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_mysql" "test" {
 	name = "%s"
@@ -49,7 +49,7 @@ resource "gridscale_mysql" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleMySQLConfig_basic_update() string {
+func testAccCheckResourceGridscaleMySQLConfigBasicUpdate() string {
 	return `
 resource "gridscale_mysql" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_mysql_test.go
+++ b/gridscale/resource_gridscale_mysql_test.go
@@ -50,7 +50,7 @@ resource "gridscale_mysql" "test" {
 }
 
 func testAccCheckResourceGridscaleMySQLConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_mysql" "test" {
 	name = "newname"
 	release = "5.7"
@@ -59,5 +59,5 @@ resource "gridscale_mysql" "test" {
 	mysql_max_connections = 2000
 	labels = ["test"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_network_test.go
+++ b/gridscale/resource_gridscale_network_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleNetwork_Basic(t *testing.T) {
+func TestAccResourceGridscaleNetworkBasic(t *testing.T) {
 	var object gsclient.Network
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleNetwork_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleNetworkDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleNetworkConfig_basic(name),
+				Config: testAccCheckResourceGridscaleNetworkConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleNetworkExists("gridscale_network.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -38,7 +38,7 @@ func TestAccResourceGridscaleNetwork_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleNetworkConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleNetworkConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleNetworkExists("gridscale_network.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -115,7 +115,7 @@ func testAccCheckGridscaleNetworkDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleNetworkConfig_basic(name string) string {
+func testAccCheckResourceGridscaleNetworkConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_network" "foo" {
   name   = "%s"
@@ -128,7 +128,7 @@ resource "gridscale_network" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleNetworkConfig_basic_update() string {
+func testAccCheckResourceGridscaleNetworkConfigBasicUpdate() string {
 	return `
 resource "gridscale_network" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_network_test.go
+++ b/gridscale/resource_gridscale_network_test.go
@@ -129,7 +129,7 @@ resource "gridscale_network" "foo" {
 }
 
 func testAccCheckResourceGridscaleNetworkConfig_basic_update() string {
-	return fmt.Sprint(`
+	return `
 resource "gridscale_network" "foo" {
   name   = "newname"
   l2security = true
@@ -139,5 +139,5 @@ resource "gridscale_network" "foo" {
   dhcp_range = "192.168.122.0/27"
   dhcp_reserved_subnet = ["192.168.122.0/31"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_objectstorage_test.go
+++ b/gridscale/resource_gridscale_objectstorage_test.go
@@ -89,8 +89,8 @@ func testAccCheckGridscaleObjectStorageDestroyCheck(s *terraform.State) error {
 }
 
 func testAccCheckResourceGridscaleObjectStorageConfig_basic() string {
-	return fmt.Sprint(`
+	return `
 resource "gridscale_object_storage_accesskey" "foo" {
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_objectstorage_test.go
+++ b/gridscale/resource_gridscale_objectstorage_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleObjectStorage_Basic(t *testing.T) {
+func TestAccResourceGridscaleObjectStorageBasic(t *testing.T) {
 	var object gsclient.ObjectStorageAccessKey
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,7 +19,7 @@ func TestAccResourceGridscaleObjectStorage_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleObjectStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleObjectStorageConfig_basic(),
+				Config: testAccCheckResourceGridscaleObjectStorageConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleObjectStorageExists("gridscale_object_storage_accesskey.foo", &object),
 					resource.TestCheckResourceAttrSet(
@@ -88,7 +88,7 @@ func testAccCheckGridscaleObjectStorageDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleObjectStorageConfig_basic() string {
+func testAccCheckResourceGridscaleObjectStorageConfigBasic() string {
 	return `
 resource "gridscale_object_storage_accesskey" "foo" {
 }

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -209,7 +209,7 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err = d.Set("name", props.Name); err != nil {
 		return fmt.Errorf("%s error setting name: %v", errorPrefix, err)
 	}
-	if creds != nil && len(creds) > 0 {
+	if len(creds) > 0 {
 		if err = d.Set("username", creds[0].Username); err != nil {
 			return fmt.Errorf("%s error setting username: %v", errorPrefix, err)
 		}
@@ -272,6 +272,10 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}
 		valueInString, err := convInterfaceToString(paramValType, value)
+
+		if err != nil {
+			return err
+		}
 		param := map[string]interface{}{
 			"param": k,
 			"value": valueInString,

--- a/gridscale/resource_gridscale_paas_test.go
+++ b/gridscale/resource_gridscale_paas_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscalePaaS_Basic(t *testing.T) {
+func TestAccResourceGridscalePaaSBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscalePaaS_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscalePaaSConfig_basic(name),
+				Config: testAccCheckResourceGridscalePaaSConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_paas.foopaas", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscalePaaS_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscalePaaSConfig_basic_update(),
+				Config: testAccCheckResourceGridscalePaaSConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_paas.foopaas", &object),
 					resource.TestCheckResourceAttr(
@@ -38,7 +38,7 @@ func TestAccResourceGridscalePaaS_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscalePaaSConfig_tmp_update(),
+				Config: testAccCheckResourceGridscalePaaSConfigTMPUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_paas.foopaas", &object),
 					resource.TestCheckResourceAttr(
@@ -95,7 +95,7 @@ func testAccCheckResourceGridscalePaaSDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscalePaaSConfig_basic(name string) string {
+func testAccCheckResourceGridscalePaaSConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas" "foopaas" {
   name = "%s"
@@ -104,7 +104,7 @@ resource "gridscale_paas" "foopaas" {
 `, name)
 }
 
-func testAccCheckResourceGridscalePaaSConfig_basic_update() string {
+func testAccCheckResourceGridscalePaaSConfigBasicUpdate() string {
 	return `
 resource "gridscale_paas" "foopaas" {
   name = "newname"
@@ -129,7 +129,7 @@ resource "gridscale_paas" "foopaas" {
 
 // TO DO: update `service_template_uuid` when the backend enables the option to
 // update `service_template_uuid`.
-func testAccCheckResourceGridscalePaaSConfig_tmp_update() string {
+func testAccCheckResourceGridscalePaaSConfigTMPUpdate() string {
 	return `
 resource "gridscale_paas" "foopaas" {
   name = "newname"

--- a/gridscale/resource_gridscale_paas_test.go
+++ b/gridscale/resource_gridscale_paas_test.go
@@ -105,7 +105,7 @@ resource "gridscale_paas" "foopaas" {
 }
 
 func testAccCheckResourceGridscalePaaSConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_paas" "foopaas" {
   name = "newname"
   service_template_uuid = "d7a5e8ec-fa78-4d1b-86f9-febe3e16e398"
@@ -124,13 +124,13 @@ resource "gridscale_paas" "foopaas" {
     type = "string"
   }
 }
-`)
+`
 }
 
 // TO DO: update `service_template_uuid` when the backend enables the option to
 // update `service_template_uuid`.
 func testAccCheckResourceGridscalePaaSConfig_tmp_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_paas" "foopaas" {
   name = "newname"
   service_template_uuid = "d7a5e8ec-fa78-4d1b-86f9-febe3e16e398"
@@ -149,5 +149,5 @@ resource "gridscale_paas" "foopaas" {
     type = "string"
   }
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_postgresql.go
+++ b/gridscale/resource_gridscale_postgresql.go
@@ -20,11 +20,6 @@ import (
 
 const postgresTemplateFlavourName = "postgres"
 
-const (
-	postgresReleaseValidationOpt = iota
-	postgresMaxCoreCountValidationOpt
-)
-
 func resourceGridscalePostgreSQL() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGridscalePostgreSQLCreate,
@@ -191,7 +186,7 @@ func resourceGridscalePostgreSQL() *schema.Resource {
 				Computed:    true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					if 1 > v.(int) || v.(int) > 32 {
-						errors = append(errors, fmt.Errorf("%v is not a valid value for number of \"max_core_count\". Valid value should be between 1 and 32\n", v.(int)))
+						errors = append(errors, fmt.Errorf("%v is not a valid value for number of \"max_core_count\". Valid value should be between 1 and 32", v.(int)))
 					}
 					return
 				},
@@ -495,7 +490,7 @@ func getPostgresTemplateUUID(client *gsclient.Client, release, performanceClass 
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid PostgreSQL release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid PostgreSQL release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_postgresql_test.go
+++ b/gridscale/resource_gridscale_postgresql_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscalePostgres_Basic(t *testing.T) {
+func TestAccResourceGridscalePostgresBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("postgres-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscalePostgres_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscalePostgresConfig_basic(name),
+				Config: testAccCheckResourceGridscalePostgresConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_postgresql.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscalePostgres_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscalePostgresConfig_basic_update(),
+				Config: testAccCheckResourceGridscalePostgresConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_postgresql.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscalePostgres_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscalePostgresConfig_basic(name string) string {
+func testAccCheckResourceGridscalePostgresConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_postgresql" "test" {
 	name = "%s"
@@ -54,7 +54,7 @@ resource "gridscale_postgresql" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscalePostgresConfig_basic_update() string {
+func testAccCheckResourceGridscalePostgresConfigBasicUpdate() string {
 	return `
 resource "gridscale_postgresql" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_postgresql_test.go
+++ b/gridscale/resource_gridscale_postgresql_test.go
@@ -55,7 +55,7 @@ resource "gridscale_postgresql" "test" {
 }
 
 func testAccCheckResourceGridscalePostgresConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_postgresql" "test" {
 	name = "newname"
 	release = "13"
@@ -68,5 +68,5 @@ resource "gridscale_postgresql" "test" {
 	pgaudit_log_secret_key = "testing"
 	pgaudit_log_rotation_frequency = 25
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_redis_cache.go
+++ b/gridscale/resource_gridscale_redis_cache.go
@@ -368,7 +368,7 @@ func getRedisCacheTemplateUUID(client *gsclient.Client, release, performanceClas
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid RedisCache release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid RedisCache release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_redis_cache_test.go
+++ b/gridscale/resource_gridscale_redis_cache_test.go
@@ -50,12 +50,12 @@ resource "gridscale_redis_cache" "test" {
 }
 
 func testAccCheckResourceGridscaleRedisCacheConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_redis_cache" "test" {
 	name = "newname"
 	release = "7"
 	performance_class = "standard"
 	labels = ["test"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_redis_cache_test.go
+++ b/gridscale/resource_gridscale_redis_cache_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleRedisCache_Basic(t *testing.T) {
+func TestAccResourceGridscaleRedisCacheBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("redis_cache-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleRedisCache_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleRedisCacheConfig_basic(name),
+				Config: testAccCheckResourceGridscaleRedisCacheConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_redis_cache.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleRedisCache_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleRedisCacheConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleRedisCacheConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_redis_cache.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleRedisCache_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleRedisCacheConfig_basic(name string) string {
+func testAccCheckResourceGridscaleRedisCacheConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_redis_cache" "test" {
 	name = "%s"
@@ -49,7 +49,7 @@ resource "gridscale_redis_cache" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleRedisCacheConfig_basic_update() string {
+func testAccCheckResourceGridscaleRedisCacheConfigBasicUpdate() string {
 	return `
 resource "gridscale_redis_cache" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_redis_store.go
+++ b/gridscale/resource_gridscale_redis_store.go
@@ -368,7 +368,7 @@ func getRedisStoreTemplateUUID(client *gsclient.Client, release, performanceClas
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid RedisStore release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid RedisStore release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_redis_store_test.go
+++ b/gridscale/resource_gridscale_redis_store_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleRedisStore_Basic(t *testing.T) {
+func TestAccResourceGridscaleRedisStoreBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("redis_store-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleRedisStore_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleRedisStoreConfig_basic(name),
+				Config: testAccCheckResourceGridscaleRedisStoreConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_redis_store.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleRedisStore_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleRedisStoreConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleRedisStoreConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_redis_store.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleRedisStore_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleRedisStoreConfig_basic(name string) string {
+func testAccCheckResourceGridscaleRedisStoreConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_redis_store" "test" {
 	name = "%s"
@@ -49,7 +49,7 @@ resource "gridscale_redis_store" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleRedisStoreConfig_basic_update() string {
+func testAccCheckResourceGridscaleRedisStoreConfigBasicUpdate() string {
 	return `
 resource "gridscale_redis_store" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_redis_store_test.go
+++ b/gridscale/resource_gridscale_redis_store_test.go
@@ -50,12 +50,12 @@ resource "gridscale_redis_store" "test" {
 }
 
 func testAccCheckResourceGridscaleRedisStoreConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_redis_store" "test" {
 	name = "newname"
 	release = "7"
 	performance_class = "standard"
 	labels = ["test"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_securityzone_test.go
+++ b/gridscale/resource_gridscale_securityzone_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccDataSourceGridscaleSecurityZone_Basic(t *testing.T) {
+func TestAccDataSourceGridscaleSecurityZoneBasic(t *testing.T) {
 	var object gsclient.PaaSSecurityZone
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccDataSourceGridscaleSecurityZone_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDataSourceGridscaleSecurityZoneDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleSecurityZoneConfig_basic(name),
+				Config: testAccCheckDataSourceGridscaleSecurityZoneConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSecurityZoneExists("gridscale_paas_securityzone.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccDataSourceGridscaleSecurityZone_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleSecurityZoneConfig_basic_update(),
+				Config: testAccCheckDataSourceGridscaleSecurityZoneConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSecurityZoneExists("gridscale_paas_securityzone.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -87,7 +87,7 @@ func testAccCheckDataSourceGridscaleSecurityZoneDestroyCheck(s *terraform.State)
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleSecurityZoneConfig_basic(name string) string {
+func testAccCheckDataSourceGridscaleSecurityZoneConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_paas_securityzone" "foo" {
   name = "%s"
@@ -95,7 +95,7 @@ resource "gridscale_paas_securityzone" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleSecurityZoneConfig_basic_update() string {
+func testAccCheckDataSourceGridscaleSecurityZoneConfigBasicUpdate() string {
 	return `
 resource "gridscale_paas_securityzone" "foo" {
   name = "newname"

--- a/gridscale/resource_gridscale_securityzone_test.go
+++ b/gridscale/resource_gridscale_securityzone_test.go
@@ -96,9 +96,9 @@ resource "gridscale_paas_securityzone" "foo" {
 }
 
 func testAccCheckDataSourceGridscaleSecurityZoneConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_paas_securityzone" "foo" {
   name = "newname"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleServer_Basic(t *testing.T) {
+func TestAccResourceGridscaleServerBasic(t *testing.T) {
 	var object gsclient.Server
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleServer_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscaleServerDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleServerConfig_basic(name),
+				Config: testAccCheckResourceGridscaleServerConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleServerExists("gridscale_server.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -36,7 +36,7 @@ func TestAccResourceGridscaleServer_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleServerConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleServerConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleServerExists("gridscale_server.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -109,7 +109,7 @@ func testAccCheckResourceGridscaleServerDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleServerConfig_basic(name string) string {
+func testAccCheckResourceGridscaleServerConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ipv4" "foo" {
   name   = "ip-%s"
@@ -158,7 +158,7 @@ resource "gridscale_server" "foo" {
 `, name, name, name, name)
 }
 
-func testAccCheckResourceGridscaleServerConfig_basic_update() string {
+func testAccCheckResourceGridscaleServerConfigBasicUpdate() string {
 	return `
 resource "gridscale_ipv4" "foo1" {
   name   = "newname"

--- a/gridscale/resource_gridscale_server_test.go
+++ b/gridscale/resource_gridscale_server_test.go
@@ -159,7 +159,7 @@ resource "gridscale_server" "foo" {
 }
 
 func testAccCheckResourceGridscaleServerConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_ipv4" "foo1" {
   name   = "newname"
 }
@@ -197,5 +197,5 @@ resource "gridscale_server" "foo" {
   	object_uuid = gridscale_storage.foo1.id
   }
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_snapshot_test.go
+++ b/gridscale/resource_gridscale_snapshot_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleSnapshot_Basic(t *testing.T) {
+func TestAccResourceGridscaleSnapshotBasic(t *testing.T) {
 	var object gsclient.StorageSnapshot
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleSnapshot_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDataSourceGridscaleSnapshotDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleSnapshotConfig_basic(name),
+				Config: testAccCheckDataSourceGridscaleSnapshotConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSnapshotExists("gridscale_snapshot.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleSnapshot_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleSnapshotConfig_basic_update(),
+				Config: testAccCheckDataSourceGridscaleSnapshotConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSnapshotExists("gridscale_snapshot.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -38,7 +38,7 @@ func TestAccResourceGridscaleSnapshot_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleSnapshotConfig_forcenew_update(),
+				Config: testAccCheckDataSourceGridscaleSnapshotConfigForceNewUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSnapshotExists("gridscale_snapshot.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -96,7 +96,7 @@ func testAccCheckDataSourceGridscaleSnapshotDestroyCheck(s *terraform.State) err
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleSnapshotConfig_basic(name string) string {
+func testAccCheckDataSourceGridscaleSnapshotConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "storage"
@@ -112,7 +112,7 @@ resource "gridscale_snapshot" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleSnapshotConfig_basic_update() string {
+func testAccCheckDataSourceGridscaleSnapshotConfigBasicUpdate() string {
 	return `
 resource "gridscale_storage" "foo" {
   name   = "storage"
@@ -132,7 +132,7 @@ resource "gridscale_snapshot" "foo" {
 `
 }
 
-func testAccCheckDataSourceGridscaleSnapshotConfig_forcenew_update() string {
+func testAccCheckDataSourceGridscaleSnapshotConfigForceNewUpdate() string {
 	return `
 resource "gridscale_storage" "new" {
   name   = "storage"

--- a/gridscale/resource_gridscale_snapshot_test.go
+++ b/gridscale/resource_gridscale_snapshot_test.go
@@ -113,7 +113,7 @@ resource "gridscale_snapshot" "foo" {
 }
 
 func testAccCheckDataSourceGridscaleSnapshotConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "foo" {
   name   = "storage"
   capacity = 1
@@ -129,11 +129,11 @@ resource "gridscale_snapshot" "foo" {
 	id = "second"
   }
 }
-`)
+`
 }
 
 func testAccCheckDataSourceGridscaleSnapshotConfig_forcenew_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "new" {
   name   = "storage"
   capacity = 1
@@ -142,5 +142,5 @@ resource "gridscale_snapshot" "foo" {
   name = "newname"
   storage_uuid = gridscale_storage.new.id
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_snapshotschedule_test.go
+++ b/gridscale/resource_gridscale_snapshotschedule_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleSnapshotSchedule_Basic(t *testing.T) {
+func TestAccResourceGridscaleSnapshotScheduleBasic(t *testing.T) {
 	var object gsclient.StorageSnapshotSchedule
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleSnapshotSchedule_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDataSourceGridscaleSnapshotScheduleDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic(name),
+				Config: testAccCheckDataSourceGridscaleSnapshotScheduleConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSnapshotScheduleExists("gridscale_snapshotschedule.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleSnapshotSchedule_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic_update(),
+				Config: testAccCheckDataSourceGridscaleSnapshotScheduleConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSnapshotScheduleExists("gridscale_snapshotschedule.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -38,7 +38,7 @@ func TestAccResourceGridscaleSnapshotSchedule_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckDataSourceGridscaleSnapshotScheduleConfig_forcenew_update(),
+				Config: testAccCheckDataSourceGridscaleSnapshotScheduleConfigForceNewUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataSourceGridscaleSnapshotScheduleExists("gridscale_snapshotschedule.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -96,7 +96,7 @@ func testAccCheckDataSourceGridscaleSnapshotScheduleDestroyCheck(s *terraform.St
 	return nil
 }
 
-func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic(name string) string {
+func testAccCheckDataSourceGridscaleSnapshotScheduleConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "storage"
@@ -112,7 +112,7 @@ resource "gridscale_snapshotschedule" "foo" {
 `, name)
 }
 
-func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic_update() string {
+func testAccCheckDataSourceGridscaleSnapshotScheduleConfigBasicUpdate() string {
 	return `
 resource "gridscale_storage" "foo" {
   name   = "storage"
@@ -128,7 +128,7 @@ resource "gridscale_snapshotschedule" "foo" {
 `
 }
 
-func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_forcenew_update() string {
+func testAccCheckDataSourceGridscaleSnapshotScheduleConfigForceNewUpdate() string {
 	return `
 resource "gridscale_storage" "new" {
   name   = "storage"

--- a/gridscale/resource_gridscale_snapshotschedule_test.go
+++ b/gridscale/resource_gridscale_snapshotschedule_test.go
@@ -113,7 +113,7 @@ resource "gridscale_snapshotschedule" "foo" {
 }
 
 func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "foo" {
   name   = "storage"
   capacity = 1
@@ -125,11 +125,11 @@ resource "gridscale_snapshotschedule" "foo" {
   keep_snapshots = 1
   run_interval = 60
 }
-`)
+`
 }
 
 func testAccCheckDataSourceGridscaleSnapshotScheduleConfig_forcenew_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "new" {
   name   = "storage"
   capacity = 1
@@ -140,5 +140,5 @@ resource "gridscale_snapshotschedule" "foo" {
   keep_snapshots = 1
   run_interval = 60
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_sqlserver.go
+++ b/gridscale/resource_gridscale_sqlserver.go
@@ -163,7 +163,7 @@ func resourceGridscaleMSSQLServer() *schema.Resource {
 							Default:  defaultBackupServerURL,
 							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 								if v.(string) != defaultBackupServerURL {
-									errors = append(errors, fmt.Errorf("Currently, only %s is supported", defaultBackupServerURL))
+									errors = append(errors, fmt.Errorf("currently, only %s is supported", defaultBackupServerURL))
 								}
 								return
 							},
@@ -466,7 +466,7 @@ func getMSSQLTemplateUUID(client *gsclient.Client, release, performanceClass str
 		}
 	}
 	if !isReleaseValid {
-		return "", fmt.Errorf("%v is not a valid MS SQL Server release. Valid releases are: %v\n", release, strings.Join(releases, ", "))
+		return "", fmt.Errorf("%v is not a valid MS SQL Server release. Valid releases are: %v", release, strings.Join(releases, ", "))
 	}
 
 	return uTemplate.Properties.ObjectUUID, nil

--- a/gridscale/resource_gridscale_sqlserver_test.go
+++ b/gridscale/resource_gridscale_sqlserver_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
+func TestAccResourceGridscaleMSSQLServerBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("MSSQLServer-%s", acctest.RandString(10))
 
@@ -20,7 +20,7 @@ func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceGridscalePaaSDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleMSSQLServerConfig_basic(name),
+				Config: testAccCheckResourceGridscaleMSSQLServerConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_sqlserver.test", &object),
 					resource.TestCheckResourceAttr(
@@ -28,7 +28,7 @@ func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleMSSQLServerConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleMSSQLServerConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_sqlserver.test", &object),
 					resource.TestCheckResourceAttr(
@@ -39,7 +39,7 @@ func TestAccResourceGridscaleMSSQLServer_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceGridscaleMSSQLServerConfig_basic(name string) string {
+func testAccCheckResourceGridscaleMSSQLServerConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sqlserver" "test" {
 	name = "%s"
@@ -49,7 +49,7 @@ resource "gridscale_sqlserver" "test" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleMSSQLServerConfig_basic_update() string {
+func testAccCheckResourceGridscaleMSSQLServerConfigBasicUpdate() string {
 	return `
 resource "gridscale_sqlserver" "test" {
 	name = "newname"

--- a/gridscale/resource_gridscale_sqlserver_test.go
+++ b/gridscale/resource_gridscale_sqlserver_test.go
@@ -50,12 +50,12 @@ resource "gridscale_sqlserver" "test" {
 }
 
 func testAccCheckResourceGridscaleMSSQLServerConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_sqlserver" "test" {
 	name = "newname"
 	release = "2019"
 	performance_class = "standard"
 	labels = ["test"]
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_sshkey_test.go
+++ b/gridscale/resource_gridscale_sshkey_test.go
@@ -111,10 +111,10 @@ resource "gridscale_sshkey" "foo" {
 }
 
 func testAccCheckResourceGridscaleSshkeyConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_sshkey" "foo" {
   name   = "newname"
   sshkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvOYJ3xXtPXaPOacFQ97+nGq5QDkl17/JeTaY36RLPKgYBt2Z5YSPSROdzh/5GgZ0p6E3W84gKNaedUo3v+zvgmdGZeDFk+cxlC0HtXwQN87GQRtYTMsucbI6OJT7p4qntl70MIBzvIrmheGZqXnpeRxA7PjVcjkA3nxps3XJsuMDd0Ft0Ue3j0lmOno779mfgg34VeTgE2GZlH31gFqxWz3fXUgaZoLdO7HbLKu4ybfFWdCzqBt4B8RG9xMq0220gJR6ZwAaiMc1CGIknK7C6EKeCx9LOWDjCaHg6pA2iPAb/PoxDuiqbUIzfRmkgMf0lYmrf0kqx529ALm92ulSx root@33c294c5235e"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_sshkey_test.go
+++ b/gridscale/resource_gridscale_sshkey_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleSshkey_Basic(t *testing.T) {
+func TestAccResourceGridscaleSshkeyBasic(t *testing.T) {
 	var object gsclient.Sshkey
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleSshkey_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleSshkeyDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleSshkeyConfig_basic(name),
+				Config: testAccCheckResourceGridscaleSshkeyConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -32,7 +32,7 @@ func TestAccResourceGridscaleSshkey_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleSshkeyConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleSshkeyConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleSshkeyExists("gridscale_sshkey.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -101,7 +101,7 @@ func testAccCheckGridscaleSshkeyDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleSshkeyConfig_basic(name string) string {
+func testAccCheckResourceGridscaleSshkeyConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "foo" {
   name   = "%s"
@@ -110,7 +110,7 @@ resource "gridscale_sshkey" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleSshkeyConfig_basic_update() string {
+func testAccCheckResourceGridscaleSshkeyConfigBasicUpdate() string {
 	return `
 resource "gridscale_sshkey" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_sslcert_test.go
+++ b/gridscale/resource_gridscale_sslcert_test.go
@@ -17,7 +17,7 @@ const (
 	leafCertExample   = "-----BEGIN CERTIFICATE-----\nMIIC1TCCAb2gAwIBAgIJAP4/xUQz5NypMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNV\nBAMTD3d3dy5leGFtcGxlLmNvbTAeFw0yMTAzMjkxNDQxNTdaFw0zMTAzMjcxNDQx\nNTdaMBoxGDAWBgNVBAMTD3d3dy5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEB\nBQADggEPADCCAQoCggEBANIM0Lom/iIwroEsBrSzmibfVRhpI9BQM1x9AigEhjo3\nttb90/TNpbhEZ+EsElVVQJgbyy6e0jIVikxsRmd+8KHcsGEIiSVYk2w0VkhxJqpX\ndPTMVANL8G8fSlCeUsGVCp6PViKhSBt9EyptqUSe17qVgigXac46uxackWdSjNuE\ntnw3muCM7h0cCb3s9geRFaPbOvTYNVm/wFi5I0joQeJYXV4LKjT33g2fiKhb6c4b\n4fPui5FYUhSJgB4o35uFR/qBsota38OZwl4dUIBPirb8mFT6buYwD/dw2DVTxjHx\naD8aWtQWg896U1sc/A3CPvWb+EyD/4Jn3YzKvOdX7PUCAwEAAaMeMBwwGgYDVR0R\nBBMwEYIPd3d3LmV4YW1wbGUuY29tMA0GCSqGSIb3DQEBBQUAA4IBAQDKWvBcVS1R\n8K+HYBpEaVnElMk7vBOvdq7h/SZSXVAGNgNM1RPK7w6zWyDwI2Zs5COQiAbK0MwL\nBkI6RwTfDd8RL/nZe35iL6agI0CQbX3/l7Zo09n2RpShpzHbzWIkuzPNlzR+b0pb\nIGyChAsL1O+d3Ft/8LFkFiXIcEb+0kB75X/R+Tx2+LmCMxCHM4JYudzE8mzuKHuR\neXktzUNvVHzkcAN1rpTCK0tGJivmh+QMrwXZh2cWsL6xdI8m24J+e2zJef/mosYQ\n+xX/qCCQKbsRfckG3SDHi6RZlCnzrwSaW+djekAIuju+3HIbeDjjAI4DUSfqd1SH\n87fnnaj9tE69\n-----END CERTIFICATE-----"
 )
 
-func TestAccResourceGridscaleSSLCert_Basic(t *testing.T) {
+func TestAccResourceGridscaleSSLCertBasic(t *testing.T) {
 	var object gsclient.SSLCertificate
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -27,7 +27,7 @@ func TestAccResourceGridscaleSSLCert_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleSSLCertDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleSSLCertConfig_basic(name),
+				Config: testAccCheckResourceGridscaleSSLCertConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleSSLCertExists("gridscale_ssl_certificate.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -108,7 +108,7 @@ func testAccCheckGridscaleSSLCertDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleSSLCertConfig_basic(name string) string {
+func testAccCheckResourceGridscaleSSLCertConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_ssl_certificate" "foo" {
   name   = "%s"

--- a/gridscale/resource_gridscale_storage_clone_test.go
+++ b/gridscale/resource_gridscale_storage_clone_test.go
@@ -1,13 +1,9 @@
 package gridscale
 
 import (
-	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
 	"github.com/gridscale/gsclient-go/v3"
 )
@@ -43,7 +39,7 @@ func TestAccResourceGridscaleStorageClone_Basic(t *testing.T) {
 	})
 }
 
-func testAccCheckGridscaleStorageCloneDestroyCheck(s *terraform.State) error {
+/*func testAccCheckGridscaleStorageCloneDestroyCheck(s *terraform.State) error {
 	client := testAccProvider.Meta().(*gsclient.Client)
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gridscale_storage_clone" {
@@ -68,10 +64,10 @@ func testAccCheckGridscaleStorageCloneDestroyCheck(s *terraform.State) error {
 	}
 
 	return nil
-}
+}*/
 
 func testAccCheckResourceGridscaleStorageCloneConfig_basic() string {
-	return fmt.Sprint(`
+	return `
 resource "gridscale_storage" "foo" {
   name   = "test"
   capacity = 1
@@ -82,11 +78,11 @@ resource "gridscale_storage_clone" "foo" {
   name = "desired_name"
   storage_type = "storage_high"
 }
-`)
+`
 }
 
 func testAccCheckResourceGridscaleStorageCloneConfig_basic_update() string {
-	return fmt.Sprint(`
+	return `
 resource "gridscale_storage" "foo" {
 	name   = "test"
 	capacity = 1
@@ -98,5 +94,5 @@ resource "gridscale_storage_clone" "foo" {
   capacity = 2
   storage_type = "storage_insane"
 }
-`)
+`
 }

--- a/gridscale/resource_gridscale_storage_clone_test.go
+++ b/gridscale/resource_gridscale_storage_clone_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleStorageClone_Basic(t *testing.T) {
+func TestAccResourceGridscaleStorageCloneBasic(t *testing.T) {
 	var object gsclient.Storage
 
 	resource.Test(t, resource.TestCase{
@@ -17,7 +17,7 @@ func TestAccResourceGridscaleStorageClone_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleStorageCloneConfig_basic(),
+				Config: testAccCheckResourceGridscaleStorageCloneConfigBasic(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleStorageExists("gridscale_storage_clone.foo", &object),
 					resource.TestCheckResourceAttrSet("gridscale_storage_clone.foo", "name"),
@@ -26,7 +26,7 @@ func TestAccResourceGridscaleStorageClone_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleStorageCloneConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleStorageCloneConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleStorageExists("gridscale_storage_clone.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -66,7 +66,7 @@ func TestAccResourceGridscaleStorageClone_Basic(t *testing.T) {
 	return nil
 }*/
 
-func testAccCheckResourceGridscaleStorageCloneConfig_basic() string {
+func testAccCheckResourceGridscaleStorageCloneConfigBasic() string {
 	return `
 resource "gridscale_storage" "foo" {
   name   = "test"
@@ -81,7 +81,7 @@ resource "gridscale_storage_clone" "foo" {
 `
 }
 
-func testAccCheckResourceGridscaleStorageCloneConfig_basic_update() string {
+func testAccCheckResourceGridscaleStorageCloneConfigBasicUpdate() string {
 	return `
 resource "gridscale_storage" "foo" {
 	name   = "test"

--- a/gridscale/resource_gridscale_storage_test.go
+++ b/gridscale/resource_gridscale_storage_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleStorage_Basic(t *testing.T) {
+func TestAccResourceGridscaleStorageBasic(t *testing.T) {
 	var object gsclient.Storage
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -23,7 +23,7 @@ func TestAccResourceGridscaleStorage_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleStorageConfig_basic(name),
+				Config: testAccCheckResourceGridscaleStorageConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleStorageExists("gridscale_storage.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -33,7 +33,7 @@ func TestAccResourceGridscaleStorage_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleStorageConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleStorageConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleStorageExists("gridscale_storage.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -44,7 +44,7 @@ func TestAccResourceGridscaleStorage_Basic(t *testing.T) {
 	})
 }
 
-func TestAccResourceGridscaleStorage_Advanced(t *testing.T) {
+func TestAccResourceGridscaleStorageAdvanced(t *testing.T) {
 	var object gsclient.Storage
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -54,7 +54,7 @@ func TestAccResourceGridscaleStorage_Advanced(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleStorageDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleStorageConfig_advanced(name),
+				Config: testAccCheckResourceGridscaleStorageConfigAdvanced(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleStorageExists("gridscale_storage.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -128,7 +128,7 @@ func testAccCheckGridscaleStorageDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleStorageConfig_basic(name string) string {
+func testAccCheckResourceGridscaleStorageConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "%s"
@@ -137,7 +137,7 @@ resource "gridscale_storage" "foo" {
 `, name)
 }
 
-func testAccCheckResourceGridscaleStorageConfig_basic_update() string {
+func testAccCheckResourceGridscaleStorageConfigBasicUpdate() string {
 	return `
 resource "gridscale_storage" "foo" {
   name   = "newname"
@@ -146,7 +146,7 @@ resource "gridscale_storage" "foo" {
 `
 }
 
-func testAccCheckResourceGridscaleStorageConfig_advanced(name string) string {
+func testAccCheckResourceGridscaleStorageConfigAdvanced(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_sshkey" "sshkey" {
   name = "%s"

--- a/gridscale/resource_gridscale_storage_test.go
+++ b/gridscale/resource_gridscale_storage_test.go
@@ -138,12 +138,12 @@ resource "gridscale_storage" "foo" {
 }
 
 func testAccCheckResourceGridscaleStorageConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "foo" {
   name   = "newname"
   capacity = 1
 }
-`)
+`
 }
 
 func testAccCheckResourceGridscaleStorageConfig_advanced(name string) string {

--- a/gridscale/resource_gridscale_template_test.go
+++ b/gridscale/resource_gridscale_template_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gridscale/gsclient-go/v3"
 )
 
-func TestAccResourceGridscaleTemplate_Basic(t *testing.T) {
+func TestAccResourceGridscaleTemplateBasic(t *testing.T) {
 	var object gsclient.Template
 	name := fmt.Sprintf("object-%s", acctest.RandString(10))
 
@@ -22,7 +22,7 @@ func TestAccResourceGridscaleTemplate_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckGridscaleTemplateDestroyCheck,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckResourceGridscaleTemplateConfig_basic(name),
+				Config: testAccCheckResourceGridscaleTemplateConfigBasic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleTemplateExists("gridscale_template.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -30,7 +30,7 @@ func TestAccResourceGridscaleTemplate_Basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleTemplateConfig_basic_update(),
+				Config: testAccCheckResourceGridscaleTemplateConfigBasicUpdate(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscaleTemplateExists("gridscale_template.foo", &object),
 					resource.TestCheckResourceAttr(
@@ -97,7 +97,7 @@ func testAccCheckGridscaleTemplateDestroyCheck(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckResourceGridscaleTemplateConfig_basic(name string) string {
+func testAccCheckResourceGridscaleTemplateConfigBasic(name string) string {
 	return fmt.Sprintf(`
 resource "gridscale_storage" "foo" {
   name   = "%s"
@@ -116,7 +116,7 @@ resource "gridscale_template" "foo" {
 `, name, name, name)
 }
 
-func testAccCheckResourceGridscaleTemplateConfig_basic_update() string {
+func testAccCheckResourceGridscaleTemplateConfigBasicUpdate() string {
 	return `
 resource "gridscale_storage" "foo" {
   name   = "newname"

--- a/gridscale/resource_gridscale_template_test.go
+++ b/gridscale/resource_gridscale_template_test.go
@@ -117,7 +117,7 @@ resource "gridscale_template" "foo" {
 }
 
 func testAccCheckResourceGridscaleTemplateConfig_basic_update() string {
-	return fmt.Sprintf(`
+	return `
 resource "gridscale_storage" "foo" {
   name   = "newname"
   capacity = 1
@@ -133,5 +133,5 @@ resource "gridscale_template" "foo" {
   labels = ["test"]
   snapshot_uuid = gridscale_snapshot.foo.id
 }
-`)
+`
 }


### PR DESCRIPTION
The implementations out for review are used to get rid of style complaints detected by staticcheck linter.
Mostly following recurring issues have been solved:
- `error strings should not end with punctuation or newlines (ST1005)go-staticcheck`
- `error strings should not be capitalized (ST1005)go-staticcheck`
- `should omit nil check; len() for []github.com/gridscale/gsclient-go/v3.Credential is defined as zero (S1009)go-staticcheck`