### PR TITLE
Fix cannot retry upgrade 1.29 to 1.30 when previous upgrade fails

### DIFF
--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -427,30 +427,18 @@ func deriveK8sTemplateFromResourceData(client *gsclient.Client, d *schema.Resour
 	releaseInterface, isReleaseSet := d.GetOk("release")
 	release := releaseInterface.(string)
 
-	if !d.IsNewResource() { // case if update of resource is requested
-		if isVersionSet && d.HasChange("version") {
-			derivationTypesRequested += 1
-			derivationType = "version"
-		}
+	if isVersionSet {
+		derivationTypesRequested += 1
+		derivationType = "version"
+	}
 
-		if isReleaseSet && d.HasChange("release") {
-			derivationTypesRequested += 1
-			derivationType = "release"
-		}
-	} else { // case if creation of resource is requested
-		if isVersionSet {
-			derivationTypesRequested += 1
-			derivationType = "version"
-		}
+	if isReleaseSet {
+		derivationTypesRequested += 1
+		derivationType = "release"
+	}
 
-		if isReleaseSet {
-			derivationTypesRequested += 1
-			derivationType = "release"
-		}
-
-		if derivationTypesRequested == 0 {
-			return nil, errors.New("either \"release\" or \"gsk_version\" has to be defined")
-		}
+	if derivationTypesRequested == 0 {
+		return nil, errors.New("either \"release\" or \"gsk_version\" has to be defined")
 	}
 
 	if derivationTypesRequested > 1 {

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -1027,7 +1027,7 @@ func resourceGridscaleK8sCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.SetId(response.ObjectUUID)
 	log.Printf("The id for PaaS service %s has been set to %v", requestBody.Name, response.ObjectUUID)
-	return nil //resourceGridscaleK8sRead(d, meta)
+	return resourceGridscaleK8sRead(d, meta)
 }
 
 func resourceGridscaleK8sUpdate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Change:
- Remove the logic "if version/release is changed on resource update, derive template from version/release" in `deriveK8sTemplateFromResourceData`.

IF the previous upgrade (from 1.29 to 1.30) fails, the updated value of version/release is still persisted (tf provider behaviour because we don't set version/release in k8s resource READ). Hence when we re-try the upgrade, this piece of code detects no changes in version/release parameter => tf tries to get template uuid from service_template_uuid (which is just the current template of the cluster), hence no upgrade happens.
