### PR TITLE
Make gsk release validation for gs tf provider v2 clearer

### DIFF
--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -71,22 +71,10 @@ func (rgk8sv *ResourceGridscaleK8sValidator) checkIfTemplateSupportsMultiNodePoo
 		k8sMultiNodePoolSupportRelease,
 	)
 	templateRelease, err := NewRelease(template.Properties.Release)
-
 	if err != nil {
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
-	multiNodePoolSupportRelease, err := NewRelease(k8sMultiNodePoolSupportRelease)
-
-	if err != nil {
-		return fmt.Errorf("%s error: %v", errorPrefix, err)
-	}
-	err = templateRelease.CheckIfFeatureIsKnown(
-		&Feature{
-			Description: "multi node pool support",
-			Release:     *multiNodePoolSupportRelease,
-		},
-	)
-	return err
+	return templateRelease.CheckIfK8SReleaseIsSupported()
 }
 
 // buildInputSchema models the k8s resource's input schema by ResourceGridscaleK8sModeler receiver.

--- a/gridscale/resource_gridscale_release.go
+++ b/gridscale/resource_gridscale_release.go
@@ -17,6 +17,8 @@ type Feature struct {
 	Release
 }
 
+const supportedK8SRelease = "1.30"
+
 // NewRelease creates a new Release instance.
 func NewRelease(representation string) (*Release, error) {
 	version, err := goVersion.NewVersion(representation)
@@ -32,6 +34,16 @@ func (r *Release) CheckIfFeatureIsKnown(f *Feature) error {
 	if r.LessThan(&f.Version) {
 		return &ReleaseFeatureIncompatibilityError{
 			Detail: fmt.Sprintf("Feature '%s' is part of release %s but requested for release %s.", f.Description, f.String(), r.String()),
+		}
+	}
+	return nil
+}
+
+// CheckIfK8SReleaseIsSupported checks if the Kubernetes release is supported by this gridscale terraform provider.
+func (r *Release) CheckIfK8SReleaseIsSupported() error {
+	if r.LessThan(goVersion.Must(goVersion.NewVersion(supportedK8SRelease))) {
+		return &ReleaseFeatureIncompatibilityError{
+			Detail: fmt.Sprintf("this gridscale terraform provider version v2 supports only Kubernetes release >= %s, for Kubernetes release %s please use gridscale terraform provider version v1", supportedK8SRelease, r.String()),
 		}
 	}
 	return nil


### PR DESCRIPTION
The error will look like:
```bash
$ tf apply
╷
│ Error: this gridscale terraform provider version v2 supports only Kubernetes release >= 1.30, for Kubernetes release 1.29.0 please use gridscale terraform provider version v1
│ 
│   with gridscale_k8s.k8s_cluster,
│   on main.tf line 10, in resource "gridscale_k8s" "k8s_cluster":
│   10: resource "gridscale_k8s" "k8s_cluster" {
│ 
╵
```