### PR TITLE
Only allow gsk release < 1.30 to use gs tf provider v1

### DIFF
--- a/gridscale/resource_gridscale_release.go
+++ b/gridscale/resource_gridscale_release.go
@@ -17,6 +17,8 @@ type Feature struct {
 	Release
 }
 
+const unsupportedK8SRelease = "1.30"
+
 // NewRelease creates a new Release instance.
 func NewRelease(representation string) (*Release, error) {
 	version, err := goVersion.NewVersion(representation)
@@ -28,10 +30,20 @@ func NewRelease(representation string) (*Release, error) {
 }
 
 // CheckIfFeatureIsKnown checks by a Release receiver if a passed Feature instance is known.
-func (r *Release) CheckIfFeatureIsKnown(f *Feature) *ReleaseFeatureIncompatibilityError {
+func (r *Release) CheckIfFeatureIsKnown(f *Feature) error {
 	if r.LessThan(&f.Version) {
 		return &ReleaseFeatureIncompatibilityError{
 			Detail: fmt.Sprintf("Feature '%s' is part of release %s but requested for release %s.", f.Description, f.String(), r.String()),
+		}
+	}
+	return nil
+}
+
+// CheckIfK8SReleaseIsSupported checks if the Kubernetes release is supported by this gridscale terraform provider.
+func (r *Release) CheckIfK8SReleaseIsSupported() error {
+	if r.GreaterThanOrEqual(goVersion.Must(goVersion.NewVersion(unsupportedK8SRelease))) {
+		return &ReleaseFeatureIncompatibilityError{
+			Detail: fmt.Sprintf("this gridscale terraform provider version v1 supports only Kubernetes release < %s, for Kubernetes release %s please use gridscale terraform provider version v2", unsupportedK8SRelease, r.String()),
 		}
 	}
 	return nil


### PR DESCRIPTION
Error when try to provision a 1.30 cluster in tf provider v1 or upgrade to k8s release 1.30 in v1:
```bash
$ tf apply
gridscale_k8s.k8s_cluster: Refreshing state... [id=54bb3416-d591-4c23-9902-6e4c25e1e8d2]
╷
│ Error: this gridscale terraform provider version v1 supports only Kubernetes release < 1.30, for Kubernetes release 1.30.0 please use gridscale terraform provider version v2
│ 
│   with gridscale_k8s.k8s_cluster,
│   on main.tf line 10, in resource "gridscale_k8s" "k8s_cluster":
│   10: resource "gridscale_k8s" "k8s_cluster" {
│ 
╵
```