### PR TITLE
Fix cannot upgrade k8s cluster via gsk_version & add more k8s test cases

### DIFF
--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -419,7 +419,7 @@ func deriveK8sTemplateFromResourceData(client *gsclient.Client, d *schema.Resour
 	release := releaseInterface.(string)
 
 	if !d.IsNewResource() { // case if update of resource is requested
-		if isVersionSet && d.HasChange("version") {
+		if isVersionSet && d.HasChange("gsk_version") {
 			derivationTypesRequested += 1
 			derivationType = "version"
 		}

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -43,26 +43,6 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "surge_node", "false"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_enabled", "true"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_issuer_url", "https://sts.windows.net/fe4ac456-23a7-4841-a404-01fcb695412c/"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_client_id", "015ad6ba-1da5-4958-be94-8d50fa37898f"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_username_claim", "email"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_groups_claim", "groups"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_groups_prefix", "oidc:"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_username_prefix", "oidc:"),
-					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "oidc_required_claim", "family_name=8944e8db-fe55-4443-aee0-16adfe637e71,given_name=c892dd1d-b324-48e6-a7da-051a96fbee37"),
-					resource.TestCheckResourceAttrSet(
-						"gridscale_k8s.foopaas", "oidc_ca_pem"),
 				),
 			},
 			{
@@ -222,19 +202,8 @@ resource "gridscale_k8s" "foopaas" {
 		storage_type = "storage_insane"
 		rocket_storage = 90
 	}
-	
-	surge_node = false
-	oidc_enabled = true
-	oidc_issuer_url = "https://sts.windows.net/fe4ac456-23a7-4841-a404-01fcb695412c/"
-	oidc_client_id = "015ad6ba-1da5-4958-be94-8d50fa37898f"
-	oidc_username_claim = "email"
-	oidc_groups_claim = "groups"
-	oidc_groups_prefix = "oidc:"
-	oidc_username_prefix = "oidc:"
-	oidc_required_claim = "family_name=8944e8db-fe55-4443-aee0-16adfe637e71,given_name=c892dd1d-b324-48e6-a7da-051a96fbee37"
-	oidc_ca_pem = "%s"
 }
-`, name, oidcCAPEM)
+`, name)
 }
 
 func testAccCheckResourceGridscaleK8sConfigBasicUpdate() string {
@@ -316,7 +285,7 @@ func testAccCheckResourceGridscaleK8sConfigAddNodePool() string {
 		release = "1.30"
 		node_pool {
 			name = "my-node-pool"
-			node_count = 2
+			node_count = 1
 			cores = 2
 			memory = 4
 			storage = 50

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -311,7 +311,7 @@ func testAccCheckResourceGridscaleK8sConfigRemoveNodePool() string {
 		release = "1.30"
 		node_pool {
 			name = "my-node-pool"
-			node_count = 2
+			node_count = 1
 			cores = 2
 			memory = 4
 			storage = 50

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -177,6 +177,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.1.memory", "2"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.1.storage", "30"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1.storage_type", "storage_insane"),
 				),
 			},
 			{
@@ -327,6 +329,7 @@ func testAccCheckResourceGridscaleK8sConfigAddNodePool() string {
 			cores = 1
 			memory = 2
 			storage = 30
+			storage_type = "storage_insane"
 		}
 	}
 	`

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -42,7 +42,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 				),
 			},
 			{
@@ -66,7 +66,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 				),
 			},
 			{
@@ -86,7 +86,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 				),
 			},
 			{
@@ -106,7 +106,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 				),
 			},
 			{
@@ -126,7 +126,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 				),
 			},
 			{
@@ -146,7 +146,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.1.name", "my-node-pool-2"),
 					resource.TestCheckResourceAttr(
@@ -178,7 +178,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
 					resource.TestCheckNoResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.1",
 					),
@@ -200,7 +200,7 @@ resource "gridscale_k8s" "foopaas" {
 		memory = 2
 		storage = 30
 		storage_type = "storage_insane"
-		rocket_storage = 90
+		rocket_storage = 10
 	}
 }
 `, name)
@@ -218,7 +218,7 @@ resource "gridscale_k8s" "foopaas" {
 		memory = 2
 		storage = 30
 		storage_type = "storage_insane"
-		rocket_storage = 90
+		rocket_storage = 10
 	}
 }
 `
@@ -236,7 +236,7 @@ func testAccCheckResourceGridscaleK8sConfigNodePoolSpecsUpdate() string {
 			memory = 4
 			storage = 50
 			storage_type = "storage_insane"
-			rocket_storage = 90
+			rocket_storage = 10
 		}
 	}
 	`
@@ -254,7 +254,7 @@ func testAccCheckResourceGridscaleK8sConfigNodeCountIncrease() string {
 			memory = 4
 			storage = 50
 			storage_type = "storage_insane"
-			rocket_storage = 90
+			rocket_storage = 10
 		}
 	}
 	`
@@ -272,7 +272,7 @@ func testAccCheckResourceGridscaleK8sConfigNodeCountDecrease() string {
 			memory = 4
 			storage = 50
 			storage_type = "storage_insane"
-			rocket_storage = 90
+			rocket_storage = 10
 		}
 	}
 	`
@@ -290,7 +290,7 @@ func testAccCheckResourceGridscaleK8sConfigAddNodePool() string {
 			memory = 4
 			storage = 50
 			storage_type = "storage_insane"
-			rocket_storage = 90
+			rocket_storage = 10
 		}
 		node_pool {
 			name = "my-node-pool-2"
@@ -316,7 +316,7 @@ func testAccCheckResourceGridscaleK8sConfigRemoveNodePool() string {
 			memory = 4
 			storage = 50
 			storage_type = "storage_insane"
-			rocket_storage = 90
+			rocket_storage = 10
 		}
 	}
 	`

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 )
 
+const oidcCAPEM = `-----BEGIN CERTIFICATE-----\nMIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\nTzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\ncmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\nWhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\nZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\nMTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\nh77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\nA5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\nT8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\nB5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\nB5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\nKBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\nOlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\njh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\nqHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\nrU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\nHRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\nhkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\nubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\nNFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\nORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\nTkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\njNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\noyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\nmRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\nemyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n-----END CERTIFICATE-----\n`
+
 func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 	var object gsclient.PaaSService
 	name := fmt.Sprintf("k8s-%s", acctest.RandString(10))
@@ -25,6 +27,42 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "name", name),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "release", "1.30"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "30"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "surge_node", "false"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_issuer_url", "https://sts.windows.net/fe4ac456-23a7-4841-a404-01fcb695412c/"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_client_id", "015ad6ba-1da5-4958-be94-8d50fa37898f"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_username_claim", "email"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_groups_claim", "groups"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_groups_prefix", "oidc:"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_username_prefix", "oidc:"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "oidc_required_claim", "family_name=8944e8db-fe55-4443-aee0-16adfe637e71,given_name=c892dd1d-b324-48e6-a7da-051a96fbee37"),
+					resource.TestCheckResourceAttrSet(
+						"gridscale_k8s.foopaas", "oidc_ca_pem"),
 				),
 			},
 			{
@@ -33,6 +71,115 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "name", "newname"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "release", "1.30"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "30"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleK8sConfigNodePoolSpecsUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "4"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "50"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleK8sConfigNodeCountUpdate(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "3"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "4"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "50"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleK8sConfigAddNodePool(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "3"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "4"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "50"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1.name", "my-node-pool-2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1.node_count", "1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1.cores", "1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1.memory", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1.storage", "30"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleK8sConfigRemoveNodePool(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "3"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "4"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "50"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+					resource.TestCheckNoResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.1",
+					),
 				),
 			},
 		},
@@ -63,9 +210,9 @@ resource "gridscale_k8s" "foopaas" {
 	oidc_groups_prefix = "oidc:"
 	oidc_username_prefix = "oidc:"
 	oidc_required_claim = "family_name=8944e8db-fe55-4443-aee0-16adfe637e71,given_name=c892dd1d-b324-48e6-a7da-051a96fbee37"
-	oidc_ca_pem = "-----BEGIN CERTIFICATE-----\nMIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw\nTzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh\ncmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4\nWhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu\nZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY\nMTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc\nh77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+\n0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U\nA5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW\nT8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH\nB5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC\nB5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv\nKBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn\nOlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn\njh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw\nqHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI\nrU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV\nHRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq\nhkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL\nubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ\n3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK\nNFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5\nORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur\nTkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC\njNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc\noyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq\n4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA\nmRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d\nemyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=\n-----END CERTIFICATE-----\n"
+	oidc_ca_pem = "%s"
 }
-`, name)
+`, name, oidcCAPEM)
 }
 
 func testAccCheckResourceGridscaleK8sConfigBasicUpdate() string {
@@ -82,7 +229,85 @@ resource "gridscale_k8s" "foopaas" {
 		storage_type = "storage_insane"
 		rocket_storage = 90
 	}
-	surge_node = false
 }
 `
+}
+
+func testAccCheckResourceGridscaleK8sConfigNodePoolSpecsUpdate() string {
+	return `
+	resource "gridscale_k8s" "foopaas" {
+		name   = "newname"
+		release = "1.30"
+		node_pool {
+			name = "my-node-pool"
+			node_count = 2
+			cores = 2
+			memory = 4
+			storage = 50
+			storage_type = "storage_insane"
+			rocket_storage = 90
+		}
+	}
+	`
+}
+
+func testAccCheckResourceGridscaleK8sConfigNodeCountUpdate() string {
+	return `
+	resource "gridscale_k8s" "foopaas" {
+		name   = "newname"
+		release = "1.30"
+		node_pool {
+			name = "my-node-pool"
+			node_count = 3
+			cores = 2
+			memory = 4
+			storage = 50
+			storage_type = "storage_insane"
+			rocket_storage = 90
+		}
+	}
+	`
+}
+
+func testAccCheckResourceGridscaleK8sConfigAddNodePool() string {
+	return `
+	resource "gridscale_k8s" "foopaas" {
+		name   = "newname"
+		release = "1.30"
+		node_pool {
+			name = "my-node-pool"
+			node_count = 3
+			cores = 2
+			memory = 4
+			storage = 50
+			storage_type = "storage_insane"
+			rocket_storage = 90
+		}
+		node_pool {
+			name = "my-node-pool-2"
+			node_count = 1
+			cores = 1
+			memory = 2
+			storage = 30
+		}
+	}
+	`
+}
+
+func testAccCheckResourceGridscaleK8sConfigRemoveNodePool() string {
+	return `
+	resource "gridscale_k8s" "foopaas" {
+		name   = "newname"
+		release = "1.30"
+		node_pool {
+			name = "my-node-pool"
+			node_count = 3
+			cores = 2
+			memory = 4
+			storage = 50
+			storage_type = "storage_insane"
+			rocket_storage = 90
+		}
+	}
+	`
 }

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -32,7 +32,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.node_count", "2"),
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "1"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.cores", "1"),
 					resource.TestCheckResourceAttr(
@@ -76,7 +76,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.node_count", "2"),
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "1"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.cores", "1"),
 					resource.TestCheckResourceAttr(
@@ -96,6 +96,26 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
 					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.memory", "4"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage", "50"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "90"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleK8sConfigNodeCountIncrease(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
+					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.node_count", "2"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
@@ -110,13 +130,13 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckResourceGridscaleK8sConfigNodeCountUpdate(),
+				Config: testAccCheckResourceGridscaleK8sConfigNodeCountDecrease(),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceGridscalePaaSExists("gridscale_k8s.foopaas", &object),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.node_count", "3"),
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "1"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
 					resource.TestCheckResourceAttr(
@@ -136,7 +156,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.node_count", "3"),
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "1"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
 					resource.TestCheckResourceAttr(
@@ -166,7 +186,7 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.name", "my-node-pool"),
 					resource.TestCheckResourceAttr(
-						"gridscale_k8s.foopaas", "node_pool.0.node_count", "3"),
+						"gridscale_k8s.foopaas", "node_pool.0.node_count", "1"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.cores", "2"),
 					resource.TestCheckResourceAttr(
@@ -193,7 +213,7 @@ resource "gridscale_k8s" "foopaas" {
 	release = "1.30"
 	node_pool {
 		name = "my-node-pool"
-		node_count = 2
+		node_count = 1
 		cores = 1
 		memory = 2
 		storage = 30
@@ -222,7 +242,7 @@ resource "gridscale_k8s" "foopaas" {
 	release = "1.30"
 	node_pool {
 		name = "my-node-pool"
-		node_count = 2
+		node_count = 1
 		cores = 1
 		memory = 2
 		storage = 30
@@ -240,6 +260,24 @@ func testAccCheckResourceGridscaleK8sConfigNodePoolSpecsUpdate() string {
 		release = "1.30"
 		node_pool {
 			name = "my-node-pool"
+			node_count = 1
+			cores = 2
+			memory = 4
+			storage = 50
+			storage_type = "storage_insane"
+			rocket_storage = 90
+		}
+	}
+	`
+}
+
+func testAccCheckResourceGridscaleK8sConfigNodeCountIncrease() string {
+	return `
+	resource "gridscale_k8s" "foopaas" {
+		name   = "newname"
+		release = "1.30"
+		node_pool {
+			name = "my-node-pool"
 			node_count = 2
 			cores = 2
 			memory = 4
@@ -251,14 +289,14 @@ func testAccCheckResourceGridscaleK8sConfigNodePoolSpecsUpdate() string {
 	`
 }
 
-func testAccCheckResourceGridscaleK8sConfigNodeCountUpdate() string {
+func testAccCheckResourceGridscaleK8sConfigNodeCountDecrease() string {
 	return `
 	resource "gridscale_k8s" "foopaas" {
 		name   = "newname"
 		release = "1.30"
 		node_pool {
 			name = "my-node-pool"
-			node_count = 3
+			node_count = 1
 			cores = 2
 			memory = 4
 			storage = 50
@@ -276,7 +314,7 @@ func testAccCheckResourceGridscaleK8sConfigAddNodePool() string {
 		release = "1.30"
 		node_pool {
 			name = "my-node-pool"
-			node_count = 3
+			node_count = 2
 			cores = 2
 			memory = 4
 			storage = 50
@@ -301,7 +339,7 @@ func testAccCheckResourceGridscaleK8sConfigRemoveNodePool() string {
 		release = "1.30"
 		node_pool {
 			name = "my-node-pool"
-			node_count = 3
+			node_count = 2
 			cores = 2
 			memory = 4
 			storage = 50


### PR DESCRIPTION
Changes:
- Fix cannot upgrade k8s cluster when update `gsk_version`. This happened because the provider check changes of a wrong param (typo)
- Add more test cases for k8s resource: update node specs, scale in/out, add/remove node pools.