### PR TITLE
Remove hubble attribute from k8s resource schema and related code

### DIFF
--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -295,12 +295,6 @@ func (rgk8sm *ResourceGridscaleK8sModeler) buildInputSchema() map[string]*schema
 			Computed:    true,
 			Optional:    true,
 		},
-		"hubble": {
-			Type:        schema.TypeBool,
-			Description: "Enable hubble integration.",
-			Computed:    true,
-			Optional:    true,
-		},
 		"kube_apiserver_log_enabled": {
 			Type:        schema.TypeBool,
 			Description: "Enable kube-apiserver logs.",
@@ -711,13 +705,6 @@ func resourceGridscaleK8sRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	// Set hubble if it is set
-	if hubble, isHubbleSet := props.Parameters["k8s_hubble"].(bool); isHubbleSet {
-		if err = d.Set("hubble", hubble); err != nil {
-			return fmt.Errorf("%s error setting hubble: %v", errorPrefix, err)
-		}
-	}
-
 	// Set kube API server enabling if it is set
 	if kubeAPIServerLogEnabled, isKubeAPIServerLogEnabledSet := props.Parameters["k8s_kube_apiserver_log_enabled"].(bool); isKubeAPIServerLogEnabledSet {
 		if err = d.Set("kube_apiserver_log_enabled", kubeAPIServerLogEnabled); err != nil {
@@ -992,11 +979,6 @@ func resourceGridscaleK8sCreate(d *schema.ResourceData, meta interface{}) error 
 		parameters["k8s_oidc_ca_pem"] = oidcCAPEM
 	}
 
-	// Set hubble if it is set
-	if hubble, isHubbleSet := d.GetOk("hubble"); isHubbleSet {
-		parameters["k8s_hubble"] = hubble.(bool)
-	}
-
 	// Set kube API server enabling if it is set
 	if kubeAPIServerLogEnabled, isKubeAPIServerLogEnabledSet := d.GetOk("kube_apiserver_log_enabled"); isKubeAPIServerLogEnabledSet {
 		parameters["k8s_kube_apiserver_log_enabled"] = kubeAPIServerLogEnabled.(bool)
@@ -1043,7 +1025,7 @@ func resourceGridscaleK8sCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// Set hubble if it is set
-	if hubble, isHubbleSet := d.GetOk("hubble"); isHubbleSet {
+	if hubble, isHubbleSet := d.GetOk("k8s_hubble"); isHubbleSet {
 		parameters["k8s_hubble"] = hubble.(bool)
 	}
 
@@ -1155,10 +1137,6 @@ func resourceGridscaleK8sUpdate(d *schema.ResourceData, meta interface{}) error 
 	if oidcCAPEM, isOIDCCAPEMSet := d.GetOk("oidc_ca_pem"); isOIDCCAPEMSet {
 		parameters["k8s_oidc_ca_pem"] = oidcCAPEM
 	}
-	// Set hubble if it is set
-	if hubble, isHubbleSet := d.GetOk("hubble"); isHubbleSet {
-		parameters["k8s_hubble"] = hubble
-	}
 
 	// Set kube API server enabling if it is set
 	if kubeAPIServerLogEnabled, isKubeAPIServerLogEnabledSet := d.GetOk("kube_apiserver_log_enabled"); isKubeAPIServerLogEnabledSet {
@@ -1206,7 +1184,7 @@ func resourceGridscaleK8sUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	// Set hubble if it is set
-	if hubble, isHubbleSet := d.GetOk("hubble"); isHubbleSet {
+	if hubble, isHubbleSet := d.GetOk("k8s_hubble"); isHubbleSet {
 		parameters["k8s_hubble"] = hubble
 	}
 	requestBody.Parameters = parameters

--- a/gridscale/resource_gridscale_k8s_test.go
+++ b/gridscale/resource_gridscale_k8s_test.go
@@ -43,6 +43,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 			{
@@ -67,6 +69,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 			{
@@ -87,6 +91,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 			{
@@ -107,6 +113,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 			{
@@ -127,6 +135,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.0.storage_type", "storage_insane"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.0.rocket_storage", "10"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 			{
@@ -159,6 +169,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 						"gridscale_k8s.foopaas", "node_pool.1.storage", "30"),
 					resource.TestCheckResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.1.storage_type", "storage_insane"),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 			{
@@ -182,6 +194,8 @@ func TestAccResourceGridscaleK8sBasic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(
 						"gridscale_k8s.foopaas", "node_pool.1",
 					),
+					resource.TestCheckResourceAttr(
+						"gridscale_k8s.foopaas", "k8s_hubble", "true"),
 				),
 			},
 		},
@@ -202,6 +216,7 @@ resource "gridscale_k8s" "foopaas" {
 		storage_type = "storage_insane"
 		rocket_storage = 10
 	}
+	k8s_hubble = true
 }
 `, name)
 }
@@ -220,6 +235,7 @@ resource "gridscale_k8s" "foopaas" {
 		storage_type = "storage_insane"
 		rocket_storage = 10
 	}
+	k8s_hubble = true
 }
 `
 }
@@ -238,6 +254,7 @@ func testAccCheckResourceGridscaleK8sConfigNodePoolSpecsUpdate() string {
 			storage_type = "storage_insane"
 			rocket_storage = 10
 		}
+		k8s_hubble = true
 	}
 	`
 }
@@ -256,6 +273,7 @@ func testAccCheckResourceGridscaleK8sConfigNodeCountIncrease() string {
 			storage_type = "storage_insane"
 			rocket_storage = 10
 		}
+		k8s_hubble = true
 	}
 	`
 }
@@ -274,6 +292,7 @@ func testAccCheckResourceGridscaleK8sConfigNodeCountDecrease() string {
 			storage_type = "storage_insane"
 			rocket_storage = 10
 		}
+		k8s_hubble = true
 	}
 	`
 }
@@ -300,6 +319,7 @@ func testAccCheckResourceGridscaleK8sConfigAddNodePool() string {
 			storage = 30
 			storage_type = "storage_insane"
 		}
+		k8s_hubble = true
 	}
 	`
 }
@@ -318,6 +338,7 @@ func testAccCheckResourceGridscaleK8sConfigRemoveNodePool() string {
 			storage_type = "storage_insane"
 			rocket_storage = 10
 		}
+		k8s_hubble = true
 	}
 	`
 }


### PR DESCRIPTION
The correct one is `k8s_hubble`. Ref #429 