### PR TITLE
feature: add lifecycle config to s3 resource

### DIFF
--- a/gridscale/resource_gridscale_bucket.go
+++ b/gridscale/resource_gridscale_bucket.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -31,6 +32,7 @@ func resourceGridscaleBucket() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGridscaleBucketCreate,
 		Read:   resourceGridscaleBucketRead,
+		Update: resourceGridscaleBucketUpdate,
 		Delete: resourceGridscaleBucketDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -63,6 +65,34 @@ func resourceGridscaleBucket() *schema.Resource {
 				ForceNew:    true,
 				Default:     "gos3.io",
 			},
+			"lifecycle_rules": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"prefix": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"expiration_days": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"noncurrent_version_expiration_days": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
@@ -72,6 +102,59 @@ func resourceGridscaleBucket() *schema.Resource {
 }
 
 func resourceGridscaleBucketRead(d *schema.ResourceData, meta interface{}) error {
+	s3Host := d.Get("s3_host").(string)
+	accessKey := d.Get("access_key").(string)
+	secretKey := d.Get("secret_key").(string)
+	bucketName := d.Get("bucket_name").(string)
+
+	s3Client := initS3Client(&gridscaleS3Provider{
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	}, s3Host)
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutRead))
+	defer cancel()
+
+	// Fetch lifecycle configuration
+	output, err := s3Client.GetBucketLifecycleConfigurationWithContext(ctx, &s3.GetBucketLifecycleConfigurationInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		// Check if the error is an AWS-specific error
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NoSuchLifecycleConfiguration" {
+			// If the error indicates no lifecycle configuration exists, set the lifecycle_rules attribute to nil
+			d.Set("lifecycle_rules", nil)
+		} else {
+			// For any other error, return a formatted error message with context
+			return fmt.Errorf("error reading lifecycle configuration for bucket %s: %v", bucketName, err)
+		}
+	} else {
+		rules := []map[string]interface{}{}
+		for _, rule := range output.Rules {
+			r := map[string]interface{}{
+				"id":                                 aws.StringValue(rule.ID),
+				"enabled":                            aws.StringValue(rule.Status) == "Enabled",
+				"expiration_days":                    0,
+				"noncurrent_version_expiration_days": 0,
+			}
+			// Check if the rule has a filter and set the prefix accordingly
+			if rule.Filter != nil && rule.Filter.Prefix != nil {
+				r["prefix"] = aws.StringValue(rule.Filter.Prefix)
+			} else {
+				r["prefix"] = ""
+			}
+			// Check if the rule has expiration or noncurrent version expiration days set
+			if rule.Expiration != nil && rule.Expiration.Days != nil {
+				r["expiration_days"] = int(*rule.Expiration.Days)
+			}
+			if rule.NoncurrentVersionExpiration != nil && rule.NoncurrentVersionExpiration.NoncurrentDays != nil {
+				r["noncurrent_version_expiration_days"] = int(*rule.NoncurrentVersionExpiration.NoncurrentDays)
+			}
+			rules = append(rules, r)
+		}
+		d.Set("lifecycle_rules", rules)
+	}
+
 	return nil
 }
 
@@ -105,11 +188,116 @@ func resourceGridscaleBucketCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("%s error: %v", errorPrefix, err)
 	}
 
+	lifecycleRules := d.Get("lifecycle_rules").([]interface{})
+	if len(lifecycleRules) > 0 {
+		lifecycleConfig := &s3.BucketLifecycleConfiguration{
+			Rules: []*s3.LifecycleRule{},
+		}
+
+		for _, rule := range lifecycleRules {
+			r := rule.(map[string]interface{})
+			lifecycleRule := &s3.LifecycleRule{
+				ID: aws.String(r["id"].(string)),
+				Filter: &s3.LifecycleRuleFilter{
+					Prefix: aws.String(r["prefix"].(string)),
+				},
+				Status: aws.String("Enabled"),
+			}
+			// Check if the rule is enabled
+			if !r["enabled"].(bool) {
+				lifecycleRule.Status = aws.String("Disabled")
+			}
+			// Set expiration days if provided
+			if v, ok := r["expiration_days"].(int); ok && v > 0 {
+				lifecycleRule.Expiration = &s3.LifecycleExpiration{
+					Days: aws.Int64(int64(v)),
+				}
+			}
+			// Set noncurrent version expiration days if provided
+			if v, ok := r["noncurrent_version_expiration_days"].(int); ok && v > 0 {
+				lifecycleRule.NoncurrentVersionExpiration = &s3.NoncurrentVersionExpiration{
+					NoncurrentDays: aws.Int64(int64(v)),
+				}
+			}
+
+			lifecycleConfig.Rules = append(lifecycleConfig.Rules, lifecycleRule)
+		}
+
+		_, err := s3Client.PutBucketLifecycleConfigurationWithContext(ctx, &s3.PutBucketLifecycleConfigurationInput{
+			Bucket:                 &bucketNameStr,
+			LifecycleConfiguration: lifecycleConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("%s error setting lifecycle configuration: %v", errorPrefix, err)
+		}
+	}
+
 	id := fmt.Sprintf("%s/%s", s3HostStr, bucketNameStr)
 	d.SetId(id)
 
 	log.Printf("The id for the new bucket has been set to %v", id)
 	return nil
+}
+
+func resourceGridscaleBucketUpdate(d *schema.ResourceData, meta interface{}) error {
+	s3Host := d.Get("s3_host").(string)
+	accessKey := d.Get("access_key").(string)
+	secretKey := d.Get("secret_key").(string)
+	bucketName := d.Get("bucket_name").(string)
+
+	s3Client := initS3Client(&gridscaleS3Provider{
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	}, s3Host)
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.Timeout(schema.TimeoutUpdate))
+	defer cancel()
+
+	if d.HasChange("lifecycle_rules") {
+		lifecycleRules := d.Get("lifecycle_rules").([]interface{})
+		lifecycleConfig := &s3.BucketLifecycleConfiguration{
+			Rules: []*s3.LifecycleRule{},
+		}
+
+		for _, rule := range lifecycleRules {
+			r := rule.(map[string]interface{})
+			lifecycleRule := &s3.LifecycleRule{
+				ID: aws.String(r["id"].(string)),
+				Filter: &s3.LifecycleRuleFilter{
+					Prefix: aws.String(r["prefix"].(string)),
+				},
+				Status: aws.String("Enabled"),
+			}
+
+			if !r["enabled"].(bool) {
+				lifecycleRule.Status = aws.String("Disabled")
+			}
+
+			if v, ok := r["expiration_days"].(int); ok && v > 0 {
+				lifecycleRule.Expiration = &s3.LifecycleExpiration{
+					Days: aws.Int64(int64(v)),
+				}
+			}
+
+			if v, ok := r["noncurrent_version_expiration_days"].(int); ok && v > 0 {
+				lifecycleRule.NoncurrentVersionExpiration = &s3.NoncurrentVersionExpiration{
+					NoncurrentDays: aws.Int64(int64(v)),
+				}
+			}
+
+			lifecycleConfig.Rules = append(lifecycleConfig.Rules, lifecycleRule)
+		}
+
+		_, err := s3Client.PutBucketLifecycleConfigurationWithContext(ctx, &s3.PutBucketLifecycleConfigurationInput{
+			Bucket:                 aws.String(bucketName),
+			LifecycleConfiguration: lifecycleConfig,
+		})
+		if err != nil {
+			return fmt.Errorf("error updating lifecycle configuration for bucket %s: %v", bucketName, err)
+		}
+	}
+
+	return resourceGridscaleBucketRead(d, meta)
 }
 
 func resourceGridscaleBucketDelete(d *schema.ResourceData, meta interface{}) error {

--- a/gridscale/resource_gridscale_bucket.go
+++ b/gridscale/resource_gridscale_bucket.go
@@ -243,7 +243,8 @@ func resourceGridscaleBucketCreate(d *schema.ResourceData, meta interface{}) err
 			LifecycleConfiguration: lifecycleConfig,
 		})
 		if err != nil {
-			return fmt.Errorf("%s error setting lifecycle configuration: %v", errorPrefix, err)
+			// Delete the bucket if lifecycle configuration fails to set
+			return resourceGridscaleBucketDelete(d, meta)
 		}
 	}
 

--- a/gridscale/resource_gridscale_bucket.go
+++ b/gridscale/resource_gridscale_bucket.go
@@ -2,6 +2,7 @@ package gridscale
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"time"
@@ -128,13 +129,13 @@ func resourceGridscaleBucketRead(d *schema.ResourceData, meta interface{}) error
 		Bucket: aws.String(bucketName),
 	})
 	if err != nil {
-		// Check if the error is an AWS-specific error
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == "NoSuchLifecycleConfiguration" {
+		var aerr awserr.Error
+		if errors.As(err, &aerr) && aerr.Code() == "NoSuchLifecycleConfiguration" {
 			// If the error indicates no lifecycle configuration exists, set the lifecycle_rule attribute to nil
 			d.Set("lifecycle_rule", nil)
 		} else {
 			// For any other error, return a formatted error message with context
-			return fmt.Errorf("error reading lifecycle configuration for bucket %s: %v", bucketName, err)
+			return fmt.Errorf("error reading lifecycle configuration for bucket %s: %w", bucketName, err)
 		}
 	} else {
 		rules := []map[string]interface{}{}

--- a/gridscale/resource_gridscale_bucket.go
+++ b/gridscale/resource_gridscale_bucket.go
@@ -104,6 +104,7 @@ func resourceGridscaleBucket() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(5 * time.Minute),
 			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
 		},
 	}
 }

--- a/gridscale/resource_gridscale_bucket_test.go
+++ b/gridscale/resource_gridscale_bucket_test.go
@@ -45,3 +45,101 @@ resource "gridscale_object_storage_bucket" "foo" {
 }
 `
 }
+
+func TestAccResourceGridscaleBucketLifecycleRules(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckResourceGridscaleBucketConfigWithLifecycleRules(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule.0.id", "rule1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule.0.enabled", "true"),
+					resource.TestCheckResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule.0.expiration_days", "30"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleBucketConfigWithUpdatedLifecycleRules(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule.0.id", "rule1"),
+					resource.TestCheckResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule.0.enabled", "false"),
+					resource.TestCheckResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule.0.expiration_days", "60"),
+				),
+			},
+			{
+				Config: testAccCheckResourceGridscaleBucketConfigWithoutLifecycleRules(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckNoResourceAttr(
+						"gridscale_object_storage_bucket.foo", "lifecycle_rule"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckResourceGridscaleBucketConfigWithLifecycleRules() string {
+	return `
+resource "gridscale_object_storage_accesskey" "test" {
+   timeouts {
+      create="10m"
+  }
+}
+
+resource "gridscale_object_storage_bucket" "foo" {
+   access_key = gridscale_object_storage_accesskey.test.access_key
+   secret_key = gridscale_object_storage_accesskey.test.secret_key
+   bucket_name = "myterraformbucket"
+
+   lifecycle_rule {
+     id = "rule1"
+     enabled = true
+     expiration_days = 30
+   }
+}
+`
+}
+
+func testAccCheckResourceGridscaleBucketConfigWithUpdatedLifecycleRules() string {
+	return `
+resource "gridscale_object_storage_accesskey" "test" {
+   timeouts {
+      create="10m"
+  }
+}
+
+resource "gridscale_object_storage_bucket" "foo" {
+   access_key = gridscale_object_storage_accesskey.test.access_key
+   secret_key = gridscale_object_storage_accesskey.test.secret_key
+   bucket_name = "myterraformbucket"
+
+   lifecycle_rule {
+     id = "rule1"
+     enabled = false
+     expiration_days = 60
+   }
+}
+`
+}
+
+func testAccCheckResourceGridscaleBucketConfigWithoutLifecycleRules() string {
+	return `
+resource "gridscale_object_storage_accesskey" "test" {
+   timeouts {
+      create="10m"
+  }
+}
+
+resource "gridscale_object_storage_bucket" "foo" {
+   access_key = gridscale_object_storage_accesskey.test.access_key
+   secret_key = gridscale_object_storage_accesskey.test.secret_key
+   bucket_name = "myterraformbucket"
+}
+`
+}

--- a/website/docs/r/object_storage_bucket.html.md
+++ b/website/docs/r/object_storage_bucket.html.md
@@ -42,3 +42,10 @@ The following arguments are supported:
 * `secret_key` - (Required, Force New) Secret key.
 * `s3_host` - (Required, Force New) Host of the s3. Default: "gos3.io".
 * `bucket_name` - (Required, Force New) Name of the bucket.
+* `lifecycle_rule` - (Optional) A list of lifecycle rules for the bucket. Each rule supports the following:
+  * `id` - (Required) Unique identifier for the rule.
+  * `enabled` - (Required) Whether the rule is enabled.
+  * `prefix` - (Optional) Object key prefix identifying one or more objects to which the rule applies.
+  * `expiration_days` - (Optional) Number of days after which objects are deleted. Default: `365`.
+  * `noncurrent_version_expiration_days` - (Optional) Number of days after which noncurrent object versions are deleted. Default: `365`.
+  * `incomplete_upload_expiration_days` - (Optional) Number of days after which incomplete multipart uploads are deleted. Default: `3`.


### PR DESCRIPTION
This pull request introduces lifecycle management for Gridscale object storage buckets, enabling users to define and manage lifecycle rules for bucket objects. 
### Lifecycle Management Enhancements:

* Added a new `lifecycle_rule` attribute to the `gridscale_object_storage_bucket` resource schema, allowing users to define lifecycle rules with properties such as `id`, `enabled`, `prefix`, `expiration_days`, `noncurrent_version_expiration_days`, and `incomplete_upload_expiration_days`.
* Implemented lifecycle rule handling in the `Create`, `Read`, and `Update` functions, including support for adding, updating, and clearing lifecycle configurations via AWS S3 APIs. 