### PR TITLE
Fix empty versions in GSK version error

### DIFF
--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -495,7 +495,7 @@ func deriveK8sTemplateFromGSKVersion(client *gsclient.Client, version string) (*
 	for _, paasTemplate := range paasTemplates {
 		if paasTemplate.Properties.Flavour == k8sTemplateFlavourName {
 			if paasTemplate.Properties.Active {
-				versions = append(versions, template.Properties.Version)
+				versions = append(versions, paasTemplate.Properties.Version)
 			}
 
 			if paasTemplate.Properties.Version == version {


### PR DESCRIPTION
We saw errors such as this one:

```
Error: 1.31.9-gs0 is a deprecated gridscale Kubernetes (GSK) version. Valid GSK versions are: , ,
```