### PR TITLE
Fix inactive GSK versions breaking commands for existing clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.2.2 (Sept 29, 2025)
+
+IMPROVEMENTS:
+- Upgrade various go dependencies.
+
+BUG FIXES:
+- Fix inactive GSK versions breaking commands for existing clusters. [PR #464](https://github.com/gridscale/terraform-provider-gridscale/pull/464)
+
 ## 2.2.1 (July 10, 2025)
 
 IMPROVEMENTS:

--- a/gridscale/resource_gridscale_k8s.go
+++ b/gridscale/resource_gridscale_k8s.go
@@ -510,17 +510,18 @@ func deriveK8sTemplateFromGSKVersion(client *gsclient.Client, version string, ch
 	var versions []string
 	var template gsclient.PaaSTemplate
 
+	// This loop does two things: Gather all valid verions and find the one which matches the requested version
 	for _, paasTemplate := range paasTemplates {
 		if paasTemplate.Properties.Flavour == k8sTemplateFlavourName {
 			if paasTemplate.Properties.Active {
 				versions = append(versions, paasTemplate.Properties.Version)
 			}
 
-			if paasTemplate.Properties.Version == version {
+			// Check if the version matches and we haven't derived a template yet
+			if !derived && paasTemplate.Properties.Version == version {
 				isActive = paasTemplate.Properties.Active
 				derived = true
 				template = paasTemplate
-				break
 			}
 		}
 	}
@@ -568,15 +569,16 @@ func deriveK8sTemplateFromRelease(client *gsclient.Client, release, currenTempla
 	var releases []string
 	var template gsclient.PaaSTemplate
 
+	// This loop does two things: Gather all valid releases and find the one which matches the requested release
 	for _, paasTemplate := range paasTemplates {
 		if paasTemplate.Properties.Flavour == k8sTemplateFlavourName {
 			releases = append(releases, paasTemplate.Properties.Release)
 
+			// Check if the release matches and we haven't derived a template yet
 			if paasTemplate.Properties.Release == release {
 				isActive = paasTemplate.Properties.Active
 				derived = true
 				template = paasTemplate
-				break
 			}
 		}
 	}


### PR DESCRIPTION
This PR aims to fix #461 

## Manual testing

Testing this fix is complex. Locally i have used the following approach.

1. Create a real cluster using this version

```
resource "gridscale_k8s" "gsk-test" {
  name   = "gsk-test"
  gsk_version = "1.30.14-gs0" # active - this was the version used to create this cluster
  # gsk_version = "1.31.9-gs0" # inactive
  # gsk_version = "1.31.11-gs0" # active

  node_pool {
    name = "pool-0"
    node_count = 1
    cores = 2
    memory = 4
    storage = 30
    storage_type = "storage_insane"
  }

  timeouts {
    create = "60m"
    update = "60m"
    delete = "60m"
  }
}
```

2. After creation, add this mocking to the source code and build the provider. Follow the README for using your local build

```diff
--- a/vendor/github.com/gridscale/gsclient-go/v3/paas.go
+++ b/vendor/github.com/gridscale/gsclient-go/v3/paas.go
@@ -610,6 +610,12 @@ func (c *Client) GetPaaSTemplateList(ctx context.Context) ([]PaaSTemplate, error
                paasTemplate := PaaSTemplate{
                        Properties: properties,
                }
+
+               // Mock disabled templates
+               if paasTemplate.Properties.Version == "1.30.14-gs0" { // This is the version the cluster was created with.
+                       paasTemplate.Properties.Active = false
+               }
+
                paasTemplates = append(paasTemplates, paasTemplate)
        }
        return paasTemplates, err
```

What this does is it fakes that the version you just used to provision the cluster is inactive.

3. Run `terraform plan` with the various `gsk_version` values from above. You should:
  - run it without any changes
  - run it with an upgraded, active version
  - run it with an upgraded, inactive version (this is the only thing that should fail)