### PR TITLE
Fix gridscale_paas data source when used on GSK >= 1.30

### DIFF
--- a/gridscale/common.go
+++ b/gridscale/common.go
@@ -40,8 +40,8 @@ func convStrToTypeInterface(interfaceType, str string) (interface{}, error) {
 	}
 }
 
-// getInterfaceType gets interface type
-func getInterfaceType(value interface{}) (string, error) {
+// getPrimitiveInterfaceType gets interface type
+func getPrimitiveInterfaceType(value interface{}) (string, error) {
 	switch value.(type) {
 	case bool:
 		return boolInterfaceType, nil

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -219,12 +219,12 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 	for k, value := range props.Parameters {
 		paramValType, err := getInterfaceType(value)
 		if err != nil {
-			return fmt.Errorf("%s error: %v", errorPrefix, err)
+			return fmt.Errorf("%s error on parameter with key %q and type %T: %w", errorPrefix, k, value, err)
 		}
 		valueInString, err := convInterfaceToString(paramValType, value)
 
 		if err != nil {
-			return err
+			return fmt.Errorf("%s error on parameter with key %q: %w", errorPrefix, k, err)
 		}
 		param := map[string]interface{}{
 			"param": k,

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -222,7 +222,7 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 			continue
 		}
 
-		paramValType, err := getInterfaceType(value)
+		paramValType, err := getPrimitiveInterfaceType(value)
 		if err != nil {
 			return fmt.Errorf("%s error on parameter with key %q and type %T: %w", errorPrefix, k, value, err)
 		}

--- a/gridscale/datasource_gridscale_paas.go
+++ b/gridscale/datasource_gridscale_paas.go
@@ -217,6 +217,11 @@ func dataSourceGridscalePaaSRead(d *schema.ResourceData, meta interface{}) error
 	//Get parameters
 	parameters := make([]interface{}, 0)
 	for k, value := range props.Parameters {
+		// Skip node pool parameter on k8s data source.
+		if props.ServiceTemplateCategory == k8sTemplateFlavourName && k == "pools" {
+			continue
+		}
+
 		paramValType, err := getInterfaceType(value)
 		if err != nil {
 			return fmt.Errorf("%s error on parameter with key %q and type %T: %w", errorPrefix, k, value, err)

--- a/gridscale/resource_gridscale_paas.go
+++ b/gridscale/resource_gridscale_paas.go
@@ -267,7 +267,7 @@ func resourceGridscalePaaSServiceRead(d *schema.ResourceData, meta interface{}) 
 	//Get parameters
 	parameters := make([]interface{}, 0)
 	for k, value := range props.Parameters {
-		paramValType, err := getInterfaceType(value)
+		paramValType, err := getPrimitiveInterfaceType(value)
 		if err != nil {
 			return fmt.Errorf("%s error: %v", errorPrefix, err)
 		}


### PR DESCRIPTION
Closes #476

With this change, the `paas` data source will be fixed, when used on GSK instances.

Node pool parameters are **not** included in the parameters field. If you have previously relied on that information, open an issue to request support for that field.